### PR TITLE
Add `SNAPSHOT_REMOVED_ATTRS` to remove attributes from spans in snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Please refer to `ddapm-test-agent-fmt --help` for more information.
 - `DD_SUPPRESS_TRACE_PARSE_ERRORS` [`false`]: Set to `"True"` to disable span parse errors when decoding handled traces. When disabled, errors will not be thrown for
 metrics incorrectly placed within the meta field, or other type errors related to span tag formatting/types. Can also be set using the `--suppress-trace-parse-errors=True` option.
 
-- `SNAPSHOT_REMOVED_ATTRS` []: The attributes to remove from spans in snapshots. This is useful for removing attributes 
+- `SNAPSHOT_REMOVED_ATTRS` [`""`]: The attributes to remove from spans in snapshots. This is useful for removing attributes 
 that are not relevant to the test case. **Note that you shouldn't remove both `start` and `span_id` to allow span 
 ordering to be completed.**
 

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ Please refer to `ddapm-test-agent-fmt --help` for more information.
 metrics incorrectly placed within the meta field, or other type errors related to span tag formatting/types. Can also be set using the `--suppress-trace-parse-errors=True` option.
 
 - `SNAPSHOT_REMOVED_ATTRS` [`""`]: The attributes to remove from spans in snapshots. This is useful for removing attributes 
-that are not relevant to the test case. **Note that you shouldn't remove both `start` and `span_id` to allow span 
-ordering to be completed.**
+that are not relevant to the test case. **Note that removing `span_id` is not permitted to allow span 
+ordering to be maintained.**
 
 
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ Please refer to `ddapm-test-agent-fmt --help` for more information.
 - `DD_SUPPRESS_TRACE_PARSE_ERRORS` [`false`]: Set to `"True"` to disable span parse errors when decoding handled traces. When disabled, errors will not be thrown for
 metrics incorrectly placed within the meta field, or other type errors related to span tag formatting/types. Can also be set using the `--suppress-trace-parse-errors=True` option.
 
+- `SNAPSHOT_REMOVED_ATTRS` []: The attributes to remove from spans in snapshots. This is useful for removing attributes 
+that are not relevant to the test case. **Note that you shouldn't remove both `start` and `span_id` to allow span 
+ordering to be completed.**
+
 
 
 ## API
@@ -248,6 +252,12 @@ Warning: it is an error to specify both `file` and `dir`.
 Note: the file extension will be appended to the filename.
 
 `_tracestats` will be appended to the filename for trace stats requests.
+
+#### [optional] `?removes=`
+
+Comma-separated list of keys that will be removed from spans in the snapshot.
+
+The default built-in remove list does not remove any keys.
 
 
 ### /test/session/requests

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -475,8 +475,8 @@ class Agent:
         span_removes = list(default_span_removes | overrides)
         log.info("using removes %r", span_removes)
 
-        if "start" in span_removes and "span_id" in span_removes:
-            raise ValueError("Cannot remove both 'start' and 'span_id' from spans")
+        if "span_id" in span_removes:
+            raise AssertionError("Cannot remove 'span_id' from spans")
 
         with CheckTrace.add_frame(f"snapshot (token='{token}')") as frame:
             frame.add_item(f"Directory: {snap_dir}")

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -475,6 +475,10 @@ class Agent:
         span_removes = list(default_span_removes | overrides)
         log.info("using removes %r", span_removes)
 
+        # if both "start" and "span_id" are in span_removes, raise an error
+        if "start" in span_removes and "span_id" in span_removes:
+            raise ValueError("Cannot remove both 'start' and 'span_id' from spans")
+
         with CheckTrace.add_frame(f"snapshot (token='{token}')") as frame:
             frame.add_item(f"Directory: {snap_dir}")
             frame.add_item(f"CI mode: {snap_ci_mode}")

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -475,7 +475,6 @@ class Agent:
         span_removes = list(default_span_removes | overrides)
         log.info("using removes %r", span_removes)
 
-        # if both "start" and "span_id" are in span_removes, raise an error
         if "start" in span_removes and "span_id" in span_removes:
             raise ValueError("Cannot remove both 'start' and 'span_id' from spans")
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -469,6 +469,12 @@ class Agent:
         span_ignores = list(default_span_ignores | overrides)
         log.info("using ignores %r", span_ignores)
 
+        # Get the span attributes that are to be removed for this snapshot.
+        default_span_removes: Set[str] = request.app["snapshot_removed_attrs"]
+        overrides = set(_parse_csv(request.url.query.get("removes", "")))
+        span_removes = list(default_span_removes | overrides)
+        log.info("using removes %r", span_removes)
+
         with CheckTrace.add_frame(f"snapshot (token='{token}')") as frame:
             frame.add_item(f"Directory: {snap_dir}")
             frame.add_item(f"CI mode: {snap_ci_mode}")
