### PR TITLE
feat(vcr): add ability to run in ci mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ And pass in a valid API key (if needed) in the way that provider expects.
 
 To redact api keys, modify the `filter_headers` list in the `get_vcr` function in `ddapm_test_agent/vcr_proxy.py`. This can be confirmed by viewing cassettes in the `vcr-cassettes` directory (or the otherwise specified directory), and verifying that any new cassettes do not contain the api key.
 
+#### Running in CI
+
+To have the vcr proxy throw a 404 error if a cassette is not found in CI mode to ensure that all cassettes are generated locally and committed, set the `VCR_CI_MODE` environment variable or the `--vcr-ci-mode` flag in the cli tool to `true` (this value defaults to `false`).
+
 ## Configuration
 
 The test agent can be configured via command-line options or via environment variables.

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -1355,6 +1355,7 @@ def make_app(
     snapshot_removed_attrs: List[str],
     snapshot_regex_placeholders: Dict[str, str],
     vcr_cassettes_directory: str,
+    vcr_ci_mode: bool,
 ) -> web.Application:
     agent = Agent()
     app = web.Application(
@@ -1416,7 +1417,7 @@ def make_app(
             web.route(
                 "*",
                 "/vcr/{path:.*}",
-                lambda request: proxy_request(request, vcr_cassettes_directory),
+                lambda request: proxy_request(request, vcr_cassettes_directory, vcr_ci_mode),
             ),
         ]
     )
@@ -1581,6 +1582,12 @@ def main(args: Optional[List[str]] = None) -> None:
         default=os.environ.get("VCR_CASSETTES_DIRECTORY", os.path.join(os.getcwd(), "vcr-cassettes")),
         help="Directory to read and store third party API cassettes.",
     )
+    parser.add_argument(
+        "--vcr-ci-mode",
+        type=bool,
+        default=os.environ.get("VCR_CI_MODE", False),
+        help="Will change the test agent to record VCR cassettes in CI mode, throwing an error if a cassette is not found on /vcr/{provider}",
+    )
     parsed_args = parser.parse_args(args=args)
     logging.basicConfig(level=parsed_args.log_level)
 
@@ -1624,6 +1631,7 @@ def main(args: Optional[List[str]] = None) -> None:
         snapshot_removed_attrs=parsed_args.snapshot_removed_attrs,
         snapshot_regex_placeholders=parsed_args.snapshot_regex_placeholders,
         vcr_cassettes_directory=parsed_args.vcr_cassettes_directory,
+        vcr_ci_mode=parsed_args.vcr_ci_mode,
     )
 
     # Validate port configuration

--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -173,7 +173,6 @@ async def proxy_request(request: Request, vcr_cassettes_directory: str, vcr_ci_m
             status=404,
         )
 
-    
     target_url = url_path_join(PROVIDER_BASE_URLS[provider], remaining_path)
     headers = {key: value for key, value in request.headers.items() if key != "Host"}
 

