### PR TITLE
add request forwarding for telemetry

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -658,7 +658,9 @@ class Agent:
             request["_dd_trace_env_variables"] = env_vars
 
         if "X-Datadog-Agent-Proxy-Disabled" in headers:
-            request["_proxy_to_agent"] = headers.pop("X-Datadog-Agent-Proxy-Disabled").lower() != "true"
+            request["_proxy_to_agent"] = (
+                headers.pop("X-Datadog-Agent-Proxy-Disabled").lower() != "true" and request.app["agent_url"] != ""
+            )
 
         if "X-Datadog-Proxy-Port" in headers:
             port = headers.pop("X-Datadog-Proxy-Port")
@@ -666,7 +668,7 @@ class Agent:
             log.info("Found port in headers, new trace agent URL is: {}".format(request.app["agent_url"]))
 
         request["_headers"] = headers
-        # Call the original handlerx
+        # Call the original handler
         return await handler(request)
 
     @middleware  # type: ignore

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -177,7 +177,6 @@ class Agent:
         # Token to be used if running test cases synchronously
         self._requests: List[Request] = []
         self._rc_server = RemoteConfigServer()
-        self._trace_failures: List[str] = []
         self._forward_endpoints: List[str] = [
             "/v0.4/traces",
             "/v0.5/traces",

--- a/releasenotes/notes/add-request-forwarding-middleware-d3f325166b0f8e9e.yaml
+++ b/releasenotes/notes/add-request-forwarding-middleware-d3f325166b0f8e9e.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds middleware to forward all received requests to the Agent URL, if set. Requests are 
+    only forwarded for the `/traces`, `/stats`, and `/telemetry` paths. 


### PR DESCRIPTION
This PR adds two middlewares to the Test-Agent. The first middleware stores the request data and headers in Test-Agent memory. The second middleware forwards requests to an optional end destination (such as a real DD Agent) for any requests from the `/traces`, `/stats`, or `/telemetry` endpoints.