### PR TITLE
Ignore aiohttp warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,5 +37,7 @@ testpaths =
     ddapm_test_agent
     tests
 log_level = DEBUG
+filterwarnings =
+    ignore::aiohttp.web_exceptions.NotAppKeyWarning
 # log_cli = 1
 # log_cli_level = DEBUG


### PR DESCRIPTION
aiohttp warns about using str keys on the app instance as it can interfere with mypy typing. Right now it spams up the test logs and we don't use it that heavily so ignore the warnings.

More on the warning: https://docs.aiohttp.org/en/stable/web_advanced.html#application-s-config