### PR TITLE
[crashtracking] Add errorsintake proxy endpoint

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -329,6 +329,7 @@ class Agent:
             "/evp_proxy/v2/api/v2/llmobs",
             "/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric",
             "/evp_proxy/v2/api/intake/llm-obs/v2/eval-metric",
+            "/evp_proxy/v4/api/v2/errorsintake",
         ]
 
         # Note that sessions are not cleared at any point since we don't know
@@ -801,6 +802,9 @@ class Agent:
     async def handle_evp_proxy_v2_llmobs_eval_metric(self, request: Request) -> web.Response:
         return web.HTTPOk()
 
+    async def handle_evp_proxy_v4_api_v2_errorsintake(self, request: Request) -> web.Response:
+        return web.HTTPOk()
+
     async def handle_put_tested_integrations(self, request: Request) -> web.Response:
         # we need to store the request manually since this is not a real DD agent endpoint
         await self._store_request(request)
@@ -878,6 +882,7 @@ class Agent:
                     "/v0.7/config",
                     "/tracer_flare/v1",
                     "/evp_proxy/v2/",
+                    "/evp_proxy/v4/",
                 ],
                 "feature_flags": [],
                 "config": {},
@@ -1417,6 +1422,7 @@ class Agent:
                 "/evp_proxy/v2/api/v2/llmobs": self.handle_evp_proxy_v2_api_v2_llmobs,
                 "/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric": self.handle_evp_proxy_v2_llmobs_eval_metric,
                 "/evp_proxy/v2/api/intake/llm-obs/v2/eval-metric": self.handle_evp_proxy_v2_llmobs_eval_metric,
+                "/evp_proxy/v4/api/v2/errorsintake": self.handle_evp_proxy_v4_api_v2_errorsintake,
                 "/info": self.handle_info,
                 # Test endpoints
                 "/test/session/start": self.handle_session_start,
@@ -1615,6 +1621,7 @@ def make_app(
             web.post("/evp_proxy/v2/api/v2/llmobs", agent.handle_evp_proxy_v2_api_v2_llmobs),
             web.post("/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric", agent.handle_evp_proxy_v2_llmobs_eval_metric),
             web.post("/evp_proxy/v2/api/intake/llm-obs/v2/eval-metric", agent.handle_evp_proxy_v2_llmobs_eval_metric),
+            web.post("/evp_proxy/v4/api/v2/errorsintake", agent.handle_evp_proxy_v4_api_v2_errorsintake),
             web.get("/info", agent.handle_info),
             web.get("/test/session/start", agent.handle_session_start),
             web.get("/test/session/clear", agent.handle_session_clear),

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -1129,6 +1129,7 @@ class Agent:
                 self.handle_v1_tracer_flare,
                 self.handle_evp_proxy_v2_api_v2_llmobs,
                 self.handle_evp_proxy_v2_llmobs_eval_metric,
+                self.handle_evp_proxy_v4_api_v2_errorsintake,
                 self.handle_v1_logs,
                 self.handle_v1_metrics,
             ):

--- a/releasenotes/notes/add-errors-intake-proxy-endpoint-7e0f31d72a130f1a.yaml
+++ b/releasenotes/notes/add-errors-intake-proxy-endpoint-7e0f31d72a130f1a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for `/evp_proxy/v4/api/v2/errorsintake` endpoint to collect errors intake payload requests.

--- a/releasenotes/notes/add-errors-intake-proxy-endpoint-7e0f31d72a130f1a.yaml
+++ b/releasenotes/notes/add-errors-intake-proxy-endpoint-7e0f31d72a130f1a.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add support for `/evp_proxy/v4/api/v2/errorsintake` endpoint to collect errors intake payload requests.
+    Add support for ``/evp_proxy/v4/api/v2/errorsintake`` endpoint to collect errors intake payload requests.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -105,6 +105,7 @@ async def test_info(agent):
             "/v0.7/config",
             "/tracer_flare/v1",
             "/evp_proxy/v2/",
+            "/evp_proxy/v4/",
         ],
         "peer_tags": [
             "db.name",
@@ -512,6 +513,16 @@ async def test_post_unknown_settings(
     text = await resp.text()
     assert text == "Unknown key: 'dummy_setting'"
     assert "dummy_setting" not in agent.app
+
+
+async def test_evp_proxy_v4_api_v2_errorsintake(agent):
+    resp = await agent.post("/evp_proxy/v4/api/v2/errorsintake", data='{"key": "value"}')
+    assert resp.status == 200, await resp.text()
+
+    resp = await agent.get("/test/session/requests")
+    assert resp.status == 200
+    reqs = await resp.json()
+    assert len(reqs) == 1
 
 
 async def test_evp_proxy_v2_api_v2_llmobs(agent):


### PR DESCRIPTION
Crashtracking wants to send crash reports to errors intake through the agent proxy. We should be able to test this behavior in unit tests in each of the runtime tracers