### PR TITLE
Conti/emit tested integration versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,29 @@ summary = {
 
 ```
 curl -X GET 'http://0.0.0.0:8126/test/trace_check/summary'
+```
+
+### /test/session/integrations (PUT)
+Update information about the current tested integration.
+
+#### [optional] `?test_session_token=`
+#### [optional] `X-Datadog-Test-Session-Token`
+
+```
+curl -X PUT 'http://0.0.0.0:8126/test/session/integrations' -d '{"integration_name": [INTEGRATION_NAME], "integration_version": [INTEGRATION_VERSION],
+"dependency_name": [DEPENDENCY_NAME], "tracer_language": [TRACER_LANGUAGE], "tracer_version": [TRACER_VERSION]}'
+```
+
+### /test/integrations/tested_versions (GET)
+Return a csv list of all tested integrations received by the agent. The format of returned data will be: 
+`tracer_language,tracer_version,integration_name,integration_version,dependency_name`.
+
+#### [optional] `?test_session_token=`
+#### [optional] `X-Datadog-Test-Session-Token`
+
+```
+curl -X GET 'http://0.0.0.0:8126/test/integrations/tested_versions'
+```
 
 ### /v0.1/pipeline_stats
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -387,9 +387,9 @@ class Agent:
 
     async def _integration_requests_by_session(
         self, token: Optional[str], include_sent_integrations: Optional[bool] = False
-    ) -> List[Dict]:
+    ) -> List[Request]:
         """Get all requests with an associated tested Integration."""
-        integration_requests: List[Tuple[Request, Dict]] = []
+        integration_requests: List[Request] = []
         for req in self._requests_by_session(token):
             # see if the request was to update with a newly tested integration
             if req.match_info.handler == self.handle_put_tested_integrations:

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -573,20 +573,21 @@ class Agent:
             )
 
     async def handle_get_tested_integrations(self, request: Request) -> web.Response:
-        headers = ["language_name", "tracer_version", "integration_name", "integration_version", "dependency_name"]
-        aggregated_text = ",".join(headers) + "\n"
-
+        file_headers = ["language_name", "tracer_version", "integration_name", "integration_version", "dependency_name"]
+        aggregated_text = ""
+        headers = {}
         directory = "./artifacts"
         files = os.listdir(directory)
-
-        for file in files:
-            filepath = os.path.join(directory, file)
-            with open(filepath, "r") as f:
-                lines = f.readlines()
-                if lines[0] == ",".join(headers) + "\n":
-                    lines = lines[1:]  # Skip the headers if they already exist in the file
-                aggregated_text += "".join(lines)
-            headers = {"file-name": file.split("@")[0]}  # use integration name before @ as filename
+        if len(files) > 0:
+            aggregated_text += ",".join(file_headers) + "\n"
+            for file in files:
+                filepath = os.path.join(directory, file)
+                with open(filepath, "r") as f:
+                    lines = f.readlines()
+                    if lines[0] == ",".join(file_headers) + "\n":
+                        lines = lines[1:]  # Skip the headers if they already exist in the file
+                    aggregated_text += "".join(lines)
+                headers["file-name"]= file.split("@")[0]  # use integration name before @ as filename
         return web.Response(body=aggregated_text, content_type="text/plain", headers=headers)
 
     async def handle_info(self, request: Request) -> web.Response:

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -140,8 +140,6 @@ async def _prepare_and_send_request(data, request, headers):
     agent_url = request.app["agent_url"]
     full_agent_url = agent_url + request.path
     log.info("Forwarding request to agent at %r", full_agent_url)
-    if "DD_API_KEY" not in headers:
-        headers["DD_API_KEY"] = "00000000000000000000000000000000"
     log.debug(f"Using headers: {headers}")
     return await _forward_request(data, headers, full_agent_url)
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -522,7 +522,7 @@ class Agent:
         req_headers = {}
 
         # get all requests associated with an integration
