### PR TITLE
feat(vcr): allow for json body normalizations when recording cassettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ curl -X POST 'http://127.0.0.1:9126/vcr/provider1/some/path'
 
 To ignore headers in recorded cassettes, you can use the `--vcr-ignore-headers` flag or `VCR_IGNORE_HEADERS` environment variable. The list should take the form of `header1,header2,header3`, and will be omitted from the recorded cassettes.
 
+#### Normalizing JSON bodies in recorded cassettes
+
+To normalize JSON bodies in recorded cassettes, you can use the `--vcr-json-body-normalizers` flag or `VCR_JSON_BODY_NORMALIZERS` environment variable. The list should take the form of `json.path1,json.path2,json.path3`, and the values at those JSON paths will be replaced with a placeholder in the recorded cassettes. This is particularly useful for normalizing request bodies with dynamic values such as timestamps or ids.
+
 #### AWS Services
 AWS service proxying, specifically recording cassettes for the first time, requires a `AWS_SECRET_ACCESS_KEY` environment variable to be set for the container running the test agent. This is used to recalculate the AWS signature for the request, as the one generated client-side likely used `{test-agent-host}:{test-agent-port}/vcr/{aws-service}` as the host, and the signature will mismatch that on the actual AWS service.
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -1884,6 +1884,7 @@ def make_app(
     vcr_ci_mode: bool,
     vcr_provider_map: str,
     vcr_ignore_headers: str,
+    vcr_json_body_normalizers: str,
     dd_site: str,
     dd_api_key: Optional[str],
     disable_llmobs_data_forwarding: bool,
@@ -1965,13 +1966,7 @@ def make_app(
             web.options("/test/settings", agent.handle_settings),
             web.post("/vcr/test/start", agent.check_vcr_proxy_suffix),
             web.post("/vcr/test/stop", agent.unset_vcr_proxy_suffix),
-            web.route(
-                "*",
-                "/vcr/{path:.*}",
-                lambda request: proxy_request(
-                    request, vcr_cassettes_directory, vcr_ci_mode, vcr_provider_map, vcr_ignore_headers
-                ),
-            ),
+            web.route("*", "/vcr/{path:.*}", proxy_request),
         ]
     )
 
