### PR TITLE
Add stall feature for trace requests

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -12,7 +12,6 @@ from typing import List
 from typing import Literal
 from typing import Optional
 from typing import Set
-from unicodedata import decimal
 
 from aiohttp import ClientSession
 from aiohttp import web
@@ -491,7 +490,7 @@ def make_app(
     snapshot_ci_mode: bool,
     snapshot_ignored_attrs: List[str],
     agent_url: str,
-    trace_request_delay: str,
+    trace_request_delay: float,
 ) -> web.Application:
     agent = Agent()
     app = web.Application(
@@ -629,8 +628,8 @@ def main(args: Optional[List[str]] = None) -> None:
     )
     parser.add_argument(
         "--trace-request-delay",
-        type=str,
-        default=os.environ.get("DD_TEST_STALL_REQUEST_SECONDS", None),
+        type=float,
+        default=os.environ.get("DD_TEST_STALL_REQUEST_SECONDS", 0.0),
         help=("Will stall trace requests for specified amount of time"),
     )
     parsed_args = parser.parse_args(args=args)
@@ -640,7 +639,7 @@ def main(args: Optional[List[str]] = None) -> None:
         print(_get_version())
         sys.exit(0)
 
-    if not parsed_args.trace_request_delay is None:
+    if parsed_args.trace_request_delay is not None:
         log.info(
             "Trace request stall seconds setting set to %r.",
             parsed_args.trace_request_delay,

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -624,6 +624,10 @@ def main(args: Optional[List[str]] = None) -> None:
         print(_get_version())
         sys.exit(0)
 
+    if not parsed_args.trace_request_delay is None:
+        log.info(
+            "Trace request stall seconds setting set to %r.",
+            parsed_args.trace_request_delay)
     if not os.path.exists(parsed_args.snapshot_dir) or not os.access(
         parsed_args.snapshot_dir, os.W_OK | os.X_OK
     ):

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -238,16 +238,16 @@ class Agent:
         token = request["session_token"]
         checks: Checks = request.app["checks"]
 
-        await checks.check("trace_stall", headers=dict(request.headers), request=request)
+        await checks.check(
+            "trace_stall", headers=dict(request.headers), request=request
+        )
 
         with CheckTrace.add_frame("headers") as f:
             f.add_item(pprint.pformat(dict(request.headers)))
             await checks.check(
                 "meta_tracer_version_header", headers=dict(request.headers)
             )
-            await checks.check(
-                "trace_content_length", headers=dict(request.headers)
-            )
+            await checks.check("trace_content_length", headers=dict(request.headers))
 
             if version == "v0.4":
                 traces = await self._decode_v04_traces(request)
@@ -643,7 +643,8 @@ def main(args: Optional[List[str]] = None) -> None:
     if not parsed_args.trace_request_delay is None:
         log.info(
             "Trace request stall seconds setting set to %r.",
-            parsed_args.trace_request_delay)
+            parsed_args.trace_request_delay,
+        )
     if not os.path.exists(parsed_args.snapshot_dir) or not os.access(
         parsed_args.snapshot_dir, os.W_OK | os.X_OK
     ):

--- a/ddapm_test_agent/checks.py
+++ b/ddapm_test_agent/checks.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import contextvars
 import dataclasses
@@ -152,7 +153,7 @@ class Checks:
             return False
         return check.default_enabled
 
-    def check(self, name: str, *args: Any, **kwargs: Any) -> None:
+    async def check(self, name: str, *args: Any, **kwargs: Any) -> None:
         """Find and run the check with the given ``name`` if it is enabled."""
         check = self._get_check(name)()
 
@@ -161,7 +162,10 @@ class Checks:
             CheckTrace.add_check(check)
 
             # Run the check
-            check.check(*args, **kwargs)
+            if asyncio.iscoroutinefunction(check.check):
+                await check.check(*args, **kwargs)
+            else:
+                check.check(*args, **kwargs)
 
 
 def start_trace(msg: str) -> CheckTrace:

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -1,4 +1,5 @@
 import asyncio
+from aiohttp.web import Request
 from typing import Dict
 
 from .checks import Check
