### PR TITLE
Add delay for telemetry requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,22 @@ Returns the tracer-flares in the following json format:
 
 If there was an error parsing the tracer-flare form, that will be recorded under `error`.
 
+### /test/settings (POST)
+
+Allows to change some settings on the fly.
+This endpoint takes a POST request with a json content listing the keys and values to apply.
+
+```json
+{ 'key': value }
+```
+
+Supported keys:
+ - `trace_request_delay`: sets a delay to apply to trace and telemetry requests
+
+ ```
+curl -X POST 'http://0.0.0.0:8126/test/settings' -d '{ "trace_request_delay": 5 }'
+```
+
 ## Development
 
 ### Prerequisites

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -669,7 +669,7 @@ class Agent:
         # First pass to validate the data
         for key in data:
             if key not in request.app:
-                return web.HTTPUnprocessableEntity(f"Unknown key: {key}")
+                return web.HTTPUnprocessableEntity(text=f"Unknown key: {key}")
 
         # Second pass to apply the config
         for key in data:

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -662,7 +662,7 @@ class Agent:
         return web.Response(body=aggregated_text, content_type="text/plain", headers=req_headers)
 
     async def handle_settings(self, request: Request) -> web.Response:
-        """Allows to change test agent settings on the fly"""
+        """Allow to change test agent settings on the fly"""
         raw_data = await request.read()
         data = json.loads(raw_data)
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -435,7 +435,7 @@ class Agent:
         events: List[TelemetryEvent] = []
         for req in self._requests_by_session(token):
             if req.match_info.handler == self.handle_v2_apmtelemetry:
-                events.append(v2_apmtelemetry_decode(await req.read()))
+                events.append(await v2_apmtelemetry_decode_request(req, await req.read()))
 
         # TODO: Sort the events?
         return events

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -669,7 +669,7 @@ class Agent:
         # First pass to validate the data
         for key in data:
             if key not in request.app:
-                return web.HTTPUnprocessableEntity(text=f"Unknown key: {key}")
+                return web.HTTPUnprocessableEntity(text=f"Unknown key: '{key}'")
 
         # Second pass to apply the config
         for key in data:

--- a/ddapm_test_agent/apmtelemetry.py
+++ b/ddapm_test_agent/apmtelemetry.py
@@ -1,10 +1,26 @@
+import asyncio
 import json
+import logging
+from aiohttp.web import Request
 from typing import Any
 from typing import Dict
 from typing import cast
 
+log = logging.getLogger(__name__)
 
 TelemetryEvent = Dict[str, Any]
+
+async def v2_decode_request(request: Request, data: bytes) -> TelemetryEvent:
+    headers = request.headers
+
+    if "X-Datadog-Test-Stall-Seconds" in headers:
+        duration = float(headers["X-Datadog-Test-Stall-Seconds"])
+    else:
+        duration = request.app["trace_request_delay"]
+    if duration > 0:
+        log.info("Stalling for %r seconds.", duration)
+        await asyncio.sleep(duration)
+    v2_decode(data)
 
 
 def v2_decode(data: bytes) -> TelemetryEvent:

--- a/ddapm_test_agent/apmtelemetry.py
+++ b/ddapm_test_agent/apmtelemetry.py
@@ -1,14 +1,16 @@
 import asyncio
 import json
 import logging
-from aiohttp.web import Request
 from typing import Any
 from typing import Dict
 from typing import cast
 
-log = logging.getLogger(__name__)
+from aiohttp.web import Request
 
+
+log = logging.getLogger(__name__)
 TelemetryEvent = Dict[str, Any]
+
 
 async def v2_decode_request(request: Request, data: bytes) -> TelemetryEvent:
     headers = request.headers
@@ -20,7 +22,7 @@ async def v2_decode_request(request: Request, data: bytes) -> TelemetryEvent:
     if duration > 0:
         log.info("Stalling for %r seconds.", duration)
         await asyncio.sleep(duration)
-    v2_decode(data)
+    return v2_decode(data)
 
 
 def v2_decode(data: bytes) -> TelemetryEvent:

--- a/releasenotes/notes/Settings-endpoint-928ae5b6e8ddc625.yaml
+++ b/releasenotes/notes/Settings-endpoint-928ae5b6e8ddc625.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a /test/settings endpoint to change the settings on the fly.
+    It takes a json encoded list of key/values, that will be applied to the app dict.
+    Example:
+    { "trace_request_delay": 5 }

--- a/releasenotes/notes/Telemetry-requests-delay-2586180b286ce393.yaml
+++ b/releasenotes/notes/Telemetry-requests-delay-2586180b286ce393.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    --trace-request-delay now also affects telemetry requests.
+    The delay can be set independently for each request by setting the X-Datadog-Test-Stall-Seconds header.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -402,9 +402,7 @@ def test_uds(tmp_path, available_port):
         raise Exception("Test agent failed to start")
 
 
-async def test_post_known_settings(
-        agent
-):
+async def test_post_known_settings(agent):
     resp = await agent.post(
         "/test/settings",
         data='{ "trace_request_delay": 5 }',
@@ -423,7 +421,7 @@ async def test_post_known_settings(
 
 
 async def test_post_unknown_settings(
-        agent,
+    agent,
 ):
     resp = await agent.post(
         "/test/settings",
@@ -433,4 +431,4 @@ async def test_post_unknown_settings(
     assert resp.status == 422
     text = await resp.text()
     assert text == "Unknown key: 'dummy_setting'"
-    assert 'dummy_setting' not in agent.app
+    assert "dummy_setting" not in agent.app

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -400,3 +400,37 @@ def test_uds(tmp_path, available_port):
         pass
     else:
         raise Exception("Test agent failed to start")
+
+
+async def test_post_known_settings(
+        agent
+):
+    resp = await agent.post(
+        "/test/settings",
+        data='{ "trace_request_delay": 5 }',
+    )
+
+    assert resp.status == 202, await resp.text()
+    assert agent.app["trace_request_delay"] == 5
+
+    resp = await agent.post(
+        "/test/settings",
+        data='{ "trace_request_delay": 0 }',
+    )
+
+    assert resp.status == 202, await resp.text()
+    assert agent.app["trace_request_delay"] == 0
+
+
+async def test_post_unknown_settings(
+        agent,
+):
+    resp = await agent.post(
+        "/test/settings",
+        data='{ "dummy_setting": 5 }',
+    )
+
+    assert resp.status == 422
+    text = await resp.text()
+    assert text == "Unknown key: 'dummy_setting'"
+    assert 'dummy_setting' not in agent.app


### PR DESCRIPTION
Extend `--trace-request-delay` to also affect trace requests.

Also, add a `test/settings` endpoint to change the value of settings on the fly.