### PR TITLE
Add flag for enabling non-default checks

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -743,6 +743,7 @@ class Agent:
 
 def make_app(
     disabled_checks: List[str],
+    additional_checks: List[str],
     log_span_fmt: str,
     snapshot_dir: str,
     snapshot_ci_mode: bool,
@@ -802,6 +803,7 @@ def make_app(
             CheckTraceStallAsync,
         ],
         disabled=disabled_checks,
+        additional=additional_checks,
     )
     app["checks"] = checks
     app["snapshot_dir"] = snapshot_dir
@@ -870,6 +872,16 @@ def main(args: Optional[List[str]] = None) -> None:
         default=_parse_csv(os.environ.get("DISABLED_CHECKS", "")),
         help=(
             "Comma-separated values of checks to disable. None are disabled "
+            " by default. For the list of values see "
+            "https://github.com/datadog/dd-trace-test-agent"
+        ),
+    )
+    parser.add_argument(
+        "--additional-checks",
+        type=List[str],
+        default=_parse_csv(os.environ.get("ADDITIONAL_CHECKS", "")),
+        help=(
+            "Comma-separated values of non-default checks to add. None are added "
             " by default. For the list of values see "
             "https://github.com/datadog/dd-trace-test-agent"
         ),
@@ -950,6 +962,7 @@ def main(args: Optional[List[str]] = None) -> None:
         )
     app = make_app(
         disabled_checks=parsed_args.disabled_checks,
+        additional_checks=parsed_args.additional_checks,
         log_span_fmt=parsed_args.log_span_fmt,
         snapshot_dir=parsed_args.snapshot_dir,
         snapshot_ci_mode=parsed_args.snapshot_ci_mode,

--- a/ddapm_test_agent/checks.py
+++ b/ddapm_test_agent/checks.py
@@ -137,6 +137,7 @@ class Check:
 class Checks:
     checks: List[Type[Check]] = dataclasses.field(init=True)
     disabled: List[str] = dataclasses.field(init=True)
+    additional: List[str] = dataclasses.field(init=True)
 
     def _get_check(self, name: str) -> Type[Check]:
         for c in self.checks:
@@ -149,6 +150,8 @@ class Checks:
         check = self._get_check(name)
         if check.name in self.disabled:
             return False
+        if check.name in self.additional:
+            return True
         return check.default_enabled
 
     async def check(self, name: str, *args: Any, **kwargs: Any) -> None:

--- a/releasenotes/notes/additional-checks-3e25e1d310b1de4a.yaml
+++ b/releasenotes/notes/additional-checks-3e25e1d310b1de4a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds an argument that allows adding checks that are disabled by default.
+    env `ADDITIONAL_CHECKS` or cmd: `--additional-checks`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,11 @@ def agent_disabled_checks() -> Generator[List[str], None, None]:
 
 
 @pytest.fixture
+def agent_additional_checks() -> Generator[List[str], None, None]:
+    yield []
+
+
+@pytest.fixture
 def log_span_fmt() -> Generator[str, None, None]:
     yield "[{name}]"
 
@@ -86,6 +91,7 @@ def snapshot_removed_attrs() -> Generator[Set[str], None, None]:
 async def agent_app(
     aiohttp_server,
     agent_disabled_checks,
+    agent_additional_checks,
     log_span_fmt,
     snapshot_dir,
     snapshot_ci_mode,
@@ -100,6 +106,7 @@ async def agent_app(
     app = await aiohttp_server(
         make_app(
             agent_disabled_checks,
+            agent_additional_checks,
             log_span_fmt,
             str(snapshot_dir),
             snapshot_ci_mode,


### PR DESCRIPTION
Adds a config to allow some languages to use checks that are not enabled by default. Unblocks #127