### PR TITLE
Add pipeline stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ The keys of the JSON body are `path` and `msg`
 curl -X POST 'http://0.0.0.0:8126/test/session/responses/config/path' -d '{"path": "datadog/2/ASM_DATA/blocked_users/config", "msg": {"rules_data": []}}'
 ```
 
+### /v0.1/pipeline_stats
+
+Mimics the pipeline_stats endpoint of the agent, but always returns OK, and logs a line everytime it's called.
+
 ## Development
 
 ### Prerequisites

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -183,6 +183,7 @@ class Agent:
             "/v0.6/stats",
             "/v0.7/config",
             "/telemetry/proxy/api/v2/apmtelemetry",
+            "/v0.1/pipeline_stats",
         ]
 
     async def traces(self) -> TraceMap:
@@ -333,6 +334,10 @@ class Agent:
             nstats,
             "s" if nstats else "",
         )
+        return web.HTTPOk()
+
+    async def handle_v01_pipelinestats(self, request: Request) -> web.Response:
+        log.info("received /v0.1/pipeline_stats payload")
         return web.HTTPOk()
 
     async def handle_v07_remoteconfig(self, request: Request) -> web.Response:
@@ -565,6 +570,7 @@ class Agent:
                 self.handle_v04_traces,
                 self.handle_v05_traces,
                 self.handle_v06_tracestats,
+                self.handle_v01_pipelinestats,
                 self.handle_v2_apmtelemetry,
                 self.handle_v1_profiling,
             ):
@@ -739,6 +745,7 @@ def make_app(
             web.post("/v0.5/traces", agent.handle_v05_traces),
             web.put("/v0.5/traces", agent.handle_v05_traces),
             web.post("/v0.6/stats", agent.handle_v06_tracestats),
+            web.post("/v0.1/pipeline_stats", agent.handle_v01_pipelinestats),
             web.put("/v0.6/stats", agent.handle_v06_tracestats),
             web.post("/v0.7/config", agent.handle_v07_remoteconfig),
             web.post("/telemetry/proxy/api/v2/apmtelemetry", agent.handle_v2_apmtelemetry),

--- a/releasenotes/notes/pipeline_stats_endpoint-e8ad6da735dc2647.yaml
+++ b/releasenotes/notes/pipeline_stats_endpoint-e8ad6da735dc2647.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add new pipeline stats endpoint for data streams monitoring.


### PR DESCRIPTION
Add pipeline stats endpoint to the test agent.
For now, I'm not storing anything, the goal here is just to avoid errors when trying to submit payloads to the test agent.