### PR TITLE
feat(vcr): use provided test name as part of cassette name

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -64,6 +64,8 @@ from .tracerflare import v1_decode as v1_tracerflare_decode
 from .tracestats import decode_v06 as tracestats_decode_v06
 from .tracestats import v06StatsPayload
 from .vcr_proxy import proxy_request
+from .vcr_proxy import start_vcr_test
+from .vcr_proxy import stop_vcr_test
 
 
 class NoSuchSessionException(Exception):
@@ -1204,6 +1206,8 @@ def make_app(
             web.get("/test/trace_check/summary", agent.get_trace_check_summary),
             web.get("/test/integrations/tested_versions", agent.handle_get_tested_integrations),
             web.post("/test/settings", agent.handle_settings),
+            web.post("/vcr/test/start", start_vcr_test),
+            web.post("/vcr/test/stop", stop_vcr_test),
             web.route(
                 "*",
                 "/vcr/{path:.*}",

--- a/releasenotes/notes/vcr-proxy-use-test-name-e47891994c961c52.yaml
+++ b/releasenotes/notes/vcr-proxy-use-test-name-e47891994c961c52.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    vcr: adds two new ``/vcr/test/start`` and ``/vcr/test/stop``, which capture all proxy requests made in between these two requests with a test name specified in ``/vcr/test/start``.


### PR DESCRIPTION
Adds two endpoints
1. `/vcr/test/start` to signal the start of a test that will rely on recording or using generated cassettes. it takes a body field of `test_name` to use as a "singleton" test instance name to add as a suffix to any generated cassettes until `/vcr/test/stop` is called
2. `/vcr/test/stop` to unset the current test name suffix in use

this should enable quicker development to search for cassettes with a given test name suffix. cassettes will still be prefixed with the path, method, and body hash.