### PR TITLE
Ignore Transfer-Encoding header in VCR requests

### DIFF
--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -465,7 +465,8 @@ async def proxy_request(
         )
 
     target_url = _url_path_join(provider_base_urls[provider], remaining_path)
-    headers = {key: value for key, value in request.headers.items() if key != "Host"}
+    skip_headers = {"host", "transfer-encoding"}
+    headers = {key: value for key, value in request.headers.items() if not (key.lower() in skip_headers)}
 
     request_kwargs: Dict[str, Any] = {
         "method": request.method,

--- a/releasenotes/notes/ignore-transfer-encoding-header-3b22699615356f91.yaml
+++ b/releasenotes/notes/ignore-transfer-encoding-header-3b22699615356f91.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Ignores the Transfer-Encoding header in proxied vcr requests, forwarding this header can lead to failures in 
+    downstream services. 

--- a/tests/test_vcr_proxy.py
+++ b/tests/test_vcr_proxy.py
@@ -276,3 +276,10 @@ async def test_vcr_proxy_converts_legacy_vcr_cassette_to_json(
     assert os.path.exists(os.path.join(vcr_cassettes_directory, "custom", cassette_file))
 
     assert not os.path.exists(vcr_legacy_cassette)
+
+
+async def test_vcr_proxy_with_chunked_request(agent: TestClient[Any, Any], vcr_cassettes_directory: str) -> None:
+    resp = await agent.post("/vcr/custom/serve", json={"foo": "bar"}, chunked=True)
+
+    assert resp.status == 200
+    assert await resp.text() == "OK"


### PR DESCRIPTION
This change ensures that chunked transfer-encoding headers are removed when proxying requests through the VCR proxy. Since the requests are de-chunked during proxying, forwarding this header can lead to inconsistencies and failures in downstream services. This update prevents that header from being propagated to avoid such issues.