### PR TITLE
Decode service in trace stats payloads

### DIFF
--- a/ddapm_test_agent/tracestats.py
+++ b/ddapm_test_agent/tracestats.py
@@ -13,6 +13,7 @@ import msgpack
 class StatsAggr(TypedDict):
     Name: str
     Resource: str
+    Service: Optional[str]
     Type: Optional[str]
     HTTPStatusCode: int
     Synthetics: bool
@@ -46,6 +47,7 @@ def decode_v06(data: bytes) -> v06StatsPayload:
             stat = StatsAggr(
                 Name=raw_stats["Name"],
                 Resource=raw_stats["Resource"],
+                Service=raw_stats.get("Service"),
                 Type=raw_stats.get("Type"),
                 HTTPStatusCode=raw_stats.get("HTTPStatusCode"),
                 Synthetics=raw_stats["Synthetics"],

--- a/releasenotes/notes/tracestats-service-2a0a178cbd21b07d.yaml
+++ b/releasenotes/notes/tracestats-service-2a0a178cbd21b07d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Decode service field in trace stats requests, it was previously omitted.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,6 +215,7 @@ def v06_reference_http_stats_payload_data_raw():
                     {
                         "Name": "http.request",
                         "Resource": "/user/profile",
+                        "Service": "web-svc",
                         "Synthetics": False,
                         "Hits": ok_n + err_n,
                         "TopLevelHits": ok_n + err_n,


### PR DESCRIPTION
This was missed originally.