### PR TITLE
fix(vcr): attaching vcr suffix name to the request results in 400s from providers, omit google api key from cassettes

### DIFF
--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -123,7 +123,7 @@ async def proxy_request(request: Request, vcr_cassettes_directory: str) -> Respo
 
     body_bytes = await request.read()
 
-    vcr_cassette_suffix = request["vcr_cassette_suffix"]
+    vcr_cassette_suffix = request.pop("vcr_cassette_suffix", None)
 
     cassette_name = generate_cassette_name(path, request.method, body_bytes, vcr_cassette_suffix)
     with get_vcr(provider, vcr_cassettes_directory).use_cassette(f"{cassette_name}.yaml"):

--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -79,6 +79,7 @@ def get_vcr(subdirectory: str, vcr_cassettes_directory: str) -> vcr.VCR:
             "x-api-key",
             "dd-api-key",
             "dd-application-key",
+            "x-goog-api-key",
         ],
     )
 

--- a/releasenotes/notes/vcr-proxy-use-test-name-bugfix-be758294ba30ac78.yaml
+++ b/releasenotes/notes/vcr-proxy-use-test-name-bugfix-be758294ba30ac78.yaml
@@ -2,3 +2,5 @@
 fixes:
   - |
     vcr: fixes a bug where the vcr cassette would cause unnecessary 400s from proxied providers.
+  - |
+    vcr: fixes a bug where google genai client keys would not be omitted from generated vcr cassettes.

--- a/releasenotes/notes/vcr-proxy-use-test-name-bugfix-be758294ba30ac78.yaml
+++ b/releasenotes/notes/vcr-proxy-use-test-name-bugfix-be758294ba30ac78.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    vcr: fixes a bug where the vcr cassette would cause unnecessary 400s from proxied providers.


### PR DESCRIPTION
instead, we pop the name from the request dict-like object, so that cassette name generation works properly. i _think_ this is only true when there is no suffix being used (ie value of `None`), which is still a valid use case.

example:
```bash
  File "/usr/local/lib/python3.12/site-packages/google/genai/errors.py", line 105, in raise_for_response
    raise ClientError(status_code, response_json, response)
google.genai.errors.ClientError: 400 'vcr_cassette_suffix'. {'message': "400: 'vcr_cassette_suffix'", 'status': "'vcr_cassette_suffix'"}
```

Additionally, make sure Google GenAI API keys are omitted from cassettes