### PR TITLE
Fix case sensitive headers

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -330,12 +330,12 @@ class Agent:
         token = request["session_token"]
         checks: Checks = request.app["checks"]
 
-        await checks.check("trace_stall", headers=dict(request.headers), request=request)
+        await checks.check("trace_stall", headers=request.headers, request=request)
 
         with CheckTrace.add_frame("headers") as f:
             f.add_item(pprint.pformat(dict(request.headers)))
-            await checks.check("meta_tracer_version_header", headers=dict(request.headers))
-            await checks.check("trace_content_length", headers=dict(request.headers))
+            await checks.check("meta_tracer_version_header", headers=request.headers)
+            await checks.check("trace_content_length", headers=request.headers)
 
             if version == "v0.4":
                 traces = self._decode_v04_traces(request)
@@ -360,7 +360,7 @@ class Agent:
             with CheckTrace.add_frame(f"payload ({len(traces)} traces)"):
                 await checks.check(
                     "trace_count_header",
-                    headers=dict(request.headers),
+                    headers=request.headers,
                     num_traces=len(traces),
                 )
 

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
-from typing import Dict
 
 from aiohttp.web import Request
+from multidict import CIMultiDictProxy
 
 from .checks import Check
 
@@ -19,7 +19,7 @@ header must match the number of traces included in the payload.
 """.strip()
     default_enabled = True
 
-    def check(self, headers: Dict[str, str], num_traces: int) -> None:
+    def check(self, headers: CIMultiDictProxy, num_traces: int) -> None:
         if "X-Datadog-Trace-Count" not in headers:
             self.fail("X-Datadog-Trace-Count header not found in headers")
             return
@@ -40,7 +40,7 @@ class CheckMetaTracerVersionHeader(Check):
     description = """v0.4 payloads must include the Datadog-Meta-Tracer-Version header."""
     default_enabled = True
 
-    def check(self, headers: Dict[str, str]) -> None:
+    def check(self, headers: CIMultiDictProxy) -> None:
         if "Datadog-Meta-Tracer-Version" not in headers:
             self.fail("Datadog-Meta-Tracer-Version not found in headers")
 
@@ -52,7 +52,7 @@ The max content size of a trace payload is 50MB.
 """.strip()
     default_enabled = True
 
-    def check(self, headers: Dict[str, str]) -> None:
+    def check(self, headers: CIMultiDictProxy) -> None:
         if "Content-Length" not in headers:
             self.fail(f"content length header 'Content-Length' not in http headers {headers}")
             return
@@ -74,7 +74,7 @@ affected.
 """.strip()
     default_enabled = True
 
-    async def check(self, headers: Dict[str, str], request: Request) -> None:
+    async def check(self, headers: CIMultiDictProxy, request: Request) -> None:
         if "X-Datadog-Test-Stall-Seconds" in headers:
             duration = float(headers["X-Datadog-Test-Stall-Seconds"])
         else:

--- a/releasenotes/notes/check-http-header-sensitivity-daaa9d9595ae86d6.yaml
+++ b/releasenotes/notes/check-http-header-sensitivity-daaa9d9595ae86d6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix case sensitive headers for trace checks.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -19,6 +19,22 @@ async def test_reference(
     assert resp.status == 200, await resp.text()
 
 
+async def test_reference_case_insensitive(
+    agent,
+    v04_reference_http_trace_payload_data,
+):
+    resp = await agent.put(
+        "/v0.4/traces",
+        headers={
+            "content-type": "application/msgpack",
+            "x-datadog-trace-count": "1",
+            "datadog-meta-tracer-version": "v0.1",
+        },
+        data=v04_reference_http_trace_payload_data,
+    )
+    assert resp.status == 200, await resp.text()
+
+
 @pytest.mark.parametrize("agent_disabled_checks", [[], ["trace_count_header"]])
 async def test_trace_count_header(
     agent,


### PR DESCRIPTION
The headers were pointlessly being cast to a normal dictionary from a case insensitive multi dict implementation.

Fixes #112