### PR TITLE
Bump ddtrace version to 2.6.0

### DIFF
--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -30,7 +30,7 @@ from .trace import trace_id as get_trace_id
 log = logging.getLogger(__name__)
 
 
-DEFAULT_SNAPSHOT_IGNORES = "span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,metrics._dd.tracer_kr,meta.runtime-id,span_links.trace_id_high,meta.pathway.hash"
+DEFAULT_SNAPSHOT_IGNORES = "span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,metrics._dd.tracer_kr,meta.runtime-id,span_links.trace_id_high,meta.pathway.hash,meta._dd.p.tid"
 
 
 def _key_match(d1: Dict[str, Any], d2: Dict[str, Any], key: str) -> bool:

--- a/test_deps.txt
+++ b/test_deps.txt
@@ -1,3 +1,3 @@
-ddtrace==1.7.2
+ddtrace==2.6.0
 pytest
 riot==0.13.0

--- a/tests/integration_snapshots/test_multi_trace.json
+++ b/tests/integration_snapshots/test_multi_trace.json
@@ -4,35 +4,36 @@
     "service": "",
     "resource": "root0",
     "trace_id": 0,
-    "type": "",
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
+      "_dd.p.tid": "65caa2a800000000",
+      "language": "python",
+      "runtime-id": "ce77bb0dd15e4f36aa106905fdddbc19"
     },
     "metrics": {
-      "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 28509
+      "process_id": 94638
     },
-    "duration": 137000,
-    "error": 0,
-    "start": 1633558542938056000
+    "duration": 223000,
+    "start": 1707778728600188000
   },
      {
        "name": "child0",
        "service": "",
        "resource": "child0",
        "trace_id": 0,
-       "type": "",
        "span_id": 2,
        "parent_id": 1,
-       "duration": 16000,
+       "type": "",
        "error": 0,
-       "start": 1633558542938164000
+       "duration": 9000,
+       "start": 1707778728600249000
      }],
 [
   {
@@ -40,33 +41,34 @@
     "service": "",
     "resource": "root1",
     "trace_id": 1,
-    "type": "",
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
+      "_dd.p.tid": "65caa2a800000000",
+      "language": "python",
+      "runtime-id": "ce77bb0dd15e4f36aa106905fdddbc19"
     },
     "metrics": {
-      "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 28509
+      "process_id": 94638
     },
-    "duration": 51000,
-    "error": 0,
-    "start": 1633558542938430000
+    "duration": 136000,
+    "start": 1707778728600778000
   },
      {
        "name": "child1",
        "service": "",
        "resource": "child1",
        "trace_id": 1,
-       "type": "",
        "span_id": 2,
        "parent_id": 1,
-       "duration": 12000,
+       "type": "",
        "error": 0,
-       "start": 1633558542938461000
+       "duration": 8000,
+       "start": 1707778728600803000
      }]]

--- a/tests/integration_snapshots/test_single_trace.json
+++ b/tests/integration_snapshots/test_single_trace.json
@@ -7,18 +7,20 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
+      "_dd.base_service": "",
       "_dd.p.dm": "-0",
-      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
+      "_dd.p.tid": "65caa2a600000000",
+      "language": "python",
+      "runtime-id": "ce77bb0dd15e4f36aa106905fdddbc19"
     },
     "metrics": {
-      "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 28509
+      "process_id": 94638
     },
-    "duration": 76000,
-    "error": 0,
-    "start": 1633558540524060000
+    "duration": 57000,
+    "start": 1707778726658859000
   }]]

--- a/tests/integration_snapshots/test_trace_distributed_propagated.json
+++ b/tests/integration_snapshots/test_trace_distributed_propagated.json
@@ -4,30 +4,31 @@
     "service": "",
     "resource": "root",
     "trace_id": 0,
-    "type": "",
     "span_id": 1,
     "parent_id": 5678,
+    "type": "",
+    "error": 0,
     "meta": {
-      "runtime-id": "9118dd9528d447629254178d1bb4dbcf"
+      "language": "python",
+      "runtime-id": "ce77bb0dd15e4f36aa106905fdddbc19"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
-      "system.pid": 81934
+      "process_id": 94638
     },
