### PR TITLE
Publish wheels to PyPI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheel
           path: dist/*.whl
 
   build_sdist:
@@ -65,7 +66,12 @@ jobs:
           name: sdist
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/releasenotes/notes/wheels-68a7dc2f4b00e0c4.yaml
+++ b/releasenotes/notes/wheels-68a7dc2f4b00e0c4.yaml
@@ -1,0 +1,2 @@
+---
+fixes: Publish wheels to PyPI.


### PR DESCRIPTION
We were building them, just not uploading to PyPI.

Fixes #206 