@@ -2022,6 +2017,10 @@ def make_app(
     app["snapshot_removed_attrs"] = snapshot_removed_attrs
     app["snapshot_regex_placeholders"] = snapshot_regex_placeholders
     app["vcr_cassettes_directory"] = vcr_cassettes_directory
+    app["vcr_ci_mode"] = vcr_ci_mode
+    app["vcr_provider_map"] = vcr_provider_map
+    app["vcr_ignore_headers"] = vcr_ignore_headers
+    app["vcr_json_body_normalizers"] = vcr_json_body_normalizers
     app["dd_site"] = dd_site
     app["dd_api_key"] = dd_api_key
     app["disable_llmobs_data_forwarding"] = disable_llmobs_data_forwarding
@@ -2317,6 +2316,12 @@ def main(args: Optional[List[str]] = None) -> None:
         help="Comma-separated list of headers to ignore when recording VCR cassettes.",
     )
     parser.add_argument(
+        "--vcr-json-body-normalizers",
+        type=str,
+        default=os.environ.get("VCR_NORMALIZERS", ""),
+        help="Comma-separated list of normalizers to apply when recording VCR cassettes.",
+    )
+    parser.add_argument(
         "--web-ui-port",
         type=int,
         default=int(os.environ.get("WEB_UI_PORT", 0)),
@@ -2398,6 +2403,7 @@ def main(args: Optional[List[str]] = None) -> None:
         vcr_ci_mode=parsed_args.vcr_ci_mode,
         vcr_provider_map=parsed_args.vcr_provider_map,
         vcr_ignore_headers=parsed_args.vcr_ignore_headers,
+        vcr_json_body_normalizers=parsed_args.vcr_json_body_normalizers,
         dd_site=parsed_args.dd_site,
         dd_api_key=parsed_args.dd_api_key,
         disable_llmobs_data_forwarding=parsed_args.disable_llmobs_data_forwarding,

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -2318,7 +2318,7 @@ def main(args: Optional[List[str]] = None) -> None:
     parser.add_argument(
         "--vcr-json-body-normalizers",
         type=str,
-        default=os.environ.get("VCR_NORMALIZERS", ""),
+        default=os.environ.get("VCR_JSON_BODY_NORMALIZERS", ""),
         help="Comma-separated list of normalizers to apply when recording VCR cassettes.",
     )
     parser.add_argument(

--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -170,28 +170,48 @@ def _get_custom_vcr_providers(vcr_provider_map: str) -> Dict[str, str]:
     )
 
 
-def _normalize_multipart_body(body: bytes) -> str:
+def _get_vcr_normalizers(vcr_normalizers: str) -> List[str]:
+    return [normalizer.strip() for normalizer in vcr_normalizers.split(",") if normalizer.strip()]
+
+
+def _apply_json_path_normalizer(body_dict: Dict[str, Any], path: str, placeholder: str = "<normalized>") -> None:
+    """Set the value at a dot-notation path in a nested dict to a placeholder string."""
+    parts = path.split(".")
+    obj: Any = body_dict
+    for part in parts[:-1]:
+        if not isinstance(obj, dict) or part not in obj:
+            return
+        obj = obj[part]
+    if isinstance(obj, dict) and parts[-1] in obj:
+        obj[parts[-1]] = placeholder
+
+
+def _normalize_body(body: bytes, vcr_json_body_normalizers: Optional[List[str]] = None) -> str:
     if not body:
         return ""
 
     try:
         body_str = body.decode("utf-8")
-
-        for pattern, replacement in NORMALIZERS:
-            body_str = re.sub(pattern, replacement, body_str)
-
-        return body_str
     except UnicodeDecodeError:
         try:
             body_str = body.decode("latin-1")
-
-            for pattern, replacement in NORMALIZERS:
-                body_str = re.sub(pattern, replacement, body_str)
-
-            return body_str
         except Exception:
             hex_digest = hashlib.sha256(body).hexdigest()[:8]
             return f"[binary_data_{hex_digest}]"
+
+    for pattern, replacement in NORMALIZERS:
+        body_str = re.sub(pattern, replacement, body_str)
+
+    if vcr_json_body_normalizers:
+        try:
+            body_dict = json.loads(body_str)
+            for path in vcr_json_body_normalizers:
+                _apply_json_path_normalizer(body_dict, path)
+            body_str = json.dumps(body_dict)
+        except json.JSONDecodeError:
+            pass
+
+    return body_str
 
 
 def _decode_body(body: bytes) -> str:
@@ -243,8 +263,14 @@ def _parse_authorization_header(auth_header: str) -> Dict[str, str]:
     return parsed
 
 
-def _generate_cassette_name(path: str, method: str, body: bytes, vcr_cassette_prefix: Optional[str]) -> str:
-    decoded_body = _normalize_multipart_body(body) if body else ""
+def _generate_cassette_name(
+    path: str,
+    method: str,
+    body: bytes,
+    vcr_cassette_prefix: Optional[str],
+    vcr_json_body_normalizers: Optional[List[str]] = None,
+) -> str:
+    decoded_body = _normalize_body(body, vcr_json_body_normalizers) if body else ""
     try:
         parsed_body = json.loads(decoded_body) if decoded_body else {}
     except json.JSONDecodeError:
@@ -435,8 +461,14 @@ async def _request(
 
 
 async def proxy_request(
-    request: Request, vcr_cassettes_directory: str, vcr_ci_mode: bool, vcr_provider_map: str, vcr_ignore_headers: str
+    request: Request
 ) -> Response:
+    vcr_cassettes_directory: str = request.app["vcr_cassettes_directory"]
+    vcr_ci_mode: bool = request.app["vcr_ci_mode"]
+    vcr_provider_map: str = request.app["vcr_provider_map"]
+    vcr_ignore_headers: str = request.app["vcr_ignore_headers"]
+    vcr_json_body_normalizers: str = request.app["vcr_json_body_normalizers"]
+
     provider_base_urls = PROVIDER_BASE_URLS.copy()
     provider_base_urls.update(_get_custom_vcr_providers(vcr_provider_map))
 
@@ -455,7 +487,13 @@ async def proxy_request(
     body_bytes = await request.read()
 
     vcr_cassette_prefix = request.pop("vcr_cassette_prefix", None)
-    cassette_name = _generate_cassette_name(path, request.method, body_bytes, vcr_cassette_prefix)
+    cassette_name = _generate_cassette_name(
+        path,
+        request.method,
+        body_bytes,
+        vcr_cassette_prefix,
+        _get_vcr_normalizers(vcr_json_body_normalizers),
+    )
     cassette_file_path = os.path.join(vcr_cassettes_directory, provider, cassette_name)
     cassette_exists = len(glob(f"{cassette_file_path}.*")) > 0
 

--- a/releasenotes/notes/vcr-body-normalization-0e8a3fcfb7ca3077.yaml
+++ b/releasenotes/notes/vcr-body-normalization-0e8a3fcfb7ca3077.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    vcr: Add support for normalizing parts of JSON request bodies when recording requests via ``--vcr-json-body-normalizers`` or ``VCR_JSON_BODY_NORMALIZERS``. This option should take a comma-separated list of JSON paths to normalize, e.g. ``request.user.id``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,11 @@ def vcr_ignore_headers() -> Generator[str, None, None]:
 
 
 @pytest.fixture
+def vcr_json_body_normalizers() -> Generator[str, None, None]:
+    yield ""
+
+
+@pytest.fixture
 def dd_site() -> Generator[str, None, None]:
     yield "datadoghq.com"
 
@@ -172,6 +177,7 @@ async def agent_app(
     vcr_ci_mode,
     vcr_provider_map,
     vcr_ignore_headers,
+    vcr_json_body_normalizers,
     dd_site,
     dd_api_key,
     disable_llmobs_data_forwarding,
@@ -194,6 +200,7 @@ async def agent_app(
             vcr_ci_mode=vcr_ci_mode,
             vcr_provider_map=vcr_provider_map,
             vcr_ignore_headers=vcr_ignore_headers,
+            vcr_json_body_normalizers=vcr_json_body_normalizers,
             dd_site=dd_site,
             dd_api_key=dd_api_key,
             disable_llmobs_data_forwarding=disable_llmobs_data_forwarding,

--- a/tests/test_vcr_proxy.py
+++ b/tests/test_vcr_proxy.py
@@ -115,6 +115,11 @@ async def vcr_test_name(agent: TestClient[Any, Any]) -> AsyncGenerator[None, Non
 
 
 @pytest.fixture
+def vcr_json_body_normalizers() -> Generator[str, None, None]:
+    yield "dummy_id,metadata.dummy_id"
+
+
+@pytest.fixture
 def vcr_legacy_cassette(vcr_cassettes_directory: str) -> Generator[str, None, None]:
     cassette_name = _generate_cassette_name("custom/serve", "POST", b'{"foo": "bar"}', None)
     os.makedirs(os.path.join(vcr_cassettes_directory, "custom"), exist_ok=True)
@@ -285,3 +290,56 @@ async def test_vcr_proxy_with_chunked_request(agent: TestClient[Any, Any], vcr_c
 
     assert resp.status == 200
     assert await resp.text() == "OK"
+
+
+async def test_vcr_proxy_normalizes_json_field_to_single_cassette(
+    agent: TestClient[Any, Any], vcr_cassettes_directory: str
+) -> None:
+    resp = await agent.post("/vcr/custom/serve", json={"foo": "bar", "dummy_id": "aaa-111"})
+
+    assert resp.status == 200
+    assert await resp.text() == "OK"
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 1
+
+    resp = await agent.post("/vcr/custom/serve", json={"foo": "bar", "dummy_id": "bbb-222"})
+
+    assert resp.status == 200
+    assert await resp.text() == "OK"
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 1  # same cassette reused despite different dummy_id
+
+
+async def test_vcr_proxy_normalizer_does_not_collapse_other_body_differences(
+    agent: TestClient[Any, Any], vcr_cassettes_directory: str
+) -> None:
+    resp = await agent.post("/vcr/custom/serve", json={"foo": "bar", "dummy_id": "aaa-111"})
+
+    assert resp.status == 200
+
+    resp = await agent.post("/vcr/custom/serve", json={"foo": "DIFFERENT", "dummy_id": "bbb-222"})
+
+    assert resp.status == 200
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 2  # different foo values still produce separate cassettes
+
+
+async def test_vcr_proxy_normalizes_nested_json_field_to_single_cassette(
+    agent: TestClient[Any, Any], vcr_cassettes_directory: str
+) -> None:
+    resp = await agent.post("/vcr/custom/serve", json={"metadata": {"dummy_id": "aaa-111", "stable": "x"}})
+
+    assert resp.status == 200
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 1
+
+    resp = await agent.post("/vcr/custom/serve", json={"metadata": {"dummy_id": "bbb-222", "stable": "x"}})
+
+    assert resp.status == 200
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 1  # same cassette despite different nested dummy_id


### PR DESCRIPTION
Specifying `--vcr-json-body-normalizers` or `VCR_JSON_BODY_NORMALIZERS` will normalize all (nested) fields of each JSON request body when recording a cassette. This is so random things like generated IDs, dates, etc. that might not want to be counted towards a new cassette hash won't be counted.