### PR TITLE
Generate better snapshot error messages

### DIFF
--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -140,12 +140,20 @@ def _match_traces(t1s: List[Trace], t2s: List[Trace]) -> List[Tuple[Trace, Trace
         matched_t1s.add(t1_trace_id)
         matched_t2s.add(t2_trace_id)
 
-    assert len(matched_t1s) == len(
-        t1_map
-    ), f"Unmatched expected traces {set(t1_map.keys()) - matched_t1s}"
-    assert len(matched_t2s) == len(
-        t2_map
-    ), f"Unmatched received traces {set(t2_map.keys()) - matched_t2s}"
+    if len(matched_t1s) != len(t1_map):
+        unmatched_ids = set(t1_map.keys()) - matched_t1s
+        op_names = [t1_map[tid][0]["name"] for tid in unmatched_ids]
+        raise AssertionError(
+            "Did not receive expected traces: %s"
+            % (",".join(map(lambda s: f"'{s}'", op_names)))
+        )
+    if len(matched_t2s) != len(t2_map):
+        unmatched_ids = set(t2_map.keys()) - matched_t2s
+        op_names = [t2_map[tid][0]["name"] for tid in unmatched_ids]
+        raise AssertionError(
+            "Received unmatched traces: %s"
+            % (",".join(map(lambda s: f"'{s}'", op_names)))
+        )
     return matches
 
 
@@ -208,9 +216,16 @@ def _compare_traces(expected: Trace, received: Trace, ignored: Set[str]) -> None
 
     The given traces are assumed to be in BFS order.
     """
-    assert len(expected) == len(
-        received
-    ), f"Number of traces received ({len(received)}) doesn't match expected ({len(expected)})."
+    if len(received) > len(expected):
+        names = ["'%s'" % s["name"] for s in received[len(expected) - len(received) :]]
+        raise AssertionError(
+            f"Received more spans ({len(received)}) than expected ({len(expected)}). Received unmatched spans: {', '.join(names)}"
+        )
+    elif len(expected) > len(received):
+        names = ["'%s'" % s["name"] for s in expected[len(received) - len(expected) :]]
+        raise AssertionError(
+            f"Received less spans ({len(received)}) than expected ({len(expected)}). Expected unmatched spans: {', '.join(names)}"
+        )
 
     for s_exp, s_rec in zip(expected, received):
         with CheckTrace.add_frame(
@@ -256,16 +271,19 @@ def snapshot(
 ) -> None:
     normed_expected = _normalize_traces(expected_traces)
     normed_received = _normalize_traces(received_traces)
-    matched = _match_traces(normed_expected, normed_received)
-    log.debug("Matched traces %r", matched)
+    with CheckTrace.add_frame(
+        f"compare of {len(normed_expected)} expected trace(s) to {len(normed_received)} received trace(s)"
+    ):
+        matched = _match_traces(normed_expected, normed_received)
+        log.debug("Matched traces %r", matched)
 
-    for exp, rec in matched:
-        with CheckTrace.add_frame(f"trace ({len(exp)}) spans"):
-            _compare_traces(exp, rec, set(ignored))
+        for exp, rec in matched:
+            with CheckTrace.add_frame(f"trace '{exp[0]['name']}' ({len(exp)} spans)"):
+                _compare_traces(exp, rec, set(ignored))
 
 
 def _ordered_span(s: Span) -> OrderedDictType[str, TopLevelSpanValue]:
-    """Order the span to be more human readable."""
+    """Order the span to be more human-readable."""
     d = OrderedDict()
     order = [
         "name",

--- a/releasenotes/notes/snapshot-error-messages-de41d9e3207fa30a.yaml
+++ b/releasenotes/notes/snapshot-error-messages-de41d9e3207fa30a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Better snapshot error messages for unexpected number of traces received.

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -75,12 +75,12 @@ FIVE_SPAN_TRACE = random_trace(5)
         (
             [TWO_SPAN_TRACE],
             [TWO_SPAN_TRACE[:-1]],
-            "Number of traces received (1) doesn't match expected (2).",
+            "Received less spans (1) than expected (2). Expected unmatched spans: 'postgres.query'",
         ),
         (
             [TWO_SPAN_TRACE[:-1]],
             [TWO_SPAN_TRACE],
-            "Number of traces received (2) doesn't match expected (1).",
+            "Received more spans (2) than expected (1). Received unmatched spans: 'postgres.query'",
         ),
         (
             [[set_attr(copy_span(ONE_SPAN_TRACE[0]), "name", "name_expected")]],


### PR DESCRIPTION
Be more verbose about received/expected traces rather than just spitting
out a normalized trace id.