-    "duration": 171000,
-    "error": 0,
-    "start": 1653668237165110000
+    "duration": 162000,
+    "start": 1707778728991370000
   },
      {
        "name": "child",
        "service": "",
        "resource": "child",
        "trace_id": 0,
-       "type": "",
        "span_id": 2,
        "parent_id": 1,
-       "duration": 6000,
+       "type": "",
        "error": 0,
-       "start": 1653668237165133000
+       "duration": 6000,
+       "start": 1707778728991395000
      }]]

--- a/tests/integration_snapshots/test_trace_distributed_same_payload.json
+++ b/tests/integration_snapshots/test_trace_distributed_same_payload.json
@@ -4,67 +4,70 @@
     "service": "",
     "resource": "root0",
     "trace_id": 0,
-    "type": "",
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
+      "_dd.p.tid": "65caa2a800000000",
+      "language": "python",
+      "runtime-id": "ce77bb0dd15e4f36aa106905fdddbc19"
     },
     "metrics": {
-      "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 28509
+      "process_id": 94638
     },
-    "duration": 115000,
-    "error": 0,
-    "start": 1633558543195969000
+    "duration": 210000,
+    "start": 1707778728801900000
   },
      {
        "name": "child0",
        "service": "",
        "resource": "child0",
        "trace_id": 0,
-       "type": "",
        "span_id": 2,
        "parent_id": 1,
-       "duration": 14000,
+       "type": "",
        "error": 0,
-       "start": 1633558543196058000
+       "duration": 7000,
+       "start": 1707778728801961000
      },
         {
           "name": "root1",
           "service": "",
           "resource": "root1",
           "trace_id": 0,
-          "type": "",
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.dm": "-0",
-            "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
+            "_dd.p.tid": "65caa2a800000000",
+            "language": "python",
+            "runtime-id": "ce77bb0dd15e4f36aa106905fdddbc19"
           },
           "metrics": {
             "_dd.top_level": 1,
             "_dd.tracer_kr": 1.0,
             "_sampling_priority_v1": 1,
-            "system.pid": 28509
+            "process_id": 94638
           },
-          "duration": 36000,
-          "error": 0,
-          "start": 1633558543196287000
+          "duration": 103000,
+          "start": 1707778728802478000
         },
            {
              "name": "child1",
              "service": "",
              "resource": "child1",
              "trace_id": 0,
-             "type": "",
              "span_id": 4,
              "parent_id": 3,
-             "duration": 8000,
+             "type": "",
              "error": 0,
-             "start": 1633558543196307000
+             "duration": 6000,
+             "start": 1707778728802490000
            }]]

--- a/tests/integration_snapshots/test_trace_missing_received.json
+++ b/tests/integration_snapshots/test_trace_missing_received.json
@@ -4,33 +4,34 @@
     "service": "",
     "resource": "root0",
     "trace_id": 0,
-    "type": "",
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "runtime-id": "2d377516ca12429aaf072f037ed2e4cc"
+      "_dd.p.tid": "65caa2a900000000",
+      "language": "python",
+      "runtime-id": "ce77bb0dd15e4f36aa106905fdddbc19"
     },
     "metrics": {
-      "_dd.agent_psr": 1.0,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "system.pid": 28509
+      "process_id": 94638
     },
-    "duration": 98000,
-    "error": 0,
-    "start": 1633558543448651000
+    "duration": 220000,
+    "start": 1707778729179859000
   },
      {
        "name": "child0",
        "service": "",
        "resource": "child0",
        "trace_id": 0,
-       "type": "",
        "span_id": 2,
        "parent_id": 1,
-       "duration": 12000,
+       "type": "",
        "error": 0,
-       "start": 1633558543448725000
+       "duration": 9000,
+       "start": 1707778729179924000
      }]]

--- a/tests/integration_snapshots/test_trace_stats_tracestats.json
+++ b/tests/integration_snapshots/test_trace_stats_tracestats.json
@@ -6,12 +6,13 @@
       {
         "Name": "http.request",
         "Resource": "/users/view",
+        "Service": null,
         "Type": null,
         "HTTPStatusCode": 0,
         "Synthetics": false,
         "Hits": 5,
         "TopLevelHits": 5,
-        "Duration": 107000,
+        "Duration": 118000,
         "Errors": 1,
         "OkSummary": 1046,
         "ErrorSummary": 1046


### PR DESCRIPTION
It looks like a new tag meta._dd.p.tid was added which should probably be handled by the test agent since I believe it's used for 128-bit trace ID support.