### PR TITLE
feat: add support for distributed traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The traces are normalized and output in JSON to a file. The following transforma
 
 - Trace ids are overwritten to match the order in which the traces were received.
 - Span ids are overwritten to be the DFS order of the spans in the trace tree.
+- Parent ids are overwritten using the normalized span ids. However, if the parent is not a span in the trace, the parent id is not overwritten. This is necessary for handling distributed traces where all spans are not sent to the same agent.
 - Span attributes are ordered to be more human-readable, with the important attributes being listed first.
 - Span attributes are otherwise ordered alphanumerically.
 - The span meta and metrics maps if empty are excluded.

--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -96,7 +96,9 @@ def _normalize_trace(trace: Trace, trace_id: TraceId) -> Trace:
         span["span_id"] = span_id
         parent_id = span.get("parent_id")
         if parent_id:
-            span["parent_id"] = new_id_map[parent_id]
+            # If parent_id is not in the map, assume this is a trace chunk with
+            # a parent not in the trace chunk. Eg: distributed traces.
+            span["parent_id"] = new_id_map.get(parent_id, parent_id)
         else:
             # Normalize the parent of root spans to be 0.
             span["parent_id"] = 0

--- a/releasenotes/notes/add-distributed-trace-c35a314698a3b966.yaml
+++ b/releasenotes/notes/add-distributed-trace-c35a314698a3b966.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for distributed traces where an instrumented service sends a trace chunk where the root span has a parent not in the trace chunk.

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         "aiohttp",
         "ddsketch",
+        "protobuf<4.21.0",
         "msgpack",
         "typing_extensions",
     ],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     install_requires=[
         "aiohttp",
         "ddsketch",
-        "protobuf<4.21.0",
         "msgpack",
         "typing_extensions",
     ],

--- a/tests/integration_snapshots/test_trace_distributed_propagated.json
+++ b/tests/integration_snapshots/test_trace_distributed_propagated.json
@@ -1,0 +1,29 @@
+[[
+  {
+    "name": "root",
+    "service": null,
+    "resource": "root",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 5678,
+    "meta": {
+      "runtime-id": "9118dd9528d447629254178d1bb4dbcf"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "system.pid": 81934
+    },
+    "duration": 171000,
+    "start": 1653668237165110000
+  },
+     {
+       "name": "child",
+       "service": null,
+       "resource": "child",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "duration": 6000,
+       "start": 1653668237165133000
+     }]]

--- a/tests/test_snapshot_integration.py
+++ b/tests/test_snapshot_integration.py
@@ -7,6 +7,7 @@ import aiohttp
 from aiohttp.client_exceptions import ClientConnectorError
 from aiohttp.client_exceptions import ClientOSError
 from ddtrace import Tracer
+from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.sampler import DatadogSampler
 import pytest
 
@@ -206,6 +207,27 @@ async def test_trace_distributed_same_payload(testagent, tracer):
     tracer.flush()
     resp = await testagent.get(
         "http://localhost:8126/test/session/snapshot?test_session_token=test_trace_distributed_same_payload"
+    )
+    assert resp.status == 200
+
+
+async def test_trace_distributed_propagated(testagent, tracer):
+    await testagent.get(
+        "http://localhost:8126/test/session/start?test_session_token=test_trace_distributed_propagated"
+    )
+    headers = {
+        "x-datadog-trace-id": "1234",
+        "x-datadog-parent-id": "5678",
+    }
+    context = HTTPPropagator.extract(headers)
+    tracer.context_provider.activate(context)
+
+    with tracer.trace("root"):
+        with tracer.trace("child"):
+            pass
+    tracer.flush()
+    resp = await testagent.get(
+        "http://localhost:8126/test/session/snapshot?test_session_token=test_trace_distributed_propagated"
     )
     assert resp.status == 200
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -8,6 +8,7 @@ from ddapm_test_agent.trace import decode_v04
 from ddapm_test_agent.trace import dfs_order
 from ddapm_test_agent.trace import root_span
 
+from .trace_utils import random_id
 from .trace_utils import random_trace
 
 
@@ -18,6 +19,16 @@ def test_random_trace():
         assert len(t) == i
         assert dfs_order(t)
         assert bfs_order(t)
+
+
+def test_trace_chunk():
+    trace_id = random_id()
+    parent_id = random_id()
+    t = random_trace(10, trace_id=trace_id, parent_id=parent_id)
+    root = root_span(t)
+    assert root
+    assert root.get("trace_id") == trace_id
+    assert root.get("parent_id") == parent_id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add support for distributed traces where an instrumented service sends a trace chunk where the root span has a parent not in the trace chunk.