### PR TITLE
Fix race condition for simultaneous reading and writing

### DIFF
--- a/releasenotes/notes/fix-racecondition-9bd0ef15b7da60fa.yaml
+++ b/releasenotes/notes/fix-racecondition-9bd0ef15b7da60fa.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix race condition when the test agent would simultaneously handle requests
+    which would read and write data.


### PR DESCRIPTION
As discovered in https://github.com/DataDog/system-tests/pull/607, concurrent requests to the test agent that read and write the data (like sending and retrieving traces) could result in:

```
  File "/usr/local/lib/python3.9/site-packages/ddapm_test_agent/agent.py", line 184, in _traces_from_request
    return await self._decode_v04_traces(req)
  File "/usr/local/lib/python3.9/site-packages/ddapm_test_agent/agent.py", line 238, in _decode_v04_traces
    raw_data = await request.read()
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_request.py", line 649, in read
    chunk = await self._payload.readany()
  File "/usr/local/lib/python3.9/site-packages/aiohttp/streams.py", line 397, in readany
    await self._wait("readany")
  File "/usr/local/lib/python3.9/site-packages/aiohttp/streams.py", line 295, in _wait
    raise RuntimeError(
RuntimeError: readany() called while another coroutine is already waiting for incoming data
```
(https://github.com/DataDog/system-tests/actions/runs/3341145276/jobs/5532056812)

This was due to multiple `read()` calls being made on the request object.

The solution is to fetch the data once off of the request object and then store it on the object. Helpers are added to store requests and retrieve the request data when necessary.