### PR TITLE
(chore) refactor: fmt + test output

### DIFF
--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -1,4 +1,5 @@
 """Tracing specific functions and types"""
+
 import json
 from typing import Any
 from typing import Callable

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -59,7 +59,8 @@ async def test_concurrent_session(
     for token in ["test_case", "test_case2"]:
         resp = await agent.get("/test/session/traces", params={"test_session_token": token})
         assert resp.status == 200
-        assert await resp.json() == v04_reference_http_trace_payload_data_raw
+        result = await resp.json()
+        assert result == v04_reference_http_trace_payload_data_raw, result
 
     resp = await agent.get("/test/session/traces")
     assert resp.status == 200

--- a/tests/test_snapshot_integration.py
+++ b/tests/test_snapshot_integration.py
@@ -2,6 +2,7 @@
 If snapshots need to be (re)generated, set GENERATE_SNAPSHOTS=1
 and run the tests as usual.
 """
+
 import asyncio
 import os
 import subprocess
@@ -149,6 +150,7 @@ async def test_single_trace(
             span.set_metric(k, v)
     tracer.shutdown()
     resp = await testagent.get("http://localhost:8126/test/session/snapshot?test_session_token=test_single_trace")
+
     assert resp.status == response_code
 
 


### PR DESCRIPTION
This is a quick change which fixes some fmt issues (using riot run -s fmt) and a test output which was hard to debug