### PR TITLE
Move testing dependencies to file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: pip install riot==0.8
+      - run: pip install riot==0.10
       - run: riot -v run -s check_fmt
       - run: riot -v run -s flake8
       - run: riot -v run -s mypy
@@ -29,6 +29,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install riot
-        run: pip install riot==0.8
+        run: pip install riot==0.10
       - run: |
           riot run -p ${{ matrix.python-version}} test

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ and work out of a virtualenv:
 
     virtualenv --python=3.8 .venv
     source .venv/bin/activate
-    pip install riot
+    pip install -e .[testing]
 
 
 ### Running the tests

--- a/riotfile.py
+++ b/riotfile.py
@@ -2,17 +2,18 @@ from riot import Venv
 from riot import latest
 
 
+with open("test_deps.txt") as f:
+    testing_deps = [line.strip() for line in f.readlines()]
+
+
 venv = Venv(
     pys=["3"],
     venvs=[
         Venv(
             name="test",
             command="pytest {cmdargs}",
-            pys=["3.7", "3.8", "3.9", "3.10"],
-            pkgs={
-                "ddtrace": "==0.51.1",
-                "pytest": latest,
-            },
+            pys=["3.8", "3.9", "3.10"],
+            pkgs={pkg: latest for pkg in testing_deps},
         ),
         Venv(
             pkgs={

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from setuptools import setup
 with open("README.md", "r") as f:
     long_description = f.read()
 
+with open("test_deps.txt") as f:
+    testing_deps = [line.strip() for line in f.readlines()]
 
 setup(
     name="ddapm-test-agent",
@@ -28,6 +30,7 @@ setup(
         "aiohttp",
         "msgpack",
     ],
+    tests_require=testing_deps,
     setup_requires=["setuptools_scm"],
     use_scm_version=True,
     entry_points={
@@ -35,6 +38,9 @@ setup(
             "ddapm-test-agent=ddapm_test_agent.agent:main",
             "ddapm-test-agent-fmt=ddapm_test_agent.fmt:main",
         ]
+    },
+    extras_require={
+        "testing": testing_deps,
     },
     # Required for mypy compatibility, see
     # https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages

--- a/test_deps.txt
+++ b/test_deps.txt
@@ -1,0 +1,3 @@
+ddtrace
+pytest
+riot

--- a/tests/integration_snapshots/test_multi_trace.json
+++ b/tests/integration_snapshots/test_multi_trace.json
@@ -6,12 +6,12 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "error": 0,
     "meta": {
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "system.pid": 28509
@@ -26,7 +26,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "error": 0,
        "duration": 16000,
        "start": 1633558542938164000
      }],
@@ -38,12 +37,12 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "error": 0,
     "meta": {
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "system.pid": 28509
@@ -58,7 +57,6 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
-       "error": 0,
        "duration": 12000,
        "start": 1633558542938461000
      }]]

--- a/tests/integration_snapshots/test_single_trace.json
+++ b/tests/integration_snapshots/test_single_trace.json
@@ -7,12 +7,12 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "system.pid": 28509

--- a/tests/integration_snapshots/test_trace_distributed_same_payload.json
+++ b/tests/integration_snapshots/test_trace_distributed_same_payload.json
@@ -6,12 +6,12 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "error": 0,
     "meta": {
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "system.pid": 28509
@@ -26,7 +26,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "error": 0,
        "duration": 14000,
        "start": 1633558543196058000
      },
@@ -37,11 +36,11 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "error": 0,
           "meta": {
             "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
           },
           "metrics": {
+            "_dd.top_level": 1,
             "_dd.tracer_kr": 1.0,
             "_sampling_priority_v1": 1,
             "system.pid": 28509
@@ -56,7 +55,6 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
-             "error": 0,
              "duration": 8000,
              "start": 1633558543196307000
            }]]

--- a/tests/integration_snapshots/test_trace_missing_received.json
+++ b/tests/integration_snapshots/test_trace_missing_received.json
@@ -6,12 +6,12 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "error": 0,
     "meta": {
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
       "_dd.agent_psr": 1.0,
+      "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "system.pid": 28509
@@ -26,7 +26,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "error": 0,
        "duration": 12000,
        "start": 1633558543448725000
      }]]


### PR DESCRIPTION
This enables dependencies to be shared between manual installing `pip install -e .[testing]` and testing and riot.


The snapshots are updated since there have been some `ddtrace` changes.