### PR TITLE
Enrich tool span names with intent in Claude hooks

### DIFF
--- a/releasenotes/notes/claude-hooks-tool-intent-35bd56ac8140d0ec.yaml
+++ b/releasenotes/notes/claude-hooks-tool-intent-35bd56ac8140d0ec.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    claude hooks: Enrich tool and subagent span names with human-readable intent extracted from tool input (e.g., "Read - claude_hooks.py" instead of "Read"). Adds ``tool_name`` tag for faceting.

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -98,7 +98,7 @@ async def test_hook_tool_use_creates_tool_span(agent):
     assert len(tool_spans) == 1
 
     tool = tool_spans[0]
-    assert tool["name"] == "Bash"
+    assert tool["name"] == "Bash - ls"
     assert tool["duration"] >= 0
     assert "ls" in tool["meta"]["input"]["value"]
     assert "file1.txt" in tool["meta"]["output"]["value"]


### PR DESCRIPTION
## Summary

- Tool spans now display human-readable intent extracted from tool_input (e.g., "Read - claude_hooks.py" instead of "Read")
- Subagent spans show the Task tool's description (e.g., "Explore - Exercise Grep tool")
- Adds `tool_name` tag for faceting

   | Tool | Logic |
   |------|-------|
   | Bash | `description` if present, else `command[:80]` |
   | Read, Write, Edit | `os.path.basename(file_path)` |
   | Glob | `pattern` |
   | Grep | `"pattern" in basename(path)` if path, else `"pattern"` |
   | Task | `description` |
   | WebFetch | `urlparse(url).hostname` |
   | WebSearch | `query` |
   | TaskCreate | `subject` |
   | TaskUpdate | `status` |
   | Fallback | first non-empty from `description`, `query`, `pattern`, `file_path`, `command`, `subject` - truncated |

**Note on Bash `description`**: The `description` parameter on Bash tool calls is optional - Claude (the LLM) decides whether to include it. Different models and contexts produce different behavior (e.g., some users never see descriptions). When `description` is absent, the intent falls back to the truncated `command` string. All other tools use structural fields (`file_path`, `pattern`, `url`, etc.) that are always present.

## Sample examples

| Tool | Span name |
|---|---|
| Bash | `Bash - Test Bash intent extraction` |
| Read | `Read - setup.cfg` |
| Write | `Write - intent-test-scratch.txt` |
| Edit | `Edit - intent-test-scratch.txt` |
| Glob | `Glob - ddapm_test_agent/claude_*.py` |
| Grep | `Grep - "_extract_intent" in claude_hooks.py` |
| Task | `Explore - Exercise Task subagent tool` |
| WebFetch | `WebFetch - httpbin.org` |
| WebSearch | `WebSearch - Datadog LLM Observability documentation 2026` |
| TaskCreate | `TaskCreate - Sample task to verify TaskCreate intent` |
| TaskUpdate | `TaskUpdate - completed` |

<img width="1492" height="889" alt="image" src="https://github.com/user-attachments/assets/54b9c5c7-1bd0-4cfc-bdb8-c6afadafcf26" />



## Test plan

- [x] All 10 existing tests pass
- [x] Verified enriched names in live waterfall UI for all 11 tool types