### PR TITLE
Add peer_tags to info endpoint

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -677,6 +677,8 @@ class Agent:
                 "feature_flags": [],
                 "config": {},
                 "client_drop_p0s": True,
+                # Just a random selection of some peer_tags to aggregate on for testing, not exhaustive
+                "peer_tags": ["db.name", "mongodb.db", "messaging.system"],
             }
         )
 

--- a/releasenotes/notes/addPeerTagsToInfo-4ccc2539d22c2993.yaml
+++ b/releasenotes/notes/addPeerTagsToInfo-4ccc2539d22c2993.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add `peer_tags` field to `/info` endpoint for testing client side stats.


### PR DESCRIPTION
As part of moving towards enabling client-side-stats by default we want to add some parametric tests. To provide some peer_tags to test with this change starts returning the `peer_tags` as expected by the datadog-agent (PR for that change here: https://github.com/DataDog/datadog-agent/pull/27603 )