### PR TITLE
Don't include empty meta/metrics in snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ To do snapshot testing with the test agent:
    with the session token. The endpoint will return a `400` response code if the snapshot failed along with a plain-text
    trace of the error which can be forwarded to the test framework to help triage the issue.
 
+
+#### Snapshot output
+
+The traces are normalized and output in JSON to a file. The following transformations are made to the input:
+
+- Trace ids are overwritten to match the order in which the traces were received.
+- Span ids are overwritten to be the DFS order of the spans in the trace tree.
+- Span attributes are ordered to be more human-readable, with the important attributes being listed first.
+- Span attributes are otherwise ordered alphanumerically.
+- The span meta and metrics maps if empty are excluded.
+
+
 ### TODO
 
 - [ ] Check inconsistent trace id in a trace payload

--- a/ddapm_test_agent/snapshot.py
+++ b/ddapm_test_agent/snapshot.py
@@ -290,6 +290,10 @@ def _ordered_span(s: Span) -> OrderedDictType[str, TopLevelSpanValue]:
     # Add the rest of the attributes in alphanumeric order.
     for k in sorted(set(s.keys()) - set(order)):
         d[k] = s[k]  # type: ignore
+
+    for k in ["meta", "metrics"]:
+        if k in d and len(d[k]) == 0:
+            del d[k]
     return d  # type: ignore
 
 

--- a/releasenotes/notes/snapshot-empty-maps-2cbe8cea3e7112fa.yaml
+++ b/releasenotes/notes/snapshot-empty-maps-2cbe8cea3e7112fa.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Snapshots will no longer have empty meta/metrics maps included in the output.

--- a/tests/integration_snapshots/test_multi_trace.json
+++ b/tests/integration_snapshots/test_multi_trace.json
@@ -8,16 +8,16 @@
     "parent_id": 0,
     "error": 0,
     "meta": {
-      "runtime-id": "c01c8b1a754045aa99099f1dcf3cba97"
+      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 50012
+      "system.pid": 28509
     },
-    "duration": 125000,
-    "start": 1631826396053392000
+    "duration": 137000,
+    "start": 1633558542938056000
   },
      {
        "name": "child0",
@@ -27,10 +27,8 @@
        "span_id": 2,
        "parent_id": 1,
        "error": 0,
-       "meta": {},
-       "metrics": {},
-       "duration": 13000,
-       "start": 1631826396053493000
+       "duration": 16000,
+       "start": 1633558542938164000
      }],
 [
   {
@@ -42,16 +40,16 @@
     "parent_id": 0,
     "error": 0,
     "meta": {
-      "runtime-id": "c01c8b1a754045aa99099f1dcf3cba97"
+      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 50012
+      "system.pid": 28509
     },
-    "duration": 49000,
-    "start": 1631826396053837000
+    "duration": 51000,
+    "start": 1633558542938430000
   },
      {
        "name": "child1",
@@ -61,8 +59,6 @@
        "span_id": 2,
        "parent_id": 1,
        "error": 0,
-       "meta": {},
-       "metrics": {},
-       "duration": 9000,
-       "start": 1631826396053868000
+       "duration": 12000,
+       "start": 1633558542938461000
      }]]

--- a/tests/integration_snapshots/test_single_trace.json
+++ b/tests/integration_snapshots/test_single_trace.json
@@ -9,14 +9,14 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "runtime-id": "c01c8b1a754045aa99099f1dcf3cba97"
+      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 50012
+      "system.pid": 28509
     },
-    "duration": 109000,
-    "start": 1631826393738891000
+    "duration": 76000,
+    "start": 1633558540524060000
   }]]

--- a/tests/integration_snapshots/test_trace_distributed_same_payload.json
+++ b/tests/integration_snapshots/test_trace_distributed_same_payload.json
@@ -8,16 +8,16 @@
     "parent_id": 0,
     "error": 0,
     "meta": {
-      "runtime-id": "c01c8b1a754045aa99099f1dcf3cba97"
+      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 50012
+      "system.pid": 28509
     },
-    "duration": 149000,
-    "start": 1631826396314617000
+    "duration": 115000,
+    "start": 1633558543195969000
   },
      {
        "name": "child0",
@@ -27,10 +27,8 @@
        "span_id": 2,
        "parent_id": 1,
        "error": 0,
-       "meta": {},
-       "metrics": {},
-       "duration": 17000,
-       "start": 1631826396314735000
+       "duration": 14000,
+       "start": 1633558543196058000
      },
         {
           "name": "root1",
@@ -41,15 +39,15 @@
           "parent_id": 2,
           "error": 0,
           "meta": {
-            "runtime-id": "c01c8b1a754045aa99099f1dcf3cba97"
+            "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
           },
           "metrics": {
             "_dd.tracer_kr": 1.0,
             "_sampling_priority_v1": 1,
-            "system.pid": 50012
+            "system.pid": 28509
           },
-          "duration": 45000,
-          "start": 1631826396315049000
+          "duration": 36000,
+          "start": 1633558543196287000
         },
            {
              "name": "child1",
@@ -59,8 +57,6 @@
              "span_id": 4,
              "parent_id": 3,
              "error": 0,
-             "meta": {},
-             "metrics": {},
-             "duration": 10000,
-             "start": 1631826396315074000
+             "duration": 8000,
+             "start": 1633558543196307000
            }]]

--- a/tests/integration_snapshots/test_trace_missing_received.json
+++ b/tests/integration_snapshots/test_trace_missing_received.json
@@ -8,16 +8,16 @@
     "parent_id": 0,
     "error": 0,
     "meta": {
-      "runtime-id": "55e8c714e39543198cc99c53617faf9e"
+      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 60904
+      "system.pid": 28509
     },
-    "duration": 73000,
-    "start": 1632956239689971000
+    "duration": 98000,
+    "start": 1633558543448651000
   },
      {
        "name": "child0",
@@ -27,8 +27,6 @@
        "span_id": 2,
        "parent_id": 1,
        "error": 0,
-       "meta": {},
-       "metrics": {},
-       "duration": 6000,
-       "start": 1632956239690025000
+       "duration": 12000,
+       "start": 1633558543448725000
      }]]

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -216,32 +216,24 @@ async def test_snapshot_trace_differences(agent, expected_traces, actual_traces,
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "meta": {},
-    "metrics": {},
     "start": 0
   },
      {
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "meta": {},
-       "metrics": {},
        "start": 1
      },
         {
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "meta": {},
-          "metrics": {},
           "start": 4
         },
      {
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "meta": {},
-       "metrics": {},
        "start": 2
      }]]\n""",
         )


### PR DESCRIPTION
This should help make snapshots more concise.