### PR TITLE
fix(lapdog): include token aggregations in event platform responses

### DIFF
--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -522,6 +522,18 @@ def _build_trace_aggregates(
         result[tid] = {
             "num_evaluations_failed": num_evaluations_failed,
             "number_of_errors": number_of_errors,
+            "input_tokens": sum(
+                span.get("metrics", {}).get("input_tokens", 0)
+                for span in trace_spans
+            ),
+            "output_tokens": sum(
+                span.get("metrics", {}).get("output_tokens", 0)
+                for span in trace_spans
+            ),
+            "total_tokens": sum(
+                span.get("metrics", {}).get("total_tokens", 0)
+                for span in trace_spans
+            ),
             "estimated_total_cost": sum(
                 span.get("metrics", {}).get("estimated_total_cost", 0)
                 for span in trace_spans
@@ -631,7 +643,6 @@ def build_event_platform_list_response(
             "service": service,
             "env": env,
             "trace": {
-                "estimated_total_cost": 0,
                 **trace_aggregates.get(trace_id, {}),
             },
             "evaluation": span.get("evaluation", {}),

--- a/releasenotes/notes/token-aggregation-a5db1336357fea88.yaml
+++ b/releasenotes/notes/token-aggregation-a5db1336357fea88.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Include token aggregation fields in LLM Observability event platform responses.

--- a/tests/test_llmobs_event_platform.py
+++ b/tests/test_llmobs_event_platform.py
@@ -527,6 +527,84 @@ async def test_trace_estimated_total_cost_aggregated_across_spans(agent):
         assert event["event"]["custom"]["trace"]["estimated_total_cost"] == 15_000_000
 
 
+async def test_trace_token_metrics_aggregated_across_spans(agent):
+    """@trace.input_tokens, output_tokens, and total_tokens are summed across all spans in the trace."""
+    span_a = _create_span_for_facet_test(1, 400)
+    span_a["metrics"] = {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
+    span_b = _create_span_for_facet_test(2, 400)
+    span_b["metrics"] = {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15}
+    await _submit_spans_for_facet_test(agent, [span_a, span_b])
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": ""}, "limit": 50}},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+
+    for event in data["result"]["events"]:
+        trace = event["event"]["custom"]["trace"]
+        assert trace["input_tokens"] == 15
+        assert trace["output_tokens"] == 30
+        assert trace["total_tokens"] == 45
+
+
+async def test_trace_level_fields_populated_for_session_query(agent):
+    """Trace-level token and cost fields are present for session-id-filtered queries (non-static app path)."""
+    now = int(time.time() * 1_000_000_000)
+    root_span = {
+        "span_id": "span-sess-root",
+        "trace_id": "trace-sess-1",
+        "parent_id": "undefined",
+        "name": "root",
+        "status": "ok",
+        "start_ns": now,
+        "duration": 1_000_000_000,
+        "session_id": "session-xyz",
+        "tags": ["session_id:session-xyz"],
+        "meta": {"span": {"kind": "agent"}},
+        "metrics": {
+            "input_tokens": 8,
+            "output_tokens": 12,
+            "total_tokens": 20,
+            "estimated_total_cost": 7_000_000,
+        },
+    }
+    child_span = {
+        "span_id": "span-sess-child",
+        "trace_id": "trace-sess-1",
+        "parent_id": "span-sess-root",
+        "name": "llm-call",
+        "status": "ok",
+        "start_ns": now,
+        "duration": 500_000_000,
+        "session_id": "session-xyz",
+        "tags": ["session_id:session-xyz"],
+        "meta": {"span": {"kind": "llm"}},
+        "metrics": {
+            "input_tokens": 4,
+            "output_tokens": 6,
+            "total_tokens": 10,
+            "estimated_total_cost": 3_000_000,
+        },
+    }
+    await _submit_spans_for_facet_test(agent, [root_span, child_span])
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": "@parent_id:undefined @session_id:session-xyz"}, "limit": 50}},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["hitCount"] == 1
+
+    trace = data["result"]["events"][0]["event"]["custom"]["trace"]
+    assert trace["input_tokens"] == 12
+    assert trace["output_tokens"] == 18
+    assert trace["total_tokens"] == 30
+    assert trace["estimated_total_cost"] == 10_000_000
+
+
 async def test_facet_range_info_with_filter_query(agent):
     """Test facet_range_info respects filter query."""
     spans = [


### PR DESCRIPTION
We added support for aggregating estimated cost, but not input/output/total tokens - this PR fixes that.