### PR TITLE
Run ci on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
   pull_request:
+  push:
+    branches:
+      - master
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI no longer runs on every commit (to avoid duplicate runs on PRs) but now it doesn't run on master. Even though PRs have to be up to date in order to be merged, running on master gives some more signal to help identify flaky tests.