### PR TITLE
fix(vcr): fix middleware incompatability with request bodies that aren't utf-8 decodable

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -118,7 +118,7 @@ async def _vcr_proxy_cassette_prefix(request: Request) -> Optional[str]:
         request_body: dict[str, str] = await request.json()
         requested_test_name = request_body.get("test_name")
         return requested_test_name
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return None
 
 

--- a/releasenotes/notes/vcr-cassette-name-middleware-fix-9e47c395892a9fe7.yaml
+++ b/releasenotes/notes/vcr-cassette-name-middleware-fix-9e47c395892a9fe7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    vcr: fixes an issue where the vcr cassette name middleware would not properly ignore decoding errors for request bodies that were not associated with then ``/vcr/test/start`` path.


### PR DESCRIPTION
there's an issue with our logic for looking for the `test_name` field in a request body in our middleware. the check was expecting the body to be able to be decoded using utf-8, which should really only apply for the `/vcr/test/start` endpoint. however, any `/vcr` endpoint hits this check, but not all of those endpoints will have compatible request bodies. since we only care about doing this for the `/vcr/test/start` endpoint, and that endpoint asserts that the test name was extracted correctly, we can swallow any unicode decoding errors.