### PR TITLE
Disable flake8-logging-format plugin

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -44,7 +44,7 @@ venv = Venv(
                 "flake8-blind-except": latest,
                 "flake8-builtins": latest,
                 "flake8-docstrings": latest,
-                "flake8-logging-format": latest,
+                # "flake8-logging-format": latest,
                 "flake8-rst-docstrings": latest,
                 "pygments": latest,
                 "toml": latest,


### PR DESCRIPTION
It broke with the latest flake8 release: https://github.com/globality-corp/flake8-logging-format/issues/35