### PR TITLE
feat: meta_struct support

### DIFF
--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -71,7 +71,7 @@ class Span(TypedDict):
     meta: NotRequired[Dict[str, str]]
     metrics: NotRequired[Dict[str, MetricType]]
     span_links: NotRequired[List[SpanLink]]
-    meta_struct: NotRequired[Dict[str, dict]]
+    meta_struct: NotRequired[Dict[str, Dict[str, Any]]]
 
 
 SpanAttr = Literal[
@@ -132,9 +132,13 @@ def verify_span(d: Any) -> Span:
                 assert isinstance(k, str), f"Expected key 'meta_struct.{k}' to be of type: 'str', got: {type(k)}"
                 assert isinstance(v, bytes), f"Expected msgpack'd value of key 'meta_struct.{k}' to be of type: 'bytes', got: {type(v)}"
             # Decode meta_struct msgpack values
-            decoded_meta_struct = { key: msgpack.unpackb(val_bytes) for key, val_bytes in d["meta_struct"] }
+            decoded_meta_struct = { key: msgpack.unpackb(val_bytes) for key, val_bytes in d["meta_struct"].items() }
             for k, val in decoded_meta_struct.items():
-                assert isinstance(v, dict), f"Expected msgpack decoded value of key 'meta_struct.{k}' to be of type: 'dict', got: {type(v)}"               
+                assert isinstance(val, dict), f"Expected msgpack decoded value of key 'meta_struct.{k}' to be of type: 'dict', got: {type(v)}"
+
+                for inner_k in val.keys():
+                    assert isinstance(inner_k, str), f"Expected key 'meta_struct.{k}.{inner_k}' to be of type: 'str', got: {type(inner_k)}"
+
             d["meta_struct"] = decoded_meta_struct
         if "metrics" in d:
             assert isinstance(d["metrics"], dict)

--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -126,6 +126,7 @@ def verify_span(d: Any) -> Span:
             for k, v in d["meta"].items():
                 assert isinstance(k, str), f"Expected key 'meta.{k}' to be of type: 'str', got: {type(k)}"
                 assert isinstance(v, str), f"Expected value of key 'meta.{k}' to be of type: 'str', got: {type(v)}"
+
         if "meta_struct" in d:
             assert isinstance(d["meta_struct"], dict)
             for k, v in d["meta_struct"].items():
@@ -134,9 +135,9 @@ def verify_span(d: Any) -> Span:
             # Decode meta_struct msgpack values
             decoded_meta_struct = { key: msgpack.unpackb(val_bytes) for key, val_bytes in d["meta_struct"].items() }
             for k, val in decoded_meta_struct.items():
-                assert isinstance(val, dict), f"Expected msgpack decoded value of key 'meta_struct.{k}' to be of type: 'dict', got: {type(v)}"
+                assert isinstance(val, dict), f"Expected msgpack decoded value of key 'meta_struct.{k}' to be of type: 'dict', got: {type(val)}"
 
-                for inner_k in val.keys():
+                for inner_k in val:
                     assert isinstance(inner_k, str), f"Expected key 'meta_struct.{k}.{inner_k}' to be of type: 'str', got: {type(inner_k)}"
 
             d["meta_struct"] = decoded_meta_struct

--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -130,13 +130,19 @@ def verify_span(d: Any) -> Span:
             assert isinstance(d["meta_struct"], dict)
             for k, v in d["meta_struct"].items():
                 assert isinstance(k, str), f"Expected key 'meta_struct.{k}' to be of type: 'str', got: {type(k)}"
-                assert isinstance(v, bytes), f"Expected msgpack'd value of key 'meta_struct.{k}' to be of type: 'bytes', got: {type(v)}"
+                assert isinstance(
+                    v, bytes
+                ), f"Expected msgpack'd value of key 'meta_struct.{k}' to be of type: 'bytes', got: {type(v)}"
             # Decode meta_struct msgpack values
-            decoded_meta_struct = { key: msgpack.unpackb(val_bytes) for key, val_bytes in d["meta_struct"].items() }
+            decoded_meta_struct = {key: msgpack.unpackb(val_bytes) for key, val_bytes in d["meta_struct"].items()}
             for k, val in decoded_meta_struct.items():
-                assert isinstance(val, dict), f"Expected msgpack decoded value of key 'meta_struct.{k}' to be of type: 'dict', got: {type(val)}"
+                assert isinstance(
+                    val, dict
+                ), f"Expected msgpack decoded value of key 'meta_struct.{k}' to be of type: 'dict', got: {type(val)}"
                 for inner_k in val:
-                    assert isinstance(inner_k, str), f"Expected key 'meta_struct.{k}.{inner_k}' to be of type: 'str', got: {type(inner_k)}"
+                    assert isinstance(
+                        inner_k, str
+                    ), f"Expected key 'meta_struct.{k}.{inner_k}' to be of type: 'str', got: {type(inner_k)}"
             d["meta_struct"] = decoded_meta_struct
         if "metrics" in d:
             assert isinstance(d["metrics"], dict)

--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -126,7 +126,6 @@ def verify_span(d: Any) -> Span:
             for k, v in d["meta"].items():
                 assert isinstance(k, str), f"Expected key 'meta.{k}' to be of type: 'str', got: {type(k)}"
                 assert isinstance(v, str), f"Expected value of key 'meta.{k}' to be of type: 'str', got: {type(v)}"
-
         if "meta_struct" in d:
             assert isinstance(d["meta_struct"], dict)
             for k, v in d["meta_struct"].items():
@@ -136,10 +135,8 @@ def verify_span(d: Any) -> Span:
             decoded_meta_struct = { key: msgpack.unpackb(val_bytes) for key, val_bytes in d["meta_struct"].items() }
             for k, val in decoded_meta_struct.items():
                 assert isinstance(val, dict), f"Expected msgpack decoded value of key 'meta_struct.{k}' to be of type: 'dict', got: {type(val)}"
-
                 for inner_k in val:
                     assert isinstance(inner_k, str), f"Expected key 'meta_struct.{k}.{inner_k}' to be of type: 'str', got: {type(inner_k)}"
-
             d["meta_struct"] = decoded_meta_struct
         if "metrics" in d:
             assert isinstance(d["metrics"], dict)
@@ -400,6 +397,7 @@ def _trace_decoder_flexible(json_string: bytes) -> Dict[str, Any]:
     parsed_data: Dict[str, Any] = json.loads(json_string, object_hook=json_decoder)
     return parsed_data
 
+
 def decode_v04(content_type: str, data: bytes, suppress_errors: bool) -> v04TracePayload:
     if content_type == "application/msgpack":
         payload = msgpack.unpackb(data)
@@ -407,7 +405,6 @@ def decode_v04(content_type: str, data: bytes, suppress_errors: bool) -> v04Trac
         payload = _trace_decoder_flexible(data) if suppress_errors else json.loads(data)
     else:
         raise TypeError("Content type %r not supported" % content_type)
-
     return _verify_v04_payload(payload)
 
 

--- a/releasenotes/notes/meta-struct-2cce08475cb05470.yaml
+++ b/releasenotes/notes/meta-struct-2cce08475cb05470.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add support for parsing the `meta_struct` field in traces. This field just like the `meta` field map but the values
+    are arbitrary inner msgpack-encoded values. When the `meta_struct` field is present, its inner messages will be
+    parsed and added to the trace as a dictionary.

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -91,34 +91,34 @@ def test_decode_v04(content_type, payload):
             ),
         ),
         (
-                "application/msgpack",
-                msgpack.packb(
+            "application/msgpack",
+            msgpack.packb(
+                [
                     [
-                        [
-                            {
-                                "name": "span",
-                                "span_id": 1234,
-                                "trace_id": 321,
-                                "meta_struct": ["this is not a dict"],
-                            }
-                        ]
+                        {
+                            "name": "span",
+                            "span_id": 1234,
+                            "trace_id": 321,
+                            "meta_struct": ["this is not a dict"],
+                        }
                     ]
-                ),
+                ]
+            ),
         ),
         (
-                "application/msgpack",
-                msgpack.packb(
+            "application/msgpack",
+            msgpack.packb(
+                [
                     [
-                        [
-                            {
-                                "name": "span",
-                                "span_id": 1234,
-                                "trace_id": 321,
-                                "meta_struct": {"key": msgpack.packb(["this is not a dict"])},
-                            }
-                        ]
+                        {
+                            "name": "span",
+                            "span_id": 1234,
+                            "trace_id": 321,
+                            "meta_struct": {"key": msgpack.packb(["this is not a dict"])},
+                        }
                     ]
-                ),
+                ]
+            ),
         ),
     ],
 )

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -49,6 +49,21 @@ def test_trace_chunk():
                 ]
             ),
         ),
