### PR TITLE
Add /info endpoint support

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -215,6 +215,20 @@ class Agent:
         )
         return web.HTTPOk()
 
+    async def handle_info(self, request: Request) -> web.Response:
+        return web.json_response(
+            {
+                "version": "test",
+                "endpoints": [
+                    "/v0.4/traces",
+                    "/v0.5/traces",
+                    "/v0.6/stats",
+                ],
+                "feature_flags": [],
+                "config": {},
+            }
+        )
+
     async def _handle_traces(
         self, request: Request, version: Literal["v0.4", "v0.5"]
     ) -> web.Response:
@@ -484,6 +498,7 @@ def make_app(
             web.post("/v0.5/traces", agent.handle_v05_traces),
             web.put("/v0.5/traces", agent.handle_v05_traces),
             web.put("/v0.6/stats", agent.handle_v06_tracestats),
+            web.get("/info", agent.handle_info),
             web.get("/test/session/start", agent.handle_session_start),
             web.get("/test/session/clear", agent.handle_session_clear),
             web.get("/test/session/snapshot", agent.handle_snapshot),

--- a/releasenotes/notes/info-34dcd9cbcc382487.yaml
+++ b/releasenotes/notes/info-34dcd9cbcc382487.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for the ``/info`` endpoint.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -51,3 +51,18 @@ async def test_trace_clear_token(
     resp = await agent.get("/test/traces", params={"trace_ids": "123456"})
     assert resp.status == 200
     assert await resp.text() == "[[]]"
+
+
+async def test_info(agent):
+    resp = await agent.get("/info")
+    assert resp.status == 200
+    assert await resp.json() == {
+        "version": "test",
+        "endpoints": [
+            "/v0.4/traces",
+            "/v0.5/traces",
+            "/v0.6/stats",
+        ],
+        "feature_flags": [],
+        "config": {},
+    }


### PR DESCRIPTION
The info endpoint exists to allow clients to detect what features are
available in the agent. The go tracer specifically will only enable
trace stats computation if it detects that the agent supports the
feature.