### PR TITLE
fix: add missing runc/containerd deps from python slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,24 @@
 FROM python:3.12-slim
 
+WORKDIR /src
 EXPOSE 8126
 
 ENV SNAPSHOT_CI=1
 ENV LOG_LEVEL=INFO
 ENV SNAPSHOT_DIR=/snapshots
-
-RUN apt update && apt install -y git curl
-
-ADD vcr-cassettes ./vcr-cassettes
 ENV VCR_CASSETTES_DIRECTORY=/vcr-cassettes
 
-RUN mkdir -p /src
-WORKDIR /src
+RUN apt update && \
+    apt install -y --no-install-recommends git curl runc containerd && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD vcr-cassettes /vcr-cassettes
+
 # Add only necessary files to speed up development builds
 ADD README.md setup.py test_deps.txt ./
 ADD ddapm_test_agent ./ddapm_test_agent
 ADD .git ./.git
-RUN pip install /src
-
-# Cleanup
-RUN apt remove -y git
-RUN rm -rf /var/lib/apt/lists/* /root/.cache/pip /tmp/* /var/tmp/* /src
+RUN pip install /src && \
+    rm -rf /root/.cache/pip
 
 CMD ["ddapm-test-agent"]

--- a/releasenotes/notes/fix-missing-slim-deps-fa3b0fc0292a09b3.yaml
+++ b/releasenotes/notes/fix-missing-slim-deps-fa3b0fc0292a09b3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Ensures ``runc`` and ``containerd`` are installed in the docker image.


### PR DESCRIPTION
In some docker-in-docker situations we get failures such as:

```
WARNING: Event retrieved from the cluster: Error: failed to create containerd task: failed to create shim task: ENOENT: No such file or directory
Stack backtrace:
   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
Stack backtrace:
   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: <unknown>
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>
```


Likely from missing `containerd` from the move to the python slim base image.


This increases the image size from around 460mv to about 500mb.