+        (
+            "application/msgpack",
+            msgpack.packb(
+                [
+                    [
+                        {
+                            "name": "span",
+                            "span_id": 1234,
+                            "trace_id": 321,
+                            "meta_struct": {"key": msgpack.packb({"subkey": "value"})},
+                        }
+                    ]
+                ]
+            ),
+        ),
     ],
 )
 def test_decode_v04(content_type, payload):
@@ -58,8 +73,53 @@ def test_decode_v04(content_type, payload):
 @pytest.mark.parametrize(
     "content_type, payload",
     [
-        ("application/msgpack", msgpack.packb([{"name": "test"}])),
         ("application/json", json.dumps([{"name": "test"}])),
+        ("application/msgpack", msgpack.packb([{"name": "test"}])),
+        (
+            "application/msgpack",
+            msgpack.packb(
+                [
+                    [
+                        {
+                            "name": "span",
+                            "span_id": 1234,
+                            "trace_id": 321,
+                            "meta_struct": "not a valid msgpack",
+                        }
+                    ]
+                ]
+            ),
+        ),
+        (
+                "application/msgpack",
+                msgpack.packb(
+                    [
+                        [
+                            {
+                                "name": "span",
+                                "span_id": 1234,
+                                "trace_id": 321,
+                                "meta_struct": ["this is not a dict"],
+                            }
+                        ]
+                    ]
+                ),
+        ),
+        (
+                "application/msgpack",
+                msgpack.packb(
+                    [
+                        [
+                            {
+                                "name": "span",
+                                "span_id": 1234,
+                                "trace_id": 321,
+                                "meta_struct": {"key": msgpack.packb(["this is not a dict"])},
+                            }
+                        ]
+                    ]
+                ),
+        ),
     ],
 )
 def test_decode_v04_bad(content_type, payload):


### PR DESCRIPTION
## Description

This PR adds support for a specific field supported since agent version v7.31 called `meta_struct` which encapsulate another layer of msgpack values inside the main msgpack chunk.

## Motivation

Appsec has been using this field to store stacktraces for multiple quarters already. We need to be able to test this feature

## Notes to reviewer

Not overly happy about this implementation but there is not obvious way to do a first round of type checking, modify the span object, and then do a second round of type-checking. So I've simply put everything in the `verify_span` function.