### PR TITLE
Add support for query strings to VCR

### DIFF
--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -79,6 +79,8 @@ def generate_cassette_name(path: str, method: str, body: bytes) -> str:
 
 async def proxy_request(request: Request, vcr_cassettes_directory: str) -> Response:
     path = request.match_info["path"]
+    if request.query_string:
+        path = path + "?" + request.query_string
 
     parts = path.split("/", 1)
     if len(parts) != 2:

--- a/releasenotes/notes/vcr-support-querystring-b06555fb9a7c90ae.yaml
+++ b/releasenotes/notes/vcr-support-querystring-b06555fb9a7c90ae.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    VCR: add support for query strings.


### PR DESCRIPTION
Currently URLs containing query strings will be hashed to the same cassette. This isn't ideal for cases where arguments are passed via the query string as the returned cassette will be constant.

Solution is to simply factor in the query string into the hash.