-        reqs = await self._integration_requests_by_session(token=None, include_sent_integrations=True)
+        reqs = await self._integration_requests_by_session(token=_session_token(request), include_sent_integrations=True)
         for req in reqs:
             integration = req["integration"]
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -79,7 +79,7 @@ def _parse_csv(s: str) -> List[str]:
 
 
 def get_semver_version(version: str) -> bool:
-    """Attempts to parse the inputted version and returns the parsed semver version."""
+    """Parse the inputted version and returns the parsed semver version."""
     try:
         v = semver.Version.parse(version)
         return v
@@ -88,7 +88,7 @@ def get_semver_version(version: str) -> bool:
 
 
 def is_release_version(version: semver.Version) -> bool:
-    """Returns whether the semver version is a valid release version and does not contain
+    """Return whether the semver version is a valid release version and does not contain
     dev or pre-release tags.
     """
     return not version.prerelease and not version.build
@@ -495,7 +495,7 @@ class Agent:
         return web.HTTPAccepted()
 
     async def handle_v2_apmtelemetry(self, request: Request) -> web.Response:
-        telemetry_data = v2_apmtelemetry_decode(self._request_data(request))
+        v2_apmtelemetry_decode(self._request_data(request))
         # TODO: Validation
         # TODO: Snapshots
         return web.HTTPOk()

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -412,11 +412,11 @@ class Agent:
         for req in self._requests_by_session(token):
             if "version_sent" not in req:
                 if req.match_info.handler == self.handle_put_tested_integrations:
-                    data = await req.read()
+                    data = json.loads(await req.read())
                     integration_name = data.get("integration_name", None)
                     integration_version = data.get("integration_version", None)
                     if f"{integration_name}:{integration_version}" not in self._sent_integrations:
-                        integration_requests.append({"request": req, "data": json.loads()})
+                        integration_requests.append({"request": req, "data": data})
                 # check if integration data was provided in the trace request instead
                 elif (
                     "_dd_trace_env_variables" in req
@@ -571,8 +571,8 @@ class Agent:
             }
         }
         # emit request to APM Telemetry API
-        print(payload)
-
+        log.debug("payload")
+        log.debug(payload)
         # add hash of integration name and version so that later similar requests are not emitted
         self._sent_integrations.add(f"{integration_name}:{integration_version}")
         pass

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -529,7 +529,9 @@ class Agent:
         tracer_version = tracer_version if tracer_version else self._tracer_version
         tracer_language = tracer_language if tracer_language else self._tracer_language
         if (
-            integration_name and integration_version and enabled
+            integration_name
+            and integration_version
+            and enabled
             and f"{integration_name}:{integration_version}" not in self._sent_integration_versions
         ):
             await self.emit_instrumentation_telemetry_to_analytics_api(

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -522,7 +522,9 @@ class Agent:
         req_headers = {}
 
         # get all requests associated with an integration
-        reqs = await self._integration_requests_by_session(token=_session_token(request), include_sent_integrations=True)
+        reqs = await self._integration_requests_by_session(
+            token=_session_token(request), include_sent_integrations=True
+        )
         for req in reqs:
             integration = req["integration"]
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -1018,7 +1018,6 @@ def make_app(
             web.post("/v0.1/pipeline_stats", agent.handle_v01_pipelinestats),
             web.put("/v0.6/stats", agent.handle_v06_tracestats),
             web.post("/v0.7/config", agent.handle_v07_remoteconfig),
-            web.post("/telemetry/proxy/api/v1/apmtelemetry", agent.handle_v2_apmtelemetry),
             web.post("/telemetry/proxy/api/v2/apmtelemetry", agent.handle_v2_apmtelemetry),
             web.post("/profiling/v1/input", agent.handle_v1_profiling),
             web.get("/info", agent.handle_info),

--- a/ddapm_test_agent/integration.py
+++ b/ddapm_test_agent/integration.py
@@ -1,0 +1,6 @@
+class Integration():
+    def __init__(self, integration_name: str, integration_version: str, dependency_name: str, version_sent: bool):
+        self.integration_name = integration_name
+        self.integration_version = integration_version
+        self.dependency_name = dependency_name
+        self.version_sent = version_sent

--- a/ddapm_test_agent/integration.py
+++ b/ddapm_test_agent/integration.py
@@ -1,4 +1,4 @@
-class Integration():
+class Integration:
     def __init__(self, integration_name: str, integration_version: str, dependency_name: str, version_sent: bool):
         self.integration_name = integration_name
         self.integration_version = integration_version

--- a/ddapm_test_agent/integration.py
+++ b/ddapm_test_agent/integration.py
@@ -1,6 +1,5 @@
 class Integration:
-    def __init__(self, integration_name: str, integration_version: str, dependency_name: str, version_sent: bool):
+    def __init__(self, integration_name: str, integration_version: str, dependency_name: str):
         self.integration_name = integration_name
         self.integration_version = integration_version
         self.dependency_name = dependency_name
-        self.version_sent = version_sent

--- a/ddapm_test_agent/remoteconfig.py
+++ b/ddapm_test_agent/remoteconfig.py
@@ -90,5 +90,5 @@ class RemoteConfigServer:
     def create_config_response(self, token: str, data: Dict[str, Any]) -> None:
         self._create_response(token, data)
 
-    async def get_config_response(self, token: str) -> Dict[str, Any]:
+    async def get_config_response(self, token: str) -> Any:
         return await self._get_response(token)

--- a/ddapm_test_agent/remoteconfig.py
+++ b/ddapm_test_agent/remoteconfig.py
@@ -18,7 +18,7 @@ class RemoteConfigServer:
     def _create_response(self, token: str, data: Dict[str, Any]) -> None:
         self._responses[token] = data
 
-    async def _get_response(self, token: str) -> Dict[str, Any]:
+    async def _get_response(self, token: str) -> Any:
         return self._responses.get(token, {})
 
     def update_config_response(self, token: str, data: Dict[str, Any]) -> None:

--- a/ddapm_test_agent/trace_checks.py
+++ b/ddapm_test_agent/trace_checks.py
@@ -183,7 +183,7 @@ The ``service`` name is correctly set to ``DD_SERVICE`` for V1 auto-instrumented
             if component != "":
                 dd_service = dd_config_env.get(f"DD_{component.upper()}_SERVICE", None)
                 if not dd_service:
-                    log.error("DD_SERVICE not set for component: %s. Args %s", component, dd_config_env)
+                    log.debug("DD_SERVICE not set for component: %s. Args %s", component, dd_config_env)
                 dd_service = dd_service or dd_config_env.get("DD_SERVICE", None)
                 if dd_service is None:
                     self.fail(

--- a/releasenotes/notes/support-tracking-of-tested-integrations-ac19ccd1f8333c00.yaml
+++ b/releasenotes/notes/support-tracking-of-tested-integrations-ac19ccd1f8333c00.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add support for tracking the integrations being tested. Tracked integrations can be recorded by a [PUT] request to the Test Agent
+    at `/test/session/integrations`. To get data about which integrations the Test Agent encountered, make a [GET] request to `/test/integrations/tested_versions`.
+    Tested integrations include information such as the integration name, the tested integration version, the tracer language, the tracer version and the 
+    dependency name of the integration.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "ddsketch",
         "msgpack",
         "requests",
-        "semver",
         "typing_extensions",
         "yarl",
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "ddsketch",
         "msgpack",
         "requests",
+        "semver",
         "typing_extensions",
         "yarl",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,7 @@ def v04_reference_http_trace_payload_headers() -> Dict[str, str]:
         "X-Datadog-Trace-Count": "1",
         "Datadog-Meta-Tracer-Version": "v0.1",
         "datadog-meta-lang": "python",
-        "X-Datadog-Trace-Env-Variables": "DD_INTEGRATION=express,DD_INTEGRATION_VERSION=1.2.3"
+        "X-Datadog-Trace-Env-Variables": "DD_INTEGRATION=express,DD_INTEGRATION_VERSION=1.2.3",
     }
     return headers
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,8 @@ def v04_reference_http_trace_payload_headers() -> Dict[str, str]:
         "Content-Type": "application/msgpack",
         "X-Datadog-Trace-Count": "1",
         "Datadog-Meta-Tracer-Version": "v0.1",
+        "datadog-meta-lang": "python",
+        "X-Datadog-Trace-Env-Variables": "DD_INTEGRATION=express,DD_INTEGRATION_VERSION=1.2.3"
     }
     return headers
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -298,9 +298,7 @@ async def test_get_trace_failures_and_clear_json(
 
 
 async def test_integrations_from_trace(
-    agent,
-    v04_reference_http_trace_payload_headers,
-    v04_reference_http_trace_payload_data
+    agent, v04_reference_http_trace_payload_headers, v04_reference_http_trace_payload_data
 ):
     resp = await agent.put(
         "/v0.4/traces",
@@ -314,7 +312,10 @@ async def test_integrations_from_trace(
 
     text = await resp.text()
 
-    assert text == "language_name,tracer_version,integration_name,integration_version,dependency_name\npython,v0.1,express,1.2.3,express\n"
+    assert (
+        text
+        == "language_name,tracer_version,integration_name,integration_version,dependency_name\npython,v0.1,express,1.2.3,express\n"
+    )
 
 
 async def test_put_integrations(
@@ -322,13 +323,15 @@ async def test_put_integrations(
 ):
     resp = await agent.put(
         "/test/session/integrations",
-        data=json.dumps({
-            "integration_name": "flask",
-            "integration_version": "1.1.1",
-            "dependency_name": "not_flask",
-            "tracer_version": "v1",
-            "tracer_language": "python"
-        }),
+        data=json.dumps(
+            {
+                "integration_name": "flask",
+                "integration_version": "1.1.1",
+                "dependency_name": "not_flask",
+                "tracer_version": "v1",
+                "tracer_language": "python",
+            }
+        ),
     )
     assert resp.status == 200, await resp.text()
 
@@ -337,4 +340,7 @@ async def test_put_integrations(
 
     text = await resp.text()
 
-    assert text == "language_name,tracer_version,integration_name,integration_version,dependency_name\npython,v1,flask,1.1.1,not_flask\n"
+    assert (
+        text
+        == "language_name,tracer_version,integration_name,integration_version,dependency_name\npython,v1,flask,1.1.1,not_flask\n"
+    )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -295,3 +295,46 @@ async def test_get_trace_failures_and_clear_json(
     response = await agent.get("/test/trace_check/summary?return_all=true&use_json=true")
     assert response.status == 200
     assert await response.json() == {}
+
+
+async def test_integrations_from_trace(
+    agent,
+    v04_reference_http_trace_payload_headers,
+    v04_reference_http_trace_payload_data
+):
+    resp = await agent.put(
+        "/v0.4/traces",
+        headers=v04_reference_http_trace_payload_headers,
+        data=v04_reference_http_trace_payload_data,
+    )
+    assert resp.status == 200, await resp.text()
+
+    resp = await agent.get("/test/integrations/tested_versions")
+    assert resp.status == 200
+
+    text = await resp.text()
+
+    assert text == "language_name,tracer_version,integration_name,integration_version,dependency_name\npython,v0.1,express,1.2.3,express\n"
+
+
+async def test_put_integrations(
+    agent,
+):
+    resp = await agent.put(
+        "/test/session/integrations",
+        data=json.dumps({
+            "integration_name": "flask",
+            "integration_version": "1.1.1",
+            "dependency_name": "not_flask",
+            "tracer_version": "v1",
+            "tracer_language": "python"
+        }),
+    )
+    assert resp.status == 200, await resp.text()
+
+    resp = await agent.get("/test/integrations/tested_versions")
+    assert resp.status == 200
+
+    text = await resp.text()
+
+    assert text == "language_name,tracer_version,integration_name,integration_version,dependency_name\npython,v1,flask,1.1.1,not_flask\n"


### PR DESCRIPTION
Support receiving and emitting tested integrations and their versions. This data will be sent to Metabase to create dashboards for each tracer.