### PR TITLE
Set 722 file permissions on UDS socket

### DIFF
--- a/releasenotes/notes/uds-permissions-903266ac6445b873.yaml
+++ b/releasenotes/notes/uds-permissions-903266ac6445b873.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Use 722 permissions for UDS socket to match the agent.


### PR DESCRIPTION
The permissions of the socket created by aiohttp aren't as permissive as
the ones set by the real agent. (see
https://github.com/aio-libs/aiohttp/issues/4155)

from @devinsba:

test agent:

```
cnb@my-app:/var/run/datadog$ ls -la
total 4
drwxr-xr-x 2 root root   60 Aug  1 21:24 .
drwxr-xr-x 1 root root 4096 Aug  1 21:24 ..
srwxr-xr-x 1 root root    0 Aug  1 21:24 apm.socket
```

real agent:

```
cnb@my-app:/var/run/datadog$ ls -la
total 4
drwxr-xr-x 2 root root   80 Aug  1 21:30 .
drwxr-xr-x 1 root root 4096 Aug  1 21:31 ..
srwx-w--w- 1 root root    0 Aug  1 21:30 apm.socket
```


aiohttp doesn't seem to have a configurable way
to set these permissions but it does let us create and
manage a socket ourselves, so let's try that.