@@ -513,7 +519,7 @@ class Agent:
             elif received_traces:
                 # Create a new snapshot for the data received
                 with open(trace_snap_file, mode="w") as f:
-                    f.write(trace_snapshot.generate_snapshot(received_traces))
+                    f.write(trace_snapshot.generate_snapshot(received_traces=received_traces, removed=span_removes))
                 log.info("wrote new trace snapshot to %r", os.path.abspath(trace_snap_file))
 
             # Get all stats buckets from the payloads since we don't care about the other fields (hostname, env, etc)
@@ -662,6 +668,7 @@ def make_app(
     agent_url: str,
     trace_request_delay: float,
     suppress_trace_parse_errors: bool,
+    snapshot_removed_attrs: List[str],
 ) -> web.Application:
     agent = Agent()
     app = web.Application(
@@ -716,6 +723,7 @@ def make_app(
     app["agent_url"] = agent_url
     app["trace_request_delay"] = trace_request_delay
     app["suppress_trace_parse_errors"] = suppress_trace_parse_errors
+    app["snapshot_removed_attrs"] = snapshot_removed_attrs
     return app
 
 
@@ -753,6 +761,16 @@ def main(args: Optional[List[str]] = None) -> None:
         help=(
             "Comma-separated values of span attributes to ignore. "
             "meta/metrics attributes can be ignored by prefixing the key "
+            "with meta. or metrics."
+        ),
+    )
+    parser.add_argument(
+        "--snapshot-removed-attrs",
+        type=Set[str],
+        default=set(_parse_csv(os.environ.get("SNAPSHOT_REMOVED_ATTRS", ""))),
+        help=(
+            "Comma-separated values of span attributes to remove. "
+            "meta/metrics attributes can be removed by prefixing the key "
             "with meta. or metrics."
         ),
     )
@@ -837,6 +855,7 @@ def main(args: Optional[List[str]] = None) -> None:
         agent_url=parsed_args.agent_url,
         trace_request_delay=parsed_args.trace_request_delay,
         suppress_trace_parse_errors=parsed_args.suppress_trace_parse_errors,
+        snapshot_removed_attrs=parsed_args.snapshot_removed_attrs,
     )
 
     web.run_app(app, sock=apm_sock, port=parsed_args.port)

--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -150,9 +150,9 @@ def child_map(trace: Trace) -> Dict[int, List[Span]]:
         parent_id = s.get("parent_id") or 0
         cmap[parent_id].append(s)
 
-    # Sort the children ascending by their start time
+    # Sort the children ascending by their start time, else by their span_id
     for span_id in cmap:
-        cmap[span_id] = sorted(cmap[span_id], key=lambda _: _["start"])
+        cmap[span_id] = sorted(cmap[span_id], key=lambda _: (_["start"] if "start" in _ else _["span_id"]))
     return cmap
 
 

--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -304,7 +304,7 @@ def _ordered_span(s: Span) -> OrderedDictType[str, TopLevelSpanValue]:
     return d  # type: ignore
 
 
-def _snapshot_trace_str(trace: Trace, removed: List[str] = None) -> str:
+def _snapshot_trace_str(trace: Trace, removed: List[str] = []) -> str:
     cmap = child_map(trace)
     stack: List[Tuple[int, Span]] = [(0, root_span(trace))]
     s = "[\n"
@@ -312,9 +312,8 @@ def _snapshot_trace_str(trace: Trace, removed: List[str] = None) -> str:
         prefix, span = stack.pop(0)
 
         # Remove any keys that are not needed for comparison
-        if removed:
-            for key in removed:
-                span.pop(key, None)
+        for key in removed:
+            span.pop(key, None) # type: ignore
 
         for i, child in enumerate(reversed(cmap[span["span_id"]])):
             if i == 0:
@@ -329,7 +328,7 @@ def _snapshot_trace_str(trace: Trace, removed: List[str] = None) -> str:
     return s
 
 
-def _snapshot_json(traces: List[Trace], removed: List[str] = None) -> str:
+def _snapshot_json(traces: List[Trace], removed: List[str] = []) -> str:
     s = "["
     for t in traces:
         s += _snapshot_trace_str(t, removed)
@@ -339,5 +338,5 @@ def _snapshot_json(traces: List[Trace], removed: List[str] = None) -> str:
     return s
 
 
-def generate_snapshot(received_traces: List[Trace], removed: List[str] = None) -> str:
+def generate_snapshot(received_traces: List[Trace], removed: List[str] = []) -> str:
     return _snapshot_json(_normalize_traces(received_traces), removed)

