### PR TITLE
Add proxying feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ INFO:ddapm_test_agent.agent:end of payload -------------------------------------
 ```
 
 
+### Proxy
+
+The test agent provides proxying to the Datadog agent. This is enabled by passing the agent url to the test agent
+either via the `--agent-url` commandline argument or by the `DD_TRACE_AGENT_URL` or `DD_AGENT_URL` environment
+variables.
+
+When proxying is enabled the response from the Datadog agent will be returned instead of one from the test agent.
+
+
 ### Snapshot testing
 
 The test agent provides a form of [characterization testing](https://en.wikipedia.org/wiki/Characterization_test) which
@@ -138,6 +147,9 @@ Please refer to `ddapm-test-agent --help`.
 
 - `SNAPSHOT_IGNORED_ATTRS` [`"span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id"`]: The
   attributes to ignore when comparing spans in snapshots.
+
+- `DD_AGENT_URL` [`""`]: URL to a Datadog agent. When provided requests will be proxied to the agent.
+
 
 
 ## API

--- a/releasenotes/notes/proxy-37c94e2fb428c6fc.yaml
+++ b/releasenotes/notes/proxy-37c94e2fb428c6fc.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Trace requests can now be proxied to an actual agent by passing an agent
+    url to the test agent. This can be done by passing the ``--agent-url``
+    command-line option or via the ``DD_AGENT_URL`` or ``DD_TRACE_AGENT_URL``
+    environment variables.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,11 @@ def snapshot_ignored_attrs() -> Generator[Set[str], None, None]:
 
 
 @pytest.fixture
+def agent_url() -> Generator[str, None, None]:
+    yield ""
+
+
+@pytest.fixture
 async def agent_app(
     aiohttp_server,
     agent_disabled_checks,
@@ -55,6 +60,7 @@ async def agent_app(
     snapshot_dir,
     snapshot_ci_mode,
     snapshot_ignored_attrs,
+    agent_url,
 ):
     app = await aiohttp_server(
         make_app(
@@ -63,6 +69,7 @@ async def agent_app(
             str(snapshot_dir),
             snapshot_ci_mode,
             snapshot_ignored_attrs,
+            agent_url,
         )
     )
     yield app


### PR DESCRIPTION
Proxy /v0.4/trace requests through to an actual agent and return the
response from the agent.

Resolves #14 