--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -170,7 +170,7 @@ async def proxy_request(request: Request, vcr_cassettes_directory: str, vcr_ci_m
     if vcr_ci_mode and not cassette_exists:
         return Response(
             body=f"Cassette {cassette_file_name} not found while running in CI mode. Please generate the cassette locally and commit it.",
-            status=404,
+            status=500,
         )
 
     target_url = url_path_join(PROVIDER_BASE_URLS[provider], remaining_path)

--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -146,7 +146,7 @@ def generate_cassette_name(path: str, method: str, body: bytes, vcr_cassette_pre
     )
 
 
-async def proxy_request(request: Request, vcr_cassettes_directory: str) -> Response:
+async def proxy_request(request: Request, vcr_cassettes_directory: str, vcr_ci_mode: bool) -> Response:
     path = request.match_info["path"]
     if request.query_string:
         path = path + "?" + request.query_string
@@ -159,15 +159,23 @@ async def proxy_request(request: Request, vcr_cassettes_directory: str) -> Respo
     if provider not in PROVIDER_BASE_URLS:
         return Response(body=f"Unsupported provider: {provider}", status=400)
 
-    target_url = url_path_join(PROVIDER_BASE_URLS[provider], remaining_path)
-
-    headers = {key: value for key, value in request.headers.items() if key != "Host"}
-
     body_bytes = await request.read()
 
     vcr_cassette_prefix = request.pop("vcr_cassette_prefix", None)
     cassette_name = generate_cassette_name(path, request.method, body_bytes, vcr_cassette_prefix)
     cassette_file_name = f"{cassette_name}.yaml"
+    cassette_file_path = os.path.join(vcr_cassettes_directory, provider, cassette_file_name)
+    cassette_exists = os.path.exists(cassette_file_path)
+
+    if vcr_ci_mode and not cassette_exists:
+        return Response(
+            body=f"Cassette {cassette_file_name} not found while running in CI mode. Please generate the cassette locally and commit it.",
+            status=404,
+        )
+
+    
+    target_url = url_path_join(PROVIDER_BASE_URLS[provider], remaining_path)
+    headers = {key: value for key, value in request.headers.items() if key != "Host"}
 
     request_kwargs: Dict[str, Any] = {
         "method": request.method,
@@ -179,9 +187,7 @@ async def proxy_request(request: Request, vcr_cassettes_directory: str) -> Respo
         "stream": True,
     }
 
-    if provider in AWS_SERVICES and not os.path.exists(
-        os.path.join(vcr_cassettes_directory, provider, cassette_file_name)
-    ):
+    if provider in AWS_SERVICES and not cassette_exists:
         if not AWS_SECRET_ACCESS_KEY:
             return Response(
                 body="AWS_SECRET_ACCESS_KEY environment variable not set for aws signature recalculation",

--- a/releasenotes/notes/vcr-ci-mode-99dbd2940fff8d7a.yaml
+++ b/releasenotes/notes/vcr-ci-mode-99dbd2940fff8d7a.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    vcr: adds a new `--vcr-ci-mode` flag and accompanying `VCR_CI_MODE` environment variable that, when set to `true` (defaults to `false`), will throw a 404 error if a cassette is not found in CI mode to ensure that all cassettes are generated locally and committed.
+    vcr: adds a new ``--vcr-ci-mode`` flag and accompanying ``VCR_CI_MODE`` environment variable that, when set to ``true`` (defaults to ``false``), will throw a 404 error if a cassette is not found in CI mode to ensure that all cassettes are generated locally and committed.

--- a/releasenotes/notes/vcr-ci-mode-99dbd2940fff8d7a.yaml
+++ b/releasenotes/notes/vcr-ci-mode-99dbd2940fff8d7a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    vcr: adds a new `--vcr-ci-mode` flag and accompanying `VCR_CI_MODE` environment variable that, when set to `true` (defaults to `false`), will throw a 404 error if a cassette is not found in CI mode to ensure that all cassettes are generated locally and committed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,11 @@ def snapshot_server_cassettes_directory() -> Generator[str, None, None]:
 
 
 @pytest.fixture
+def vcr_ci_mode() -> Generator[bool, None, None]:
+    yield False
+
+
+@pytest.fixture
 async def agent_app(
     aiohttp_server,
     agent_enabled_checks,
@@ -126,6 +131,7 @@ async def agent_app(
     snapshot_removed_attrs,
     snapshot_regex_placeholders,
     snapshot_server_cassettes_directory,
+    vcr_ci_mode,
 ):
     app = await aiohttp_server(
         make_app(
@@ -142,6 +148,7 @@ async def agent_app(
             snapshot_removed_attrs,
             snapshot_regex_placeholders,
             snapshot_server_cassettes_directory,
+            vcr_ci_mode,
         )
     )
     yield app


### PR DESCRIPTION
Lets the VCR 3rd party API proxy run in "CI mode", which will return a 404 for cassette files that are not found in the designated vcr cassette directory. This will ensure that, if enabled for CI for a given repository, that all cassettes are generated locally, and there are no unintended side effects from missing cassettes.

This flag defaults to `false`. I've also separated it from the `--snapshot-ci-mode` flag, but we could easily consolidate if we wanted with backwards compatibility. Just didn't want to make too many code changes unrelated to the vcr aspect of the testagent.