### PR TITLE
Fix trace_content_length check

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -225,10 +225,7 @@ class Agent:
         with CheckTrace.add_frame("headers") as f:
             f.add_item(pprint.pformat(dict(request.headers)))
             checks.check("meta_tracer_version_header", headers=dict(request.headers))
-            checks.check(
-                "trace_content_length",
-                content_length=int(request.headers["Content-Length"]),
-            )
+            checks.check("trace_content_length", headers=dict(request.headers))
             if version == "v0.4":
                 traces = await self._decode_v04_traces(request)
             elif version == "v0.5":

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -47,6 +47,11 @@ The max content size of a trace payload is 50MB.
 """.strip()
     default_enabled = True
 
-    def check(self, content_length: int) -> None:  # type: ignore
+    def check(self, headers: Dict[str, str]) -> None:  # type: ignore
+        if "Content-Length" not in headers:
+            self.fail(
+                f"content length header 'Content-Length' not in http headers {headers}"
+            )
+        content_length = int(headers["Content-Length"])
         if content_length > 5e7:
             self.fail(f"content length {content_length} too large.")

--- a/releasenotes/notes/content_length-e1bab75580aa1dcb.yaml
+++ b/releasenotes/notes/content_length-e1bab75580aa1dcb.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix content length check assuming that the Content-Length header is always
+    included in trace http requests. Some clients (like go) don't submit this
+    header.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,7 @@ def v04_trace(  # type: ignore
     traces: List[Trace],
     encoding: Literal["msgpack", "json"] = "msgpack",
     token: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
 ):
     params = {"test_session_token": token} if token is not None else {}
     if encoding == "msgpack":


### PR DESCRIPTION
The check assumed that the header would always be included. Some
clients, particularly the go client, don't include this header.