### PR TITLE
logging: log received and expected if reasonable when len() mismatch

### DIFF
--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -262,15 +262,12 @@ def _compare_traces(expected: Trace, received: Trace, ignored: Set[str]) -> None
 
     The given traces are assumed to be in BFS order.
     """
-    if len(received) > len(expected):
+    if (len(received) != len(expected)):
         names = ["'%s'" % s["name"] for s in received[len(expected) - len(received) :]]
         raise AssertionError(
-            f"Received more spans ({len(received)}) than expected ({len(expected)}). Received unmatched spans: {', '.join(names)}"
-        )
-    elif len(expected) > len(received):
-        names = ["'%s'" % s["name"] for s in expected[len(received) - len(expected) :]]
-        raise AssertionError(
-            f"Received fewer spans ({len(received)}) than expected ({len(expected)}). Expected unmatched spans: {', '.join(names)}"
+            f"Received different number of spans ({len(received)}) than expected ({len(expected)}). Unmatched span names: {', '.join(names)}."
+            f"If spans<=10, will display received and expected.\nReceived: {received if (len(received) <= 10) else 'too long'}"
+            f"\nExpected: {expected if (len(expected) <= 10) else 'too long'}"
         )
 
     for s_exp, s_rec in zip(expected, received):


### PR DESCRIPTION
It's often very helpful to know the actual difference between received and expected snapshots when there's a length mismatch.