### PR TITLE
chore: ignore DSM pathway hash within trace snapshot

### DIFF
--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -30,7 +30,7 @@ from .trace import trace_id as get_trace_id
 log = logging.getLogger(__name__)
 
 
-DEFAULT_SNAPSHOT_IGNORES = "span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,meta.runtime-id,span_links.trace_id_high"
+DEFAULT_SNAPSHOT_IGNORES = "span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,meta.runtime-id,span_links.trace_id_high,meta.pathway.hash"
 
 
 def _key_match(d1: Dict[str, Any], d2: Dict[str, Any], key: str) -> bool:

--- a/releasenotes/notes/ignore-dsm-pathway-hash-during-trace-snapshots-f0b99ea267fbad48.yaml
+++ b/releasenotes/notes/ignore-dsm-pathway-hash-during-trace-snapshots-f0b99ea267fbad48.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Adds dsm `pathway.hash` span tag to the ignored attributes for a trace snapshot.


### PR DESCRIPTION
Ignore `pathway.hash` to prevent trace snapshot failures