### PR TITLE
Noramlize`meta._dd.parent_id` value in spans

### DIFF
--- a/ddapm_test_agent/trace_snapshot.py
+++ b/ddapm_test_agent/trace_snapshot.py
@@ -106,10 +106,13 @@ def _normalize_traces(traces: List[Trace]) -> List[Trace]:
                 span["parent_id"] = span_id_map.get(parent_id, parent_id)
             else:
                 # Normalize the parent of root spans to be 0.
+                parent_id = 0
                 span["parent_id"] = 0
 
             if "meta" not in span:
                 span["meta"] = {}
+            elif span["meta"].get("_dd.parent_id"):
+                span["meta"]["_dd.parent_id"] = parent_id
             if "metrics" not in span:
                 span["metrics"] = {}
             span_id += 1


### PR DESCRIPTION
Currently the `meta._dd.parent_id` value in snapshot spans is populate with a real parent id from the test agent. We want these values to be normalized instead.