### PR TITLE
(fix) tests: Ignore new metric

### DIFF
--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -30,7 +30,7 @@ from .trace import trace_id as get_trace_id
 log = logging.getLogger(__name__)
 
 
-DEFAULT_SNAPSHOT_IGNORES = "span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,meta.runtime-id,span_links.trace_id_high,meta.pathway.hash"
+DEFAULT_SNAPSHOT_IGNORES = "span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,metrics._dd.tracer_kr,meta.runtime-id,span_links.trace_id_high,meta.pathway.hash"
 
 
 def _key_match(d1: Dict[str, Any], d2: Dict[str, Any], key: str) -> bool:

--- a/releasenotes/notes/ignore-new-metric-in-snapshots-fca905ba6d687929.yaml
+++ b/releasenotes/notes/ignore-new-metric-in-snapshots-fca905ba6d687929.yaml
@@ -1,6 +1,0 @@
----
-fixes:
-  - |
-    Prior to this change, snapshot tests were  with newer versions of the tracers
-    because of a new metric, metrics._dd.tracer_kr.  After this change, tests pass
-    because the new metric is ignored.

--- a/releasenotes/notes/ignore-new-metric-in-snapshots-fca905ba6d687929.yaml
+++ b/releasenotes/notes/ignore-new-metric-in-snapshots-fca905ba6d687929.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Prior to this change, snapshot tests were  with newer versions of the tracers
+    because of a new metric, metrics._dd.tracer_kr.  After this change, tests pass
+    because the new metric is ignored.


### PR DESCRIPTION
A new metric, metrics._dd.tracer_kr, was added to `dd-trace-py` causing snapshot tests tofail.  This metric is now added to the list of ignored snapshot fields.