### PR TITLE
Add testing flag for snapshot generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,11 @@ To run the tests (in Python 3.8):
 
     riot run -p3.8 test
 
+Note: if snapshots need to be (re)generated in the tests set the environment variable `GENERATE_SNAPSHOTS=1`.
+
+    GENERATE_SNAPSHOTS=1 riot run --pass-env -p3.8 test -k test_trace_missing_received
+
+
 ### Linting and formatting
 
 To lint, format and type-check the code:

--- a/tests/test_snapshot_integration.py
+++ b/tests/test_snapshot_integration.py
@@ -1,3 +1,7 @@
+"""
+If snapshots need to be (re)generated, set GENERATE_SNAPSHOTS=1
+and run the tests as usual.
+"""
 import asyncio
 import os
 import subprocess
@@ -19,7 +23,9 @@ def testagent_port():
 @pytest.fixture(scope="module")
 def testagent_snapshot_ci_mode():
     # Default all tests in this module to be run in CI mode
-    yield True
+    # unless a special env var is passed to make generating
+    # the snapshots easier.
+    yield os.getenv("GENERATE_SNAPSHOTS") != "1"
 
 
 @pytest.fixture


### PR DESCRIPTION
Previously, in order to generate snapshots the pytest fixture had to be
parametrized to be set to false. This was a bit clunky and not at all
intuitive for new developers.

Now a flag, `GENERATE_SNAPSHOTS=1` can be passed when running the
integration tests which will enable the snapshots to be output.