### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ If there was an error parsing the tracer-flare form, that will be recorded under
 Allows to change some settings on the fly.
 This endpoint takes a POST request with a json content listing the keys and values to apply.
 
-```json
+```js
 { 'key': value }
 ```
 


### PR DESCRIPTION
Switching the settings example from json to js because otherwise it gets highlighted in red (can't use variables in json).