### PR TITLE
Skip macOS containers test in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,4 +33,4 @@ jobs:
       - name: install deps
         run: pip install .[testing]
       - run: |
-          riot run -p ${{ matrix.python-version}} test
+          riot run -p --pass-env ${{ matrix.python-version}} test

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -12,6 +12,10 @@ import pytest
 
 
 pytestmark = pytest.mark.skipif(os.getenv("SKIP_CONTAINER") is not None, reason="SKIP_CONTAINER set")
+pytestmark = pytest.mark.skipif(
+    platform.system() == "Darwin" and os.getenv("GITHUB_ACTIONS") is not None,
+    reason="Github actions doesn't support docker",
+)
 
 
 class DockerContainer:


### PR DESCRIPTION
Until we can get https://github.com/DataDog/dd-apm-test-agent/pull/174 merged.