### PR TITLE
Fix multiple sessions

### DIFF
--- a/ddapm_test_agent/snapshot.py
+++ b/ddapm_test_agent/snapshot.py
@@ -142,10 +142,10 @@ def _match_traces(t1s: List[Trace], t2s: List[Trace]) -> List[Tuple[Trace, Trace
 
     assert len(matched_t1s) == len(
         t1_map
-    ), f"Unmatched traces {matched_t1s - set(t1_map.keys())}"
+    ), f"Unmatched expected traces {set(t1_map.keys()) - matched_t1s}"
     assert len(matched_t2s) == len(
         t2_map
-    ), f"Unmatched traces {matched_t2s - set(t2_map.keys())}"
+    ), f"Unmatched received traces {set(t2_map.keys()) - matched_t2s}"
     return matches
 
 

--- a/releasenotes/notes/reuse-session-1670aa569907cf68.yaml
+++ b/releasenotes/notes/reuse-session-1670aa569907cf68.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix sessions returning traces from all sessions.

--- a/tests/integration_snapshots/test_trace_missing_received.json
+++ b/tests/integration_snapshots/test_trace_missing_received.json
@@ -1,0 +1,34 @@
+[[
+  {
+    "name": "root0",
+    "service": null,
+    "resource": "root0",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "error": 0,
+    "meta": {
+      "runtime-id": "55e8c714e39543198cc99c53617faf9e"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "system.pid": 60904
+    },
+    "duration": 73000,
+    "start": 1632956239689971000
+  },
+     {
+       "name": "child0",
+       "service": null,
+       "resource": "child0",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "error": 0,
+       "meta": {},
+       "metrics": {},
+       "duration": 6000,
+       "start": 1632956239690025000
+     }]]


### PR DESCRIPTION
The API for retrieving traces from the session would return all traces
matching the session token and not just the most recent traces for the
session.

Actually fixes #25 