### PR TITLE
Add agent state header to info endpoint

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -679,7 +679,8 @@ class Agent:
                 "client_drop_p0s": True,
                 # Just a random selection of some peer_tags to aggregate on for testing, not exhaustive
                 "peer_tags": ["db.name", "mongodb.db", "messaging.system"],
-            }
+            },
+            headers={"Datadog-Agent-State": "03e868b3ecdd62a91423cc4c3917d0d151fb9fa486736911ab7f5a0750c63824"},
         )
 
     async def _handle_traces(self, request: Request, version: Literal["v0.4", "v0.5", "v0.7"]) -> web.Response:

--- a/releasenotes/notes/addAgentStateToInfo-f9a179ce88f2ab9e.yaml
+++ b/releasenotes/notes/addAgentStateToInfo-f9a179ce88f2ab9e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Agent-State-Header` to `/info` endpoint.


### PR DESCRIPTION
Add a dummy value for the `Datadog-Agent-State` header