### PR TITLE
feat: Add ddapm-test-agent-fmt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,25 @@ The test agent can be configured via command-line options or via environment var
 
 ### Command line
 
-Please refer to `ddapm-test-agent --help`.
+#### ddapm-test-agent
 
+`ddapm-test-agent` is command used to run a test agent.
+
+Please refer to `ddapm-test-agent --help` for more information.
+
+#### ddapm-test-agent-fmt
+
+`ddapm-test-agent-fmt` is a command line tool to format or lint snapshot json files.
+
+``` bash
+# Format all snapshot json files
+ddapm-test-agent-fmt path/to/snapshots
+
+# Lint snapshot json files
+ddapm-test-agent-fmt --check path/to/snapshots
+```
+
+Please refer to `ddapm-test-agent-fmt --help` for more information.
 
 ### Environment Variables
 

--- a/ddapm_test_agent/fmt.py
+++ b/ddapm_test_agent/fmt.py
@@ -79,11 +79,11 @@ def main(args: Optional[List[str]] = None) -> None:
 
     # Find all json files
     resolved_files = _resolve_files(parsed_args.files)
-    log.info("Found {} snapshot files to process".format(len(resolved_files)))
+    log.info("Found {} snapshot files to process", (len(resolved_files),))
 
     has_errors = False
     for fname in resolved_files:
-        log.debug("Checking snapshot file {r}".format(r))
+        log.debug("Checking snapshot file {!r}", (fname,))
         try:
             # Read the original file data
             with open(fname, "r") as fp:
@@ -95,19 +95,19 @@ def main(args: Optional[List[str]] = None) -> None:
 
             # Only do anything if something changed
             if formatted != original:
-                log.debug("Snapshot file {!r} has changes".format(fname))
+                log.debug("Snapshot file {!r} has changes", (fname,))
                 if parsed_args.check:
                     # If we are in check mode and we changed the content, error
-                    log.error("Snapshot file {!r} would be reformatted!".format(fname))
+                    log.error("Snapshot file {!r} would be reformatted!", (fname,))
                     has_errors = True
                 else:
                     # Rewrite the original file with the new formatted version
                     with open(fname, "w") as fp:
                         fp.write(formatted)
-                    log.info("Snapshot file {!r} was formatted".format(fname))
+                    log.info("Snapshot file {!r} was formatted", fname)
 
-        except Exception as e:
-            log.error("Error processing file {!r}: {}".format(fname, e))
+        except Exception:
+            log.exception("Error processing file {!r}: {}", (fname,))
             has_errors = True
 
     if has_errors:

--- a/ddapm_test_agent/fmt.py
+++ b/ddapm_test_agent/fmt.py
@@ -1,0 +1,118 @@
+import argparse
+import glob
+import json
+import logging
+import os
+import sys
+from typing import List
+from typing import Optional
+
+from . import _get_version
+from .snapshot import generate_snapshot
+
+
+log = logging.getLogger(__name__)
+
+
+def _resolve_files(files: List[str]) -> List[str]:
+    """Return a list of json files resolved from the provided list of directories or files"""
+    resolved = []
+    for fname in files:
+        if os.path.isdir(fname):
+            curdir = os.getcwd()
+            try:
+                os.chdir(fname)
+                resolved.extend(
+                    [
+                        os.path.join(fname, f)
+                        for f in glob.glob("**/*.json", recursive=True)
+                    ]
+                )
+            finally:
+                os.chdir(curdir)
+        else:
+            resolved.append(fname)
+    return resolved
+
+
+def main(args: Optional[List[str]] = None) -> None:
+    if args is None:
+        args = sys.argv[1:]
+    parser = argparse.ArgumentParser(
+        description="Datadog APM Test Agent Snapshot Formatter",
+        prog="ddapm-test-agent-fmt",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        dest="version",
+        help="Print version info and exit.",
+    )
+    parser.add_argument(
+        "-c",
+        "--check",
+        action="store_true",
+        dest="check",
+        help="Do not rewrite files, error if any files would be changed.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default=os.environ.get("LOG_LEVEL", "INFO"),
+        help="Set the log level. DEBUG, INFO, WARNING, ERROR, CRITICAL.",
+    )
+    parser.add_argument(
+        "files",
+        metavar="FILE",
+        type=str,
+        nargs="+",
+        help="Specific snapshot files or directories to format.",
+    )
+
+    parsed_args = parser.parse_args(args=args)
+    logging.basicConfig(level=parsed_args.log_level)
+
+    if parsed_args.version:
+        print(_get_version())
+        sys.exit(0)
+
+    # Find all json files
+    resolved_files = _resolve_files(parsed_args.files)
+    log.info("Found {} snapshot files to process".format(len(resolved_files)))
+
+    has_errors = False
+    for fname in resolved_files:
+        log.debug("Checking snapshot file {r}".format(r))
+        try:
+            # Read the original file data
+            with open(fname, "r") as fp:
+                original = fp.read()
+
+            # Parse and re-format
+            traces = json.loads(original)
+            formatted = generate_snapshot(traces)
+
+            # Only do anything if something changed
+            if formatted != original:
+                log.debug("Snapshot file {!r} has changes".format(fname))
+                if parsed_args.check:
+                    # If we are in check mode and we changed the content, error
+                    log.error("Snapshot file {!r} would be reformatted!".format(fname))
+                    has_errors = True
+                else:
+                    # Rewrite the original file with the new formatted version
+                    with open(fname, "w") as fp:
+                        fp.write(formatted)
+                    log.info("Snapshot file {!r} was formatted".format(fname))
+
+        except Exception as e:
+            log.error("Error processing file {!r}: {}".format(fname, e))
+            has_errors = True
+
+    if has_errors:
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    main()

--- a/releasenotes/notes/add-fmt-command-cc31769942a5fec3.yaml
+++ b/releasenotes/notes/add-fmt-command-cc31769942a5fec3.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added ``ddapm-test-agent-fmt`` to format or validate snapshot json files.

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     entry_points={
         "console_scripts": [
             "ddapm-test-agent=ddapm_test_agent.agent:main",
+            "ddapm-test-agent-fmt=ddapm_test_agent.fmt:main",
         ]
     },
     # Required for mypy compatibility, see


### PR DESCRIPTION
New command that can be used to reformat snapshot
files to ensure a consistent style.

You can also use the command to check/error if files
are not conforming to the expected format.

```
$ ddapm-test-agent-fmt -h
usage: ddapm-test-agent-fmt [-h] [-v] [-c] [--log-level LOG_LEVEL] FILE [FILE ...]

Datadog APM Test Agent Snapshot Formatter

positional arguments:
  FILE                  Specific snapshot files or directories to format.

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         Print version info and exit.
  -c, --check           Do not rewrite files, error if any files would be changed.
  --log-level LOG_LEVEL
                        Set the log level. DEBUG, INFO, WARNING, ERROR, CRITICAL.
```