### PR TITLE
Remove unnecessary files from Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="BSD 3",
-    packages=find_packages(exclude=["tests*"]),
+    packages=find_packages(exclude=["tests*", "releasenotes", "scripts"]),
     package_data={"ddapm_test_agent": ["py.typed"]},
     python_requires=">=3.8",
     install_requires=[


### PR DESCRIPTION
These files were included in the wheel but are unnecessary for the library to function. This indirectly fixes #188 since a releasenote file name is too long for Windows.