### PR TITLE
/info: span_meta_structs

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -699,6 +699,7 @@ class Agent:
                 "client_drop_p0s": True,
                 # Just a random selection of some peer_tags to aggregate on for testing, not exhaustive
                 "peer_tags": ["db.name", "mongodb.db", "messaging.system"],
+                "span_meta_structs": True,
             },
             headers={"Datadog-Agent-State": "03e868b3ecdd62a91423cc4c3917d0d151fb9fa486736911ab7f5a0750c63824"},
         )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -100,6 +100,7 @@ async def test_info(agent):
         "feature_flags": [],
         "config": {},
         "client_drop_p0s": True,
+        "span_meta_structs": True,
     }
 
 


### PR DESCRIPTION
This PR adds a field sent to the tracer in the `/info` endpoint to the mimic the agent behavior coded here: https://github.com/DataDog/datadog-agent/blob/39d73d940f304dedd89dff2044c657142ad24c64/pkg/trace/api/info.go#L98

This will help test the feature described in this [RFC](https://docs.google.com/document/d/1iWQsOfT6Lg_IFyvQeqry9wVmXOE2Yav0X4MgOTk7mks/edit?tab=t.0#heading=h.28u3d8l2xcd0) 

