### PR TITLE
Only process trace requests with /test/traces endpoint

### DIFF
--- a/releasenotes/notes/traces-endpoint-f4f9c1d94d6ceda2.yaml
+++ b/releasenotes/notes/traces-endpoint-f4f9c1d94d6ceda2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix /test/traces endpoint attempting to decode non-trace requests.


### PR DESCRIPTION
The /test/traces endpoint was using all gathered requests, assuming that
they were trace requests. This cause the endpoint to fail if telemetry
or stats requests are sent.

It was noticed that support for v0.5 wasn't present either so that is fixed too.

Thanks @bengl for finding this the hard way.