### PR TITLE
Add `/test/session/tracerflares` endpoint to return all tracer-flares...

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,31 @@ Mimics the tracer_flare endpoint of the agent. Returns OK if the flare contains 
 
 Logs a line everytime it's called and stores the tracer flare details in the request under `"_tracer_flare"`.
 
+### /test/session/tracerflares
+
+Return all tracer-flares that have been received by the agent for the given session token.
+
+#### [optional] `?test_session_token=`
+#### [optional] `X-Datadog-Test-Session-Token`
+
+Returns the tracer-flares in the following json format:
+
+```json
+[
+  {
+    "source": "...",
+    "case_id": "...",
+    "email": "...",
+    "hostname": "...",
+    "flare_file": "...",
+  }
+]
+```
+
+`flare_file` is the base64 encoded content of the tracer-flare payload.
+
+If there was an error parsing the tracer-flare form, that will be recorded under `error`.
+
 ## Development
 
 ### Prerequisites

--- a/ddapm_test_agent/tracerflare.py
+++ b/ddapm_test_agent/tracerflare.py
@@ -1,0 +1,27 @@
+from asyncio import StreamReader
+import base64
+from typing import Dict
+from typing import Mapping
+
+from aiohttp import MultipartReader
+
+
+TracerFlareEvent = Dict[str, str]
+
+
+async def v1_decode(headers: Mapping[str, str], data: bytes) -> TracerFlareEvent:
+    """Decode v1 tracer flare form as a dict"""
+    tracer_flare: TracerFlareEvent = {}
+    try:
+        stream = StreamReader()
+        stream.feed_data(data)
+        stream.feed_eof()
+        async for part in MultipartReader(headers, stream):
+            if part.name is not None:
+                if part.name == "flare_file":
+                    tracer_flare[part.name] = base64.b64encode(await part.read()).decode("ascii")
+                else:
+                    tracer_flare[part.name] = await part.text()
+    except Exception as err:
+        tracer_flare["error"] = str(err)
+    return tracer_flare

--- a/releasenotes/notes/session-tracerflares-400ce9b3d3838b40.yaml
+++ b/releasenotes/notes/session-tracerflares-400ce9b3d3838b40.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    Add ``/test/session/tracerflares`` endpoint to return all tracer-flares received
+    by the test agent for a given session token.

--- a/tests/test_tracerflare.py
+++ b/tests/test_tracerflare.py
@@ -2,6 +2,13 @@ from aiohttp import FormData
 
 
 async def test_tracerflare(agent):
+    expected_output = {
+        "source": "tracer_test",
+        "case_id": "12345",
+        "email": "its.me@datadoghq.com",
+        "hostname": "my.hostname",
+        "flare_file": "UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA==",
+    }
     form = FormData()
     form.add_field("source", "tracer_test")
     form.add_field("case_id", "12345")
@@ -15,9 +22,17 @@ async def test_tracerflare(agent):
     )
     resp = await agent.post("/tracer_flare/v1", data=form)
     assert resp.status == 200
+    flares = await agent.get("/test/session/tracerflares")
+    assert await flares.json() == [expected_output]
 
 
 async def test_tracerflare_missing_case_id(agent):
+    expected_output = {
+        "source": "tracer_test",
+        "email": "its.me@datadoghq.com",
+        "hostname": "my.hostname",
+        "flare_file": "UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA==",
+    }
     form = FormData()
     form.add_field("source", "tracer_test")
     form.add_field("email", "its.me@datadoghq.com")
@@ -30,13 +45,21 @@ async def test_tracerflare_missing_case_id(agent):
     )
     resp = await agent.post("/tracer_flare/v1", data=form)
     assert resp.status == 400
+    flares = await agent.get("/test/session/tracerflares")
+    assert await flares.json() == [expected_output]
 
 
-async def test_tracerflare_missing_file(agent):
-    form = FormData()
-    form.add_field("source", "tracer_test")
-    form.add_field("case_id", "12345")
-    form.add_field("email", "its.me@datadoghq.com")
-    form.add_field("hostname", "my.hostname")
+async def test_tracerflare_not_multipart(agent):
+    expected_output = {
+        "error": "multipart/* content type expected",
+    }
+    form = {
+        "source": "tracer_test",
+        "case_id": "12345",
+        "email": "its.me@datadoghq.com",
+        "hostname": "my.hostname",
+    }
     resp = await agent.post("/tracer_flare/v1", data=form)
     assert resp.status == 400
+    flares = await agent.get("/test/session/tracerflares")
+    assert await flares.json() == [expected_output]


### PR DESCRIPTION
... received by the test agent for a given session token.