### PR TITLE
feat(vcr): add google genai / gemini proxy support

### DIFF
--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -2,11 +2,16 @@ import hashlib
 import json
 import os
 import re
+from urllib.parse import urljoin
 
 from aiohttp.web import Request
 from aiohttp.web import Response
 import requests
 import vcr
+
+def url_path_join(base_url: str, path: str) -> str:
+    """Join a base URL with a path, handling slashes automatically."""
+    return urljoin(base_url.rstrip('/') + '/', path.lstrip('/'))
 
 
 PROVIDER_BASE_URLS = {
@@ -15,6 +20,7 @@ PROVIDER_BASE_URLS = {
     "deepseek": "https://api.deepseek.com/",
     "anthropic": "https://api.anthropic.com/",
     "datadog": "https://api.datadoghq.com/",
+    "genai": "https://generativelanguage.googleapis.com/"
 }
 
 NORMALIZERS = [
@@ -98,7 +104,7 @@ async def proxy_request(request: Request, vcr_cassettes_directory: str) -> Respo
     if provider not in PROVIDER_BASE_URLS:
         return Response(body=f"Unsupported provider: {provider}", status=400)
 
-    target_url = f"{PROVIDER_BASE_URLS[provider]}/{remaining_path}"
+    target_url = url_path_join(PROVIDER_BASE_URLS[provider], remaining_path)
 
     headers = {key: value for key, value in request.headers.items() if key != "Host"}
 

--- a/releasenotes/notes/genai-vcr-support-b499ec54df84eaa3.yaml
+++ b/releasenotes/notes/genai-vcr-support-b499ec54df84eaa3.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    vcr: adds support for recording requests from google genai/gemini.


### PR DESCRIPTION
Adds support to proxy and record requests to the Google GenAI / Gemini provider. Additionally, includes a small tweak to join URLs together better.