### PR TITLE
Fix handling of traceflare requests

### DIFF
--- a/ddapm_test_agent/tracerflare.py
+++ b/ddapm_test_agent/tracerflare.py
@@ -1,10 +1,8 @@
-from aiohttp import StreamReader
 import base64
-from typing import Dict
-import traceback
+from aiohttp import StreamReader
 from aiohttp import MultipartReader
 from aiohttp.web import Request
-
+from typing import Dict
 
 TracerFlareEvent = Dict[str, str]
 

--- a/ddapm_test_agent/tracerflare.py
+++ b/ddapm_test_agent/tracerflare.py
@@ -1,8 +1,10 @@
 import base64
+from typing import Dict
+
 from aiohttp import MultipartReader
 from aiohttp import StreamReader
 from aiohttp.web import Request
-from typing import Dict
+
 
 TracerFlareEvent = Dict[str, str]
 

--- a/ddapm_test_agent/tracerflare.py
+++ b/ddapm_test_agent/tracerflare.py
@@ -1,6 +1,6 @@
 import base64
-from aiohttp import StreamReader
 from aiohttp import MultipartReader
+from aiohttp import StreamReader
 from aiohttp.web import Request
 from typing import Dict
 

--- a/releasenotes/notes/fix-tracerflare-request-parsing-fae18ff9997c216d.yaml
+++ b/releasenotes/notes/fix-tracerflare-request-parsing-fae18ff9997c216d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the parsing logic for tracer flare requests


### PR DESCRIPTION
Fixing a few errors in the way tracer flare requests are handled by the test agent.

- The parsing was failing because the MultipartReader was given an instance of asyncio.StreamReader instead of aiohttp.StreamReader
- When a parsing error occurred, it was not returned to the client