### PR TITLE
fix(ci): build wheels step image

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_wheel:
     name: Build wheels
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Update deprecate CI image

CI [Build wheels](https://github.com/DataDog/dd-apm-test-agent/actions/runs/4729624217/jobs/8392342342?pr=76#logs) step tries to use `ubuntu-18.04` image but It's deprecated and the job stucks:
```
Requested labels: ubuntu-18.04
Job defined at: DataDog/dd-apm-test-agent/.github/workflows/publish_pypi.yml@refs/pull/76/merge
Waiting for a runner to pick up this job...
Job is cancelled before starting.
```