### PR TITLE
feat(info): Configurable client_drop_p0s setting

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -897,7 +897,7 @@ class Agent:
                 ],
                 "feature_flags": [],
                 "config": {},
-                "client_drop_p0s": True,
+                "client_drop_p0s": request.app["client_drop_p0s"],
                 # Just a random selection of some peer_tags to aggregate on for testing, not exhaustive
                 "peer_tags": ["db.name", "mongodb.db", "messaging.system"],
                 "span_events": True,  # Advertise support for the top-level Span field for Span Events
@@ -1601,6 +1601,7 @@ def make_app(
     vcr_ci_mode: bool,
     vcr_provider_map: str,
     vcr_ignore_headers: str,
+    client_drop_p0s: bool,
     enable_web_ui: bool = False,
 ) -> web.Application:
     agent = Agent()
@@ -1707,6 +1708,7 @@ def make_app(
     app["snapshot_removed_attrs"] = snapshot_removed_attrs
     app["snapshot_regex_placeholders"] = snapshot_regex_placeholders
     app["vcr_cassettes_directory"] = vcr_cassettes_directory
+    app["client_drop_p0s"] = client_drop_p0s
     return app
 
 
@@ -1975,6 +1977,12 @@ def main(args: Optional[List[str]] = None) -> None:
         help=("Will change the test agent to send [200: Ok] responses instead of error responses back to the tracer."),
     )
     parser.add_argument(
+        "--client-drop-p0s",
+        type=bool,
+        default=os.environ.get("DD_APM_CLIENT_DROP_P0S", True),
+        help=("Controls the client_drop_p0s feature flag advertised in the /info endpoint."),
+    )
+    parser.add_argument(
         "--vcr-cassettes-directory",
         type=str,
         default=os.environ.get("VCR_CASSETTES_DIRECTORY", os.path.join(os.getcwd(), "vcr-cassettes")),
@@ -2056,6 +2064,7 @@ def main(args: Optional[List[str]] = None) -> None:
         vcr_ci_mode=parsed_args.vcr_ci_mode,
         vcr_provider_map=parsed_args.vcr_provider_map,
         vcr_ignore_headers=parsed_args.vcr_ignore_headers,
+        client_drop_p0s=parsed_args.client_drop_p0s,
         enable_web_ui=parsed_args.web_ui_port > 0,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,7 @@ async def agent_app(
             vcr_ci_mode=vcr_ci_mode,
             vcr_provider_map=vcr_provider_map,
             vcr_ignore_headers=vcr_ignore_headers,
+            client_drop_p0s=True,
         )
     )
     yield app

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -530,6 +530,38 @@ async def test_post_unknown_settings(
     assert "dummy_setting" not in agent.app
 
 
+async def test_client_drop_p0s_configuration(agent):
+    resp = await agent.get("/info")
+    assert resp.status == 200
+    info = await resp.json()
+    assert info["client_drop_p0s"] is True
+    assert agent.app["client_drop_p0s"] is True
+
+    resp = await agent.post(
+        "/test/settings",
+        data='{ "client_drop_p0s": false }',
+    )
+    assert resp.status == 202, await resp.text()
+    assert agent.app["client_drop_p0s"] is False
+
+    resp = await agent.get("/info")
+    assert resp.status == 200
+    info = await resp.json()
+    assert info["client_drop_p0s"] is False
+
+    resp = await agent.post(
+        "/test/settings",
+        data='{ "client_drop_p0s": true }',
+    )
+    assert resp.status == 202, await resp.text()
+    assert agent.app["client_drop_p0s"] is True
+
+    resp = await agent.get("/info")
+    assert resp.status == 200
+    info = await resp.json()
+    assert info["client_drop_p0s"] is True
+
+
 async def test_evp_proxy_v4_api_v2_errorsintake(agent):
     resp = await agent.post("/evp_proxy/v4/api/v2/errorsintake", data='{"key": "value"}')
     assert resp.status == 200, await resp.text()


### PR DESCRIPTION
This field was hardcoded in the /info response. This setting allows the value to be configurable, useful for system tests.