--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -313,7 +313,7 @@ def _snapshot_trace_str(trace: Trace, removed: List[str] = []) -> str:
 
         # Remove any keys that are not needed for comparison
         for key in removed:
-            span.pop(key, None) # type: ignore
+            span.pop(key, None)  # type: ignore
 
         for i, child in enumerate(reversed(cmap[span["span_id"]])):
             if i == 0:

--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -313,7 +313,12 @@ def _snapshot_trace_str(trace: Trace, removed: List[str] = []) -> str:
 
         # Remove any keys that are not needed for comparison
         for key in removed:
-            span.pop(key, None)  # type: ignore
+            if key.startswith("meta."):
+                span["meta"].pop(key[5:], None)
+            elif key.startswith("metrics."):
+                span["metrics"].pop(key[8:], None)
+            else:
+                span.pop(key, None)
 
         for i, child in enumerate(reversed(cmap[span["span_id"]])):
             if i == 0:

--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -318,7 +318,7 @@ def _snapshot_trace_str(trace: Trace, removed: List[str] = []) -> str:
             elif key.startswith("metrics."):
                 span["metrics"].pop(key[8:], None)
             else:
-                span.pop(key, None)
+                span.pop(key, None)  # type: ignore
 
         for i, child in enumerate(reversed(cmap[span["span_id"]])):
             if i == 0:

--- a/releasenotes/notes/allow-attribute-removal-snapshots-314b744b043b97c5.yaml
+++ b/releasenotes/notes/allow-attribute-removal-snapshots-314b744b043b97c5.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    This change adds a new feature that allows desired attributes to be removed from spans in snapshots. By default, no
+    attributes will be removed. The attributes to be removed can be set through the optional environment variable
+    `SNAPSHOT_REMOVED_ATTRS`, or with the optional query parameter `?removes`. Both `start` and `span_id` shouldn't be
+    removed together.

--- a/releasenotes/notes/allow-attribute-removal-snapshots-314b744b043b97c5.yaml
+++ b/releasenotes/notes/allow-attribute-removal-snapshots-314b744b043b97c5.yaml
@@ -3,5 +3,4 @@ features:
   - |
     This change adds a new feature that allows desired attributes to be removed from spans in snapshots. By default, no
     attributes will be removed. The attributes to be removed can be set through the optional environment variable
-    `SNAPSHOT_REMOVED_ATTRS`, or with the optional query parameter `?removes`. Both `start` and `span_id` shouldn't be
-    removed together.
+    `SNAPSHOT_REMOVED_ATTRS`, or with the optional query parameter `?removes`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,11 @@ def suppress_trace_parse_errors() -> Generator[bool, None, None]:
 
 
 @pytest.fixture
