### PR TITLE
Update snapshot integration tests for ddtrace 1.3

### DIFF
--- a/tests/integration_snapshots/test_multi_trace.json
+++ b/tests/integration_snapshots/test_multi_trace.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "meta": {
+      "_dd.p.dm": "-0",
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
@@ -38,6 +39,7 @@
     "span_id": 1,
     "parent_id": 0,
     "meta": {
+      "_dd.p.dm": "-0",
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {

--- a/tests/integration_snapshots/test_single_trace.json
+++ b/tests/integration_snapshots/test_single_trace.json
@@ -8,6 +8,7 @@
     "parent_id": 0,
     "type": "web",
     "meta": {
+      "_dd.p.dm": "-0",
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {

--- a/tests/integration_snapshots/test_trace_distributed_same_payload.json
+++ b/tests/integration_snapshots/test_trace_distributed_same_payload.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "meta": {
+      "_dd.p.dm": "-0",
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {
@@ -37,6 +38,7 @@
           "span_id": 3,
           "parent_id": 2,
           "meta": {
+            "_dd.p.dm": "-0",
             "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
           },
           "metrics": {

--- a/tests/integration_snapshots/test_trace_missing_received.json
+++ b/tests/integration_snapshots/test_trace_missing_received.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "meta": {
+      "_dd.p.dm": "-0",
       "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
     },
     "metrics": {


### PR DESCRIPTION
The 1.3 release of ddtrace introduced a new tag which breaks the snapshot integration tests.