### PR TITLE
Add `metrics.system.process_id` to ignored tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Please refer to `ddapm-test-agent-fmt --help` for more information.
     - When snapshots are unexpectedly _generated_ from a test case a failure will
       be raised.
 
-- `SNAPSHOT_IGNORED_ATTRS` [`"span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.process_id,meta.runtime-id"`]: The
+- `SNAPSHOT_IGNORED_ATTRS` [`"span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.process_id,metrics.system.process_id,meta.runtime-id"`]: The
   attributes to ignore when comparing spans in snapshots.
 
 - `DD_AGENT_URL` [`""`]: URL to a Datadog agent. When provided requests will be proxied to the agent.
@@ -216,7 +216,8 @@ cases sharing a test token will be grouped.
 Comma-separated list of keys of which to ignore values for.
 
 The default built-in ignore list is: `span_id`, `trace_id`, `parent_id`,
-`duration`, `start`, `metrics.system.pid`, `metrics.process_id`, `meta.runtime-id`.
+`duration`, `start`, `metrics.system.pid`, `metrics.process_id`,
+`metrics.system.process_id`, `meta.runtime-id`.
 
 
 #### [optional] `?dir=`

--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -29,7 +29,7 @@ from .trace import trace_id as get_trace_id
 log = logging.getLogger(__name__)
 
 
-DEFAULT_SNAPSHOT_IGNORES = "span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.process_id,meta.runtime-id"
+DEFAULT_SNAPSHOT_IGNORES = "span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,meta.runtime-id"
 
 
 def _key_match(d1: Dict[str, Any], d2: Dict[str, Any], key: str) -> bool:

--- a/releasenotes/notes/new-process-id-tag-f0ab0daf652e05cc.yaml
+++ b/releasenotes/notes/new-process-id-tag-f0ab0daf652e05cc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add `metrics.process_id` tag to ignored tags.


### PR DESCRIPTION
This tag is replacing the system.pid tag.