@@ -66,7 +67,7 @@ affected.
 """.strip()
     default_enabled = True
 
-    async def check(self, headers: Dict[str, str]) -> None:  # type: ignore
+    async def check(self, headers: Dict[str, str], request: Request) -> None:  # type: ignore
         duration = float(0);
         if "X-Datadog-Test-Stall-Seconds" in headers:
             duration = float(headers["X-Datadog-Test-Stall-Seconds"])

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -1,9 +1,10 @@
 import asyncio
+import logging
 from aiohttp.web import Request
 from typing import Dict
-
 from .checks import Check
 
+log = logging.getLogger(__name__)
 
 class CheckTraceCountHeader(Check):
     name = "trace_count_header"
@@ -71,7 +72,10 @@ affected.
         duration = float(0);
         if "X-Datadog-Test-Stall-Seconds" in headers:
             duration = float(headers["X-Datadog-Test-Stall-Seconds"])
-        elif "" in request.app:
+        elif request.app["trace_request_delay"] is not None:
             duration = float(request.app["trace_request_delay"])
         if duration > 0:
+            log.info(
+                "Stalling for %r seconds.",
+                duration)
             await asyncio.sleep(duration)

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -56,7 +56,7 @@ The max content size of a trace payload is 50MB.
 class CheckTraceStallAsync(Check):
     name = "trace_stall"
     description = """
-Stall the trace (mimicking an overwhelmed or throttled agent) for 1 second.
+Stall the trace (mimicking an overwhelmed or throttled agent) for the given duration in seconds.
 
 Enable the check by submitting the X-Datadog-Test-Trace-Stall http header (unit is seconds)
 with the request.

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -79,11 +79,10 @@ affected.
     default_enabled = True
 
     async def check(self, headers: Dict[str, str], request: Request) -> None:  # type: ignore
-        duration = float(0)
         if "X-Datadog-Test-Stall-Seconds" in headers:
             duration = float(headers["X-Datadog-Test-Stall-Seconds"])
-        elif request.app["trace_request_delay"] is not None:
-            duration = float(request.app["trace_request_delay"])
+        else:
+            duration = request.app["trace_request_delay"]
         if duration > 0:
             log.info("Stalling for %r seconds.", duration)
             await asyncio.sleep(duration)

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Dict
 
 from .checks import Check
@@ -50,3 +51,23 @@ The max content size of a trace payload is 50MB.
     def check(self, content_length: int) -> None:  # type: ignore
         if content_length > 5e7:
             self.fail(f"content length {content_length} too large.")
+
+
+class CheckTraceStallAsync(Check):
+    name = "trace_stall"
+    description = """
+Stall the trace (mimicking an overwhelmed or throttled agent) for 1 second.
+
+Enable the check by submitting the X-Datadog-Test-Trace-Stall http header (unit is seconds)
+with the request.
+
+Note that only the request for this trace is stalled, subsequent requests will not be
+affected.
+""".strip()
+    default_enabled = True
+
+    async def check(self, headers: Dict[str, str]) -> None:  # type: ignore
+        if "X-Datadog-Test-Trace-Stall" in headers:
+            duration = float(headers["X-Datadog-Test-Trace-Stall"])
+
+            await asyncio.sleep(duration)

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -1,10 +1,14 @@
 import asyncio
 import logging
-from aiohttp.web import Request
 from typing import Dict
+
+from aiohttp.web import Request
+
 from .checks import Check
 
+
 log = logging.getLogger(__name__)
+
 
 class CheckTraceCountHeader(Check):
     name = "trace_count_header"
@@ -75,13 +79,11 @@ affected.
     default_enabled = True
 
     async def check(self, headers: Dict[str, str], request: Request) -> None:  # type: ignore
-        duration = float(0);
+        duration = float(0)
         if "X-Datadog-Test-Stall-Seconds" in headers:
             duration = float(headers["X-Datadog-Test-Stall-Seconds"])
         elif request.app["trace_request_delay"] is not None:
             duration = float(request.app["trace_request_delay"])
         if duration > 0:
