### PR TITLE
Order snapshot span representation

### DIFF
--- a/tests/integration_snapshots/test_multi_trace.json
+++ b/tests/integration_snapshots/test_multi_trace.json
@@ -1,68 +1,68 @@
 [[
   {
-    "duration": 298000,
+    "name": "root0",
+    "service": null,
+    "resource": "root0",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
     "error": 0,
+    "duration": 51000,
     "meta": {
-      "runtime-id": "79320d2c3ec84fcb9f957659be6a9ff5"
+      "runtime-id": "ebee976449494ac4b8d58700d561f337"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 49158
+      "system.pid": 50213
     },
-    "name": "root0",
-    "parent_id": 0,
-    "resource": "root0",
-    "service": null,
-    "span_id": 1,
-    "start": 1631157693265658000,
-    "trace_id": 0
+    "start": 1631760831942109000
   },
      {
-       "duration": 8000,
+       "name": "child0",
+       "service": null,
+       "resource": "child0",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
        "error": 0,
+       "duration": 6000,
        "meta": {},
        "metrics": {},
-       "name": "child0",
-       "parent_id": 1,
-       "resource": "child0",
-       "service": null,
-       "span_id": 2,
-       "start": 1631157693265722000,
-       "trace_id": 0
+       "start": 1631760831942149000
      }],
 [
   {
-    "duration": 32000,
+    "name": "root1",
+    "service": null,
+    "resource": "root1",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
     "error": 0,
+    "duration": 20000,
     "meta": {
-      "runtime-id": "79320d2c3ec84fcb9f957659be6a9ff5"
+      "runtime-id": "ebee976449494ac4b8d58700d561f337"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 49158
+      "system.pid": 50213
     },
-    "name": "root1",
-    "parent_id": 0,
-    "resource": "root1",
-    "service": null,
-    "span_id": 1,
-    "start": 1631157693266114000,
-    "trace_id": 1
+    "start": 1631760831942252000
   },
      {
-       "duration": 6000,
+       "name": "child1",
+       "service": null,
+       "resource": "child1",
+       "trace_id": 1,
+       "span_id": 2,
+       "parent_id": 1,
        "error": 0,
+       "duration": 4000,
        "meta": {},
        "metrics": {},
-       "name": "child1",
-       "parent_id": 1,
-       "resource": "child1",
-       "service": null,
-       "span_id": 2,
-       "start": 1631157693266134000,
-       "trace_id": 1
+       "start": 1631760831942265000
      }]]

--- a/tests/integration_snapshots/test_single_trace.json
+++ b/tests/integration_snapshots/test_single_trace.json
@@ -1,22 +1,22 @@
 [[
   {
-    "duration": 73000,
+    "name": "root",
+    "service": "custom_service",
+    "resource": "/url/endpoint",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
     "error": 0,
+    "duration": 38000,
     "meta": {
-      "runtime-id": "0581ae5a3a7e491b9ed6a6323f75f002"
+      "runtime-id": "ebee976449494ac4b8d58700d561f337"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 49012
+      "system.pid": 50213
     },
-    "name": "root",
-    "parent_id": 0,
-    "resource": "/url/endpoint",
-    "service": "custom_service",
-    "span_id": 1,
-    "start": 1631157505689591000,
-    "trace_id": 0,
+    "start": 1631760829855306000,
     "type": "web"
   }]]

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -213,36 +213,36 @@ async def test_snapshot_trace_differences(agent, expected_traces, actual_traces,
             ],
             """[[
   {
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
     "meta": {},
     "metrics": {},
-    "parent_id": 0,
-    "span_id": 1,
-    "start": 0,
-    "trace_id": 0
+    "start": 0
   },
      {
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
        "meta": {},
        "metrics": {},
-       "parent_id": 1,
-       "span_id": 2,
-       "start": 1,
-       "trace_id": 0
+       "start": 1
      },
         {
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
           "meta": {},
           "metrics": {},
-          "parent_id": 2,
-          "span_id": 4,
-          "start": 4,
-          "trace_id": 0
+          "start": 4
         },
      {
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
        "meta": {},
        "metrics": {},
-       "parent_id": 1,
-       "span_id": 3,
-       "start": 2,
-       "trace_id": 0
+       "start": 2
      }]]\n""",
         )
     ],


### PR DESCRIPTION
This should make the spans more human readable by ordering the more
important attributes first.

Resolves #15 