### PR TITLE
Add support for UDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ See the [Development](#Development) section for how to get the test agent runnin
 ## Installation
 
 The test agent can be installed from PyPI:
-```
     pip install ddapm-test-agent
     ddapm-test-agent --port=8126
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The APM test agent is an application which emulates the APM endpoints of the [Datadog agent](https://github.com/DataDog/datadog-agent/) which can be used for testing Datadog APM client libraries.
 
-See the [features](#Features) section for the complete list of functionality provided.
+See the [features](#Features) section for the complete list of functionalities provided.
 
 See the [API](#API) section for the endpoint available.
 
@@ -16,14 +16,10 @@ See the [Development](#Development) section for how to get the test agent runnin
 
 ## Installation
 
-Once the agent is installed, you can start it like this:
-```
-    ddapm-test-agent --port=8126
-```
-
 The test agent can be installed from PyPI:
 ```
     pip install ddapm-test-agent
+    ddapm-test-agent --port=8126
 ```
 
 or from Docker:

--- a/README.md
+++ b/README.md
@@ -19,27 +19,20 @@ See the [Development](#Development) section for how to get the test agent runnin
 The test agent can be installed from PyPI:
     pip install ddapm-test-agent
     ddapm-test-agent --port=8126
-```
 
 or from Docker:
-```
     # Run the test agent and mount the snapshot directory
     docker run --rm\
             -p 8126:8126\
             -e CI_MODE=0\
             -v $PWD/tests/snapshots:/snapshots\
             ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
-```
 
 or from source:
-```
     pip install git+https://github.com/Datadog/dd-apm-test-agent
-```
 
 or a specific branch:
-```
 	pip install git+https://github.com/Datadog/dd-apm-test-agent@{branch}
-```
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@
 
 <img align="right" src="https://user-images.githubusercontent.com/6321485/136316621-b4af42b6-4d1f-4482-a45b-bdee47e94bb8.jpeg" alt="bits agent" width="200px"/>
 
-The APM test agent is an application which emulates the APM endpoints of
-the [Datadog agent](https://github.com/DataDog/datadog-agent/) which can be used for testing Datadog APM client
-libraries.
+The APM test agent is an application which emulates the APM endpoints of the [Datadog agent](https://github.com/DataDog/datadog-agent/) which can be used for testing Datadog APM client libraries.
 
-See the [features](#Features) section for the complete list of functionalities provided.
+See the [features](#Features) section for the complete list of functionality provided.
 
 See the [API](#API) section for the endpoint available.
 
@@ -18,32 +16,42 @@ See the [Development](#Development) section for how to get the test agent runnin
 
 ## Installation
 
-The test agent can be installed from PyPI:
-
-    pip install ddapm-test-agent
-
+Once the agent is installed, you can start it like this:
+```
     ddapm-test-agent --port=8126
+```
 
-from Docker:
+The test agent can be installed from PyPI:
+```
+    pip install ddapm-test-agent
+```
 
+or from Docker:
+```
     # Run the test agent and mount the snapshot directory
     docker run --rm\
             -p 8126:8126\
             -e CI_MODE=0\
             -v $PWD/tests/snapshots:/snapshots\
             ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
+```
 
 or from source:
-
+```
     pip install git+https://github.com/Datadog/dd-apm-test-agent
+```
 
+or a specific branch:
+```
+	pip install git+https://github.com/Datadog/dd-apm-test-agent@{branch}
+```
 
 ## Features
 
 ### Trace invariant checks
 
-Many checks are provided by the test agent which will verify trace data. All checks are enabled by default and can be
-manually disabled.
+Many checks are provided by the test agent which will verify trace data. 
+All checks are enabled by default and can be manually disabled.
 
 See the [configuration](#Configuration) section for the options.
 
@@ -63,8 +71,7 @@ All data that is submitted to the test agent can be retrieved.
 
 ### Helpful logging
 
-The `INFO` log level of the test agent outputs useful information about the requests the test agent receives. For traces
-this includes a visual representation of the traces.
+The `INFO` log level of the test agent outputs useful information about the requests the test agent receives. For traces this includes a visual representation of the traces.
 
 ```
 INFO:ddapm_test_agent.agent:received trace payload with 1 trace chunk
@@ -79,27 +86,25 @@ INFO:ddapm_test_agent.agent:end of payload -------------------------------------
 
 ### Proxy
 
-The test agent provides proxying to the Datadog agent. This is enabled by passing the agent url to the test agent
-either via the `--agent-url` commandline argument or by the `DD_TRACE_AGENT_URL` or `DD_AGENT_URL` environment
-variables.
+The test agent provides proxying to the Datadog agent. 
+This is enabled by passing the agent url to the test agent either via the `--agent-url` command-line argument or by the `DD_TRACE_AGENT_URL` or `DD_AGENT_URL` environment variables.
 
-When proxying is enabled the response from the Datadog agent will be returned instead of one from the test agent.
+When proxying is enabled, the response from the Datadog agent will be returned instead of one from the test agent.
 
 
 ### Snapshot testing
 
 The test agent provides a form of [characterization testing](https://en.wikipedia.org/wiki/Characterization_test) which
-we refer to as snapshotting. This allows library maintainers to ensure that traces don't change unexpectedly when making
-unrelated changes.
+we refer to as snapshotting. 
+This allows library maintainers to ensure that traces don't change unexpectedly when making unrelated changes.
 
-This can be used to write integration tests by having test cases use the tracer to emit traces which are collected by
-the test agent and compared against reference traces stored previously.
+This can be used to write integration tests by having test cases use the tracer to emit traces which are collected by the test agent and compared against reference traces stored previously.
 
 To do snapshot testing with the test agent:
 
 1. Ensure traces are associated with a session token (typically the name of the test case) by either:
    - Calling the `/test/session/start` with the token endpoint before emitting the traces; or
-   - Attaching an additional query param or header specifying the session token on `/vX.Y/trace` requests (see below for
+   - Attaching an additional query string parameter or header specifying the session token on `/vX.Y/trace` requests (see below for
      the API specifics). (Required for concurrent test running)
 2. Emit traces (run the integration test).
 3. Signal the end of the session and perform the snapshot comparison by calling the `/tests/session/snapshot` endpoint
@@ -155,7 +160,7 @@ Please refer to `ddapm-test-agent-fmt --help` for more information.
 - `LOG_SPAN_FMT` [`"[{name}]"`]: Format string to use when outputting spans in logs.
 
 - `SNAPSHOT_DIR` [`"./snapshots"`]: Directory in which snapshots will be stored.
-  Can be overridden by providing the `dir` query param on `/snapshot`.
+  Can be overridden by providing the `dir` query parameter on `/snapshot`.
 
 - `SNAPSHOT_CI` [`0`]: Toggles CI mode for the snapshot tests. Set to `1` to
   enable. CI mode does the following:
@@ -166,6 +171,8 @@ Please refer to `ddapm-test-agent-fmt --help` for more information.
   attributes to ignore when comparing spans in snapshots.
 
 - `DD_AGENT_URL` [`""`]: URL to a Datadog agent. When provided requests will be proxied to the agent.
+
+- `DD_APM_RECEIVER_SOCKET` [`""`]: When provided, the test agent will listen for traces on a socket at the path provided (e.g., `/var/run/datadog/apm.socket`)
 
 
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -595,9 +595,7 @@ def main(args: Optional[List[str]] = None) -> None:
         "--trace-uds-socket",
         type=str,
         default=os.environ.get("DD_APM_RECEIVER_SOCKET"),
-        help=(
-            "Will listen for traces on the specified socket path"
-        ),
+        help=("Will listen for traces on the specified socket path"),
     )
     parsed_args = parser.parse_args(args=args)
     logging.basicConfig(level=parsed_args.log_level)

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -592,9 +592,12 @@ def main(args: Optional[List[str]] = None) -> None:
         ),
     )
     parser.add_argument(
-        "--uds-path",
+        "--trace-uds-socket",
         type=str,
-        default=os.environ.get("DD_AGENT_URL") if os.environ.get("DD_AGENT_URL", "").startswith("unix://") else "/var/run/datadog/apm.socket"
+        default=os.environ.get("DD_APM_RECEIVER_SOCKET"),
+        help=(
+            "Will listen for traces on the specified socket path"
+        ),
     )
     parsed_args = parser.parse_args(args=args)
     logging.basicConfig(level=parsed_args.log_level)

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -594,7 +594,7 @@ def main(args: Optional[List[str]] = None) -> None:
     parser.add_argument(
         "--trace-uds-socket",
         type=str,
-        default=os.environ.get("DD_APM_RECEIVER_SOCKET"),
+        default=os.environ.get("DD_APM_RECEIVER_SOCKET", None),
         help=("Will listen for traces on the specified socket path"),
     )
     parsed_args = parser.parse_args(args=args)
@@ -619,9 +619,8 @@ def main(args: Optional[List[str]] = None) -> None:
         snapshot_ignored_attrs=parsed_args.snapshot_ignored_attrs,
         agent_url=parsed_args.agent_url,
     )
-    web.run_app(
-        app, path=os.path.abspath(parsed_args.trace_uds_socket), port=parsed_args.port
-    )
+
+    web.run_app(app, path=parsed_args.trace_uds_socket, port=parsed_args.port)
 
 
 if __name__ == "__main__":

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -619,7 +619,7 @@ def main(args: Optional[List[str]] = None) -> None:
         snapshot_ignored_attrs=parsed_args.snapshot_ignored_attrs,
         agent_url=parsed_args.agent_url,
     )
-    web.run_app(app, path=os.path.abspath(parsed_args.uds_path), port=parsed_args.port)
+    web.run_app(app, path=os.path.abspath(parsed_args.trace_uds_socket), port=parsed_args.port)
 
 
 if __name__ == "__main__":

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -591,6 +591,11 @@ def main(args: Optional[List[str]] = None) -> None:
             "to the agent."
         ),
     )
+    parser.add_argument(
+        "--uds-path",
+        type=str,
+        default=os.environ.get("DD_AGENT_URL") if os.environ.get("DD_AGENT_URL", "").startswith("unix://") else "/var/run/datadog/apm.socket"
+    )
     parsed_args = parser.parse_args(args=args)
     logging.basicConfig(level=parsed_args.log_level)
 
@@ -613,7 +618,7 @@ def main(args: Optional[List[str]] = None) -> None:
         snapshot_ignored_attrs=parsed_args.snapshot_ignored_attrs,
         agent_url=parsed_args.agent_url,
     )
-    web.run_app(app, port=parsed_args.port)
+    web.run_app(app, path=os.path.abspath(parsed_args.uds_path), port=parsed_args.port)
 
 
 if __name__ == "__main__":

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -362,8 +362,7 @@ class Agent:
                 with open(tracestats_snap_file, mode="r") as f:
                     raw_snapshot = json.load(f)
                 tracestats_snapshot.snapshot(
-                    expected_stats=raw_snapshot,
-                    received_stats=received_stats,
+                    expected_stats=raw_snapshot, received_stats=received_stats,
                 )
             elif received_stats:
                 # Create a new snapshot for the data received
@@ -470,10 +469,7 @@ def make_app(
     agent = Agent()
     app = web.Application(
         client_max_size=int(100e6),  # 100MB - arbitrary
-        middlewares=[
-            check_failure_middleware,
-            session_token_middleware,
-        ],
+        middlewares=[check_failure_middleware, session_token_middleware,],
     )
     app.add_routes(
         [
@@ -514,8 +510,7 @@ def main(args: Optional[List[str]] = None) -> None:
     if args is None:
         args = sys.argv[1:]
     parser = argparse.ArgumentParser(
-        description="Datadog APM test agent",
-        prog="ddapm-test-agent",
+        description="Datadog APM test agent", prog="ddapm-test-agent",
     )
     parser.add_argument(
         "-v",
@@ -619,7 +614,9 @@ def main(args: Optional[List[str]] = None) -> None:
         snapshot_ignored_attrs=parsed_args.snapshot_ignored_attrs,
         agent_url=parsed_args.agent_url,
     )
-    web.run_app(app, path=os.path.abspath(parsed_args.trace_uds_socket), port=parsed_args.port)
+    web.run_app(
+        app, path=os.path.abspath(parsed_args.trace_uds_socket), port=parsed_args.port
+    )
 
 
 if __name__ == "__main__":

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -362,7 +362,8 @@ class Agent:
                 with open(tracestats_snap_file, mode="r") as f:
                     raw_snapshot = json.load(f)
                 tracestats_snapshot.snapshot(
-                    expected_stats=raw_snapshot, received_stats=received_stats,
+                    expected_stats=raw_snapshot,
+                    received_stats=received_stats,
                 )
             elif received_stats:
                 # Create a new snapshot for the data received
@@ -469,7 +470,10 @@ def make_app(
     agent = Agent()
     app = web.Application(
         client_max_size=int(100e6),  # 100MB - arbitrary
-        middlewares=[check_failure_middleware, session_token_middleware,],
+        middlewares=[
+            check_failure_middleware,
+            session_token_middleware,
+        ],
     )
     app.add_routes(
         [
@@ -510,7 +514,8 @@ def main(args: Optional[List[str]] = None) -> None:
     if args is None:
         args = sys.argv[1:]
     parser = argparse.ArgumentParser(
-        description="Datadog APM test agent", prog="ddapm-test-agent",
+        description="Datadog APM test agent",
+        prog="ddapm-test-agent",
     )
     parser.add_argument(
         "-v",

--- a/releasenotes/notes/uds-64b11960931d8b77.yaml
+++ b/releasenotes/notes/uds-64b11960931d8b77.yaml
@@ -2,3 +2,4 @@
 features:
   - |
     Add unix domain socket support.
+    Enabled via environment variable `DD_APM_RECEIVER_SOCKET` or command line argument `--trace-uds-socket`.

--- a/releasenotes/notes/uds-64b11960931d8b77.yaml
+++ b/releasenotes/notes/uds-64b11960931d8b77.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add unix domain socket support.


### PR DESCRIPTION

```
(.venv) ~/d/dd-apm-test-agent ❮❮❮ ddapm-test-agent --uds-path=./apm.socket
======== Running on http://0.0.0.0:8126, http://unix:/Users/kverhoog/dev/dd-apm-test-agent/apm.socket: ========
(Press CTRL+C to quit)
```

Resolves #67 