-            log.info(
-                "Stalling for %r seconds.",
-                duration)
+            log.info("Stalling for %r seconds.", duration)
             await asyncio.sleep(duration)

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -58,7 +58,7 @@ class CheckTraceStallAsync(Check):
     description = """
 Stall the trace (mimicking an overwhelmed or throttled agent) for the given duration in seconds.
 
-Enable the check by submitting the X-Datadog-Test-Trace-Stall http header (unit is seconds)
+Enable the check by submitting the X-Datadog-Test-Stall-Seconds http header (unit is seconds)
 with the request.
 
 Note that only the request for this trace is stalled, subsequent requests will not be
@@ -67,7 +67,10 @@ affected.
     default_enabled = True
 
     async def check(self, headers: Dict[str, str]) -> None:  # type: ignore
-        if "X-Datadog-Test-Trace-Stall" in headers:
-            duration = float(headers["X-Datadog-Test-Trace-Stall"])
-
+        duration = float(0);
+        if "X-Datadog-Test-Stall-Seconds" in headers:
+            duration = float(headers["X-Datadog-Test-Stall-Seconds"])
+        elif "" in request.app:
+            duration = float(request.app["trace_request_delay"])
+        if duration > 0:
             await asyncio.sleep(duration)

--- a/releasenotes/notes/throttling-590bf58ecb3cc4a5.yaml
+++ b/releasenotes/notes/throttling-590bf58ecb3cc4a5.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add support for artificially throttling requests.
+    Simulates an agent under duress.
+    Enabled via variable `DD_APM_RECEIVER_SOCKET` or request header `X-Datadog-Test-Trace-Stall`.
+    Set either with milliseconds delay/

--- a/releasenotes/notes/throttling-590bf58ecb3cc4a5.yaml
+++ b/releasenotes/notes/throttling-590bf58ecb3cc4a5.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Add support for artificially throttling requests.
-    Simulates an agent under duress.
-    Enabled via variable `DD_APM_RECEIVER_SOCKET` or request header `X-Datadog-Test-Trace-Stall`.
-    Set either with milliseconds delay/
+    Add support for artificially throttling requests to simulate an agent under
+    duress.  Enabled dynamically via request header
+    ``X-Datadog-Test-Trace-Stall-Seconds`` with /v0.4/trace requests or
+    statically via the ``--trace-request-delay`` flag.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,11 @@ def agent_url() -> Generator[str, None, None]:
 
 
 @pytest.fixture
+def trace_request_delay() -> Generator[float, None, None]:
+    yield 0.0
+
+
+@pytest.fixture
 async def agent_app(
     aiohttp_server,
     agent_disabled_checks,
@@ -63,6 +68,7 @@ async def agent_app(
     snapshot_ci_mode,
     snapshot_ignored_attrs,
     agent_url,
+    trace_request_delay,
 ):
     app = await aiohttp_server(
         make_app(
@@ -72,6 +78,7 @@ async def agent_app(
             snapshot_ci_mode,
             snapshot_ignored_attrs,
             agent_url,
+            trace_request_delay,
         )
     )
     yield app

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -89,7 +89,7 @@ async def test_trace_stall(
     v04_reference_http_trace_payload_data,
     agent_disabled_checks,
 ):
-    v04_reference_http_trace_payload_headers["X-Datadog-Test-Trace-Stall"] = "0.5"
+    v04_reference_http_trace_payload_headers["X-Datadog-Test-Stall-Seconds"] = "0.8"
     start = time.monotonic_ns()
     resp = await agent.put(
         "/v0.4/traces",
@@ -98,4 +98,4 @@ async def test_trace_stall(
     )
     assert resp.status == 200, await resp.text()
     end = time.monotonic_ns()
-    assert (end - start) / 1e9 >= 0.5
+    assert (end - start) / 1e9 >= 0.8

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from .conftest import v04_trace
@@ -79,3 +81,21 @@ async def test_trace_content_length(agent):
     resp = await v04_trace(agent, [trace], "msgpack")
     assert resp.status == 400, await resp.text()
     assert "Check 'trace_content_length' failed: content length" in await resp.text()
+
+
+async def test_trace_stall(
+    agent,
+    v04_reference_http_trace_payload_headers,
+    v04_reference_http_trace_payload_data,
+    agent_disabled_checks,
+):
+    v04_reference_http_trace_payload_headers["X-Datadog-Test-Trace-Stall"] = "0.5"
+    start = time.monotonic_ns()
+    resp = await agent.put(
+        "/v0.4/traces",
+        headers=v04_reference_http_trace_payload_headers,
+        data=v04_reference_http_trace_payload_data,
+    )
+    assert resp.status == 200, await resp.text()
+    end = time.monotonic_ns()
+    assert (end - start) / 1e9 >= 0.5


### PR DESCRIPTION
Introduce a new feature that allows the artificial throttling of the test agent for specific (or all) requests to mimic a real agent being under load.