### PR TITLE
Optimize docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-slim
 
 EXPOSE 8126
 
@@ -6,8 +6,15 @@ ENV SNAPSHOT_CI=1
 ENV LOG_LEVEL=INFO
 ENV SNAPSHOT_DIR=/snapshots
 
+RUN apt update && apt install -y git
+
 RUN mkdir -p /src
 WORKDIR /src
 COPY . /src
 RUN pip install /src
+
+# Cleanup
+RUN apt remove -y git
+RUN rm -rf /var/lib/apt/lists/* /root/.cache/pip /tmp/* /var/tmp/* /src
+
 CMD ["ddapm-test-agent"]

--- a/releasenotes/notes/image-optimization-d614eccb59441217.yaml
+++ b/releasenotes/notes/image-optimization-d614eccb59441217.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    The image size has been cut roughly in half.


### PR DESCRIPTION
The current image is >1.2gb and not at all optimized. We can utilize the python-slim base image and remove unnecessary files in the image. With these changes we cut the image size to less than half (500mb on my local machine).