### PR TITLE
Fix typing on asyncio `MultipartReader` usage

### DIFF
--- a/ddapm_test_agent/tracerflare.py
+++ b/ddapm_test_agent/tracerflare.py
@@ -17,7 +17,7 @@ async def v1_decode(request: Request, data: bytes) -> TracerFlareEvent:
         stream = StreamReader(request.protocol, len(data))
         stream.feed_data(data)
         stream.feed_eof()
-        async for part in MultipartReader(request.headers, stream):
+        async for part in MultipartReader(request.headers, stream):  # type: ignore
             if part.name is not None:
                 if part.name == "flare_file":
                     tracer_flare[part.name] = base64.b64encode(await part.read()).decode("ascii")

--- a/ddapm_test_agent/tracerflare.py
+++ b/ddapm_test_agent/tracerflare.py
@@ -18,7 +18,7 @@ async def v1_decode(request: Request, data: bytes) -> TracerFlareEvent:
         stream = StreamReader(request.protocol, len(data))
         stream.feed_data(data)
         stream.feed_eof()
-        async for part in MultipartReader(request.headers, stream):  # type: ignore
+        async for part in MultipartReader(request.headers, stream):
             if isinstance(part, BodyPartReader) and part.name:
                 if part.name == "flare_file":
                     tracer_flare[part.name] = base64.b64encode(await part.read()).decode("ascii")

--- a/ddapm_test_agent/tracerflare.py
+++ b/ddapm_test_agent/tracerflare.py
@@ -1,6 +1,7 @@
 import base64
 from typing import Dict
 
+from aiohttp import BodyPartReader
 from aiohttp import MultipartReader
 from aiohttp import StreamReader
 from aiohttp.web import Request
@@ -18,7 +19,7 @@ async def v1_decode(request: Request, data: bytes) -> TracerFlareEvent:
         stream.feed_data(data)
         stream.feed_eof()
         async for part in MultipartReader(request.headers, stream):  # type: ignore
-            if part.name is not None:
+            if isinstance(part, BodyPartReader) and part.name:
                 if part.name == "flare_file":
                     tracer_flare[part.name] = base64.b64encode(await part.read()).decode("ascii")
                 else:


### PR DESCRIPTION
aiohttp itself is ignoring some types which breaks our type-checking (as far as I can tell).

```
    def __aiter__(
        self,
    ) -> AsyncIterator["BodyPartReader"]:
        return self  # type: ignore[return-value]
```