### PR TITLE
fix: add evp_proxy endpoint to /info agent endpoint

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -708,6 +708,7 @@ class Agent:
                     "/telemetry/proxy/",
                     "/v0.7/config",
                     "/tracer_flare/v1",
+                    "/evp_proxy/v2/",
                 ],
                 "feature_flags": [],
                 "config": {},

--- a/releasenotes/notes/evp-proxy-on-info-d65cd077575306ca.yaml
+++ b/releasenotes/notes/evp-proxy-on-info-d65cd077575306ca.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Adds `/evp_proxy/v2/` as one of the endpoints listed from the `/info` endpoint.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -91,6 +91,7 @@ async def test_info(agent):
             "/telemetry/proxy/",
             "/v0.7/config",
             "/tracer_flare/v1",
+            "/evp_proxy/v2/",
         ],
         "peer_tags": [
             "db.name",


### PR DESCRIPTION
Some tracers rely on the existence of `/evp_proxy/v2` for evp proxy feature discovery. This PR adds it so those tracers can properly set up EVP proxy.