### PR TITLE
Handle span `parent_id` being undefined in snapshots

### DIFF
--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -94,8 +94,9 @@ def _normalize_trace(trace: Trace, trace_id: TraceId) -> Trace:
         span["trace_id"] = trace_id
         new_id_map[span["span_id"]] = span_id
         span["span_id"] = span_id
-        if span.get("parent_id"):
-            span["parent_id"] = new_id_map[span["parent_id"]]
+        parent_id = span.get("parent_id")
+        if parent_id:
+            span["parent_id"] = new_id_map[parent_id]
         else:
             # Normalize the parent of root spans to be 0.
             span["parent_id"] = 0

--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -94,7 +94,7 @@ def _normalize_trace(trace: Trace, trace_id: TraceId) -> Trace:
         span["trace_id"] = trace_id
         new_id_map[span["span_id"]] = span_id
         span["span_id"] = span_id
-        if span["parent_id"]:
+        if "parent_id" in span and span["parent_id"]:
             span["parent_id"] = new_id_map[span["parent_id"]]
         else:
             # Normalize the parent of root spans to be 0.

--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -94,7 +94,7 @@ def _normalize_trace(trace: Trace, trace_id: TraceId) -> Trace:
         span["trace_id"] = trace_id
         new_id_map[span["span_id"]] = span_id
         span["span_id"] = span_id
-        if "parent_id" in span and span["parent_id"]:
+        if span.get("parent_id"):
             span["parent_id"] = new_id_map[span["parent_id"]]
         else:
             # Normalize the parent of root spans to be 0.

--- a/releasenotes/notes/snapshot-parent-id-7abb860008702e70.yaml
+++ b/releasenotes/notes/snapshot-parent-id-7abb860008702e70.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix not present parent_id in snapshots. It should be normalized to 0.

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -208,7 +208,7 @@ async def test_snapshot_trace_differences(agent, expected_traces, actual_traces,
         (
             [
                 [
-                    {"parent_id": 0, "span_id": 1, "start": 0},
+                    {"span_id": 1, "start": 0},
                     {"parent_id": 1, "span_id": 2, "start": 1},
                     {"parent_id": 1, "span_id": 3, "start": 2},
                     {"parent_id": 2, "span_id": 4, "start": 4},

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -239,7 +239,42 @@ async def test_snapshot_trace_differences(agent, expected_traces, actual_traces,
        "parent_id": 1,
        "start": 2
      }]]\n""",
-        )
+        ),
+        (
+            [
+                [
+                    {"parent_id": None, "span_id": 1, "start": 0},
+                    {"parent_id": 1, "span_id": 2, "start": 1},
+                    {"parent_id": 1, "span_id": 3, "start": 2},
+                    {"parent_id": 2, "span_id": 4, "start": 4},
+                ]
+            ],
+            """[[
+  {
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "start": 0
+  },
+     {
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "start": 1
+     },
+        {
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "start": 4
+        },
+     {
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "start": 2
+     }]]\n""",
+        ),
     ],
 )
 def test_generate_trace_snapshot(trace, expected):


### PR DESCRIPTION
Fixes a "missing `parent_id`" issue in the snapshot generation.

https://github.com/DataDog/dd-apm-test-agent/pull/66 fixed the issue when receiving traces, this fixes the issue when generating snapshots.

Caveats: this is about the first Python I've written 😉 

Fixes #65.