### PR TITLE
Fix matching algorithm

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -142,6 +142,7 @@ class Agent:
                     break
             manual_reqs.append(req)
         else:
+            # If the for loop falls through then there were no matching traces.
             manual_reqs = []
 
         assoc_reqs = (

--- a/releasenotes/notes/fix-matching-319744b82d2514c1.yaml
+++ b/releasenotes/notes/fix-matching-319744b82d2514c1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the snapshot matching algorithm which had previously assumed that trace
+    ids would be unique across both sets of traces.

--- a/tests/test_snapshot_integration.py
+++ b/tests/test_snapshot_integration.py
@@ -30,7 +30,7 @@ async def testagent(loop, testagent_port):
     # Wait for server to start
     try:
         async with aiohttp.ClientSession() as session:
-            for _ in range(10):
+            for _ in range(20):
                 try:
                     r = await session.get(f"http://localhost:{testagent_port}")
                 except ClientConnectorError:


### PR DESCRIPTION
The previous matching algorithm assumed that trace ids would be unique
across both sets of traces which is not true for snapshots as the traces
are normalized.

Fixes #25 