+def snapshot_removed_attrs() -> Generator[Set[str], None, None]:
+    yield set()
+
+
+@pytest.fixture
 async def agent_app(
     aiohttp_server,
     agent_disabled_checks,
@@ -78,6 +83,7 @@ async def agent_app(
     agent_url,
     trace_request_delay,
     suppress_trace_parse_errors,
+    snapshot_removed_attrs,
 ):
     app = await aiohttp_server(
         make_app(
@@ -89,6 +95,7 @@ async def agent_app(
             agent_url,
             trace_request_delay,
             suppress_trace_parse_errors,
+            snapshot_removed_attrs,
         )
     )
     yield app

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -425,3 +426,28 @@ async def test_snapshot_tracestats(agent, tmp_path, snapshot_ci_mode, do_referen
 
         resp = await agent.get("/test/session/snapshot", params={"test_session_token": "test_case"})
         assert resp.status == 200, await resp.text()
+
+
+@pytest.mark.parametrize("snapshot_removed_attrs", [{"start", "duration"}])
+async def test_removed_attributes(agent, tmp_path, snapshot_removed_attrs, do_reference_v04_http_trace):
+    resp = await do_reference_v04_http_trace(token="test_case")
+    assert resp.status == 200
+
+    custom_dir = tmp_path / "custom"
+    custom_dir.mkdir()
+    custom_file_name = custom_dir / "custom_snapshot"
+    custom_file = custom_dir / "custom_snapshot.json"
+
+    resp = await agent.get(
+        "/test/session/snapshot", params={"test_session_token": "test_case", "file": str(custom_file_name)}
+    )
+    assert resp.status == 200, await resp.text()
+    resp_text = await resp.text()
+
+    assert os.path.exists(custom_file), custom_file
+    with open(custom_file, mode="r") as f:  # Check that the removed attributes are not present in all the spans
+        file_content = "".join(f.readlines())
+        assert file_content != ""
+        span = json.loads(file_content)
+        for removed_attr in snapshot_removed_attrs:
+            assert removed_attr not in span

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -442,7 +442,6 @@ async def test_removed_attributes(agent, tmp_path, snapshot_removed_attrs, do_re
         "/test/session/snapshot", params={"test_session_token": "test_case", "file": str(custom_file_name)}
     )
     assert resp.status == 200, await resp.text()
-    resp_text = await resp.text()
 
     assert os.path.exists(custom_file), custom_file
     with open(custom_file, mode="r") as f:  # Check that the removed attributes are not present in all the spans

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -616,3 +616,13 @@ async def test_snapshot_trace_differences_removed_start(agent, expected_traces, 
         assert error in resp_text, resp_text
     else:
         assert resp.status == 200, resp_text
+
+
+@pytest.mark.parametrize("snapshot_removed_attrs", [{"span_id"}])
+async def test_removed_attributes_fails_span_id(agent, tmp_path, snapshot_removed_attrs, do_reference_v04_http_trace):
+    resp = await do_reference_v04_http_trace(token="test_case")
+    assert resp.status == 200, await resp.text()
+
+    resp = await agent.get("/test/session/snapshot", params={"test_session_token": "test_case"})
+    assert resp.status == 400
+    assert "Cannot remove 'span_id' from spans" in await resp.text()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -449,7 +449,7 @@ async def test_removed_attributes(agent, tmp_path, snapshot_removed_attrs, do_re
         assert file_content != ""
         span = json.loads(file_content)
         for removed_attr in snapshot_removed_attrs:
-            assert removed_attr not in span
+            assert removed_attr not in span[0]
 
 
 @pytest.mark.parametrize("snapshot_removed_attrs", [{"metrics.process_id"}])
@@ -472,4 +472,4 @@ async def test_removed_attributes_metrics(agent, tmp_path, snapshot_removed_attr
         file_content = "".join(f.readlines())
         assert file_content != ""
         span = json.loads(file_content)
-        assert "process_id" not in span["metrics"]
+        assert "process_id" not in span[0]

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -444,12 +444,13 @@ async def test_removed_attributes(agent, tmp_path, snapshot_removed_attrs, do_re
     assert resp.status == 200, await resp.text()
 
     assert os.path.exists(custom_file), custom_file
-    with open(custom_file, mode="r") as f:  # Check that the removed attributes are not present in all the spans
+    with open(custom_file, mode="r") as f:  # Check that the removed attributes are not present in the span
         file_content = "".join(f.readlines())
         assert file_content != ""
         span = json.loads(file_content)
         for removed_attr in snapshot_removed_attrs:
             assert removed_attr not in span
+
 
 @pytest.mark.parametrize("snapshot_removed_attrs", [{"metrics.process_id"}])
 async def test_removed_attributes_metrics(agent, tmp_path, snapshot_removed_attrs, do_reference_v04_http_trace):
@@ -467,9 +468,8 @@ async def test_removed_attributes_metrics(agent, tmp_path, snapshot_removed_attr
     assert resp.status == 200, await resp.text()
 
     assert os.path.exists(custom_file), custom_file
-    with open(custom_file, mode="r") as f:  # Check that the removed attributes are not present in all the spans
+    with open(custom_file, mode="r") as f:
         file_content = "".join(f.readlines())
         assert file_content != ""
         span = json.loads(file_content)
-        assert "metrics" in span
         assert "process_id" not in span["metrics"]

--- a/tests/trace_utils.py
+++ b/tests/trace_utils.py
@@ -1,6 +1,7 @@
 from random import Random
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 
 from ddapm_test_agent.trace import Span
@@ -118,6 +119,7 @@ def random_trace(
     rng: Random = _random,
     trace_id: Optional[int] = None,
     parent_id: Optional[int] = None,
+    remove_keys: Optional[List[str]] = None,
 ) -> Trace:
     # TODO:
     #   represent arbitrary random services (subtrees in spans)
@@ -137,6 +139,10 @@ def random_trace(
             del s["type"]
             del s["resource"]
         s["trace_id"] = trace_id
+        if remove_keys:
+            for k in remove_keys:
+                del s[k]  # type: ignore
+
     return t
 
 


### PR DESCRIPTION
Add a new _optional_ configuration to allow fields to be removed from the spans. By default, no keys will be removed from the snapshots.

💭 The motivation behind this feature is to get rid of some fields that can be noisy in the snapshots (e.g., `start` or `duration`) which could create some massive diffs when regenerating the snapshots.

Note that since the removal of the field `start` would cause an error when sorting the spans by this field, `span_id` was used as a fallback. Feel free to tell me if this would cause an issue I didn't consider (this is the reason why both `start` and `span_id` shouldn't be removed from the snapshots).
