### PR TITLE
feat(lapdog): add pi context metadata

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -59,6 +59,7 @@ from .claude_hooks import ClaudeHooksAPI
 from .claude_hooks import write_claude_code_hooks
 from .claude_link_tracker import ClaudeLinkTracker
 from .claude_proxy import ClaudeProxyAPI
+from .pi_hooks import PiHooksAPI
 from .integration import Integration
 from .llmobs_event_platform import LLMObsEventPlatformAPI
 from .logs import LOGS_ENDPOINT
@@ -1985,6 +1986,9 @@ def make_app(
 
     claude_proxy_api = ClaudeProxyAPI(hooks_api=claude_hooks_api, link_tracker=claude_link_tracker)
     app.add_routes(claude_proxy_api.get_routes())
+
+    pi_hooks_api = PiHooksAPI(hooks_api=claude_hooks_api)
+    app.add_routes(pi_hooks_api.get_routes())
 
     async def _cleanup_claude_proxy(app: web.Application) -> None:
         await claude_proxy_api.close()

--- a/ddapm_test_agent/claude_cost_tracker.py
+++ b/ddapm_test_agent/claude_cost_tracker.py
@@ -153,6 +153,44 @@ def _find_tiers(model_id: str) -> Optional[List[_PriceTier]]:
     return None
 
 
+# 1 nanodollar = 1e-9 USD
+_NANODOLLARS_PER_DOLLAR = 1_000_000_000
+
+
+def cost_from_provider_usage(
+    cost: Dict[str, float],
+) -> Dict[str, int]:
+    """Convert provider-reported cost (in USD) to nanodollar cost metrics.
+
+    The *cost* dict is expected to have keys matching the pi extension's format::
+
+        {"input": 0.00015, "output": 0.03, "cacheRead": 0.028, "cacheWrite": 0.001, "total": 0.059}
+
+    Returns a dict with the same metric keys as ``compute_cost_metrics``.
+    """
+    def _to_nano(v: float) -> int:
+        return int(round(v * _NANODOLLARS_PER_DOLLAR))
+
+    non_cached_input = _to_nano(cost.get("input", 0.0))
+    cache_write = _to_nano(cost.get("cacheWrite", 0.0))
+    cache_read = _to_nano(cost.get("cacheRead", 0.0))
+    output = _to_nano(cost.get("output", 0.0))
+    input_cost = non_cached_input + cache_write + cache_read
+    total = _to_nano(cost.get("total", 0.0))
+    # Prefer the provider's total if available; fall back to sum of parts.
+    if total == 0 and input_cost + output > 0:
+        total = input_cost + output
+
+    return {
+        "estimated_non_cached_input_cost": non_cached_input,
+        "estimated_cache_write_input_cost": cache_write,
+        "estimated_cache_read_input_cost": cache_read,
+        "estimated_input_cost": input_cost,
+        "estimated_output_cost": output,
+        "estimated_total_cost": total,
+    }
+
+
 def compute_cost_metrics(
     model_id: str,
     non_cached_input_tokens: int,

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -148,6 +148,7 @@ class SessionState:
         self.pending_tools: Dict[str, PendingToolSpan] = {}
         self.user_prompts: List[str] = []
         self.model: str = ""
+        self.model_provider: str = ""
         self.tools_used: Set[str] = set()
         self.root_span_emitted: bool = False
         # Deferred agent spans waiting for PostToolUse(Task) to provide their output.
@@ -950,7 +951,6 @@ class ClaudeHooksAPI:
             return None
         last_input_tokens = last_span.get("metrics", {}).get("input_tokens", 0)
         primary_model = last_span.get("meta", {}).get("model_name", "")
-        window = _get_context_limit(primary_model)
         delta_tokens = max(last_input_tokens - first_input_tokens, 0)
         # Extract sections from first and last LLM spans' context_breakdown
         first_span = next(
@@ -964,6 +964,12 @@ class ClaudeHooksAPI:
         last_breakdown = (
             last_span.get("meta", {}).get("metadata", {}).get("_dd", {}).get("context_breakdown")
         )
+        window = 0
+        if isinstance(last_breakdown, dict):
+            window = int(last_breakdown.get("context_window_size", 0) or 0)
+        if window <= 0:
+            window = _get_context_limit(primary_model)
+
         context_delta: Dict[str, Any] = {
             "first_input_tokens": first_input_tokens,
             "last_input_tokens": last_input_tokens,

--- a/ddapm_test_agent/lapdog_cli.py
+++ b/ddapm_test_agent/lapdog_cli.py
@@ -1,4 +1,4 @@
-"""CLI for lapdog subcommands: run, stop, status, claude."""
+"""CLI for lapdog subcommands"""
 import argparse
 import os
 import shutil
@@ -13,14 +13,15 @@ from typing import Tuple
 import requests
 
 
-LAPDOG_COMMANDS = ["start", "stop", "status", "claude"]
+LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi"]
 LAPDOG_USAGE = (
     "Usage: lapdog [OPTIONS] <command> [command-args...]\n"
     "Options must appear before <command>. Arguments after <command> are forwarded.\n"
     "  run     Start lapdog (background)\n"
     "  stop    Stop lapdog (started by 'lapdog start' or 'lapdog claude')\n"
     "  status  Show lapdog status (from /info)\n"
-    "  claude  Start lapdog in background if needed, then launch Claude with intercept"
+    "  claude  Start lapdog in background if needed, then launch Claude with intercept\n"
+    "  pi      Start lapdog in background if needed, install extension, then launch pi"
 )
 
 
@@ -222,6 +223,38 @@ def cmd_status() -> None:
         sys.exit(1)
 
 
+def _start_lapdog_detached(port: int, forward_data: bool) -> None:
+    """Start lapdog in a forked child so it is not a child of the calling process.
+
+    After os.execv replaces the current process with pi/claude, lapdog must not
+    be a child of that process.  If it were, killing/restarting lapdog would
+    send SIGCHLD to the agent which can crash the runtime.  By forking first
+    and starting lapdog in the child, the child exits immediately after lapdog
+    is ready and lapdog gets re-parented to init/launchd — fully independent of
+    the process that will become pi/claude.
+    """
+    child_pid = os.fork()
+    if child_pid == 0:
+        # Child: start lapdog, wait for it to be ready, then exit.
+        try:
+            _start_lapdog(port, forward_data=forward_data)
+        except SystemExit:
+            # _start_lapdog may call sys.exit on failure
+            os._exit(1)
+        os._exit(0)
+
+    # Parent: wait for the intermediate child to finish.
+    _, status = os.waitpid(child_pid, 0)
+    if os.WIFEXITED(status) and os.WEXITSTATUS(status) != 0:
+        print("[lapdog] Failed to start lapdog in background.", file=sys.stderr)
+        sys.exit(1)
+
+    # Double-check lapdog is actually reachable.
+    if not _lapdog_alive():
+        print("[lapdog] Lapdog started but is not reachable.", file=sys.stderr)
+        sys.exit(1)
+
+
 def cmd_claude(sub_cmd_args: List[str], forward_data: bool) -> None:
     """Ensure lapdog is running in background, then launch Claude with intercept."""
     if not _lapdog_alive():
@@ -232,9 +265,96 @@ def cmd_claude(sub_cmd_args: List[str], forward_data: bool) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        _start_lapdog(port, forward_data=forward_data)
+        _start_lapdog_detached(port, forward_data=forward_data)
 
     _run_claude(sub_cmd_args)
+
+
+# ---------------------------------------------------------------------------
+# Pi extension management
+# ---------------------------------------------------------------------------
+
+_PI_GLOBAL_EXT_DIR = os.path.expanduser("~/.pi/agent/extensions")
+_PI_EXT_DEST = os.path.join(_PI_GLOBAL_EXT_DIR, "lapdog.ts")
+_PI_EXT_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "pi_lapdog_extension.ts")
+
+# Marker comment embedded in installed copies so we can identify our file.
+_PI_EXT_MARKER = "dd-apm-test-agent/pi_lapdog_extension"
+
+
+def _install_pi_extension(port: int) -> None:
+    """Copy the bundled lapdog extension into pi's global extensions directory.
+
+    The extension is patched with the resolved LAPDOG_URL so the user does not
+    need to set an environment variable when using a non-default port.
+    """
+    os.makedirs(_PI_GLOBAL_EXT_DIR, exist_ok=True)
+
+    if not os.path.isfile(_PI_EXT_SOURCE):
+        print(f"[lapdog] Extension source not found: {_PI_EXT_SOURCE}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(_PI_EXT_SOURCE, "r") as f:
+        source = f.read()
+
+    # Patch the default URL if using a non-standard port.
+    lapdog_url = f"http://localhost:{port}"
+    source = source.replace(
+        'const LAPDOG_URL = process.env.LAPDOG_URL || "http://localhost:8126";',
+        f'const LAPDOG_URL = process.env.LAPDOG_URL || "{lapdog_url}";',
+    )
+
+    with open(_PI_EXT_DEST, "w") as f:
+        f.write(source)
+
+    print(f"[lapdog] Installed pi extension → {_PI_EXT_DEST}")
+
+
+def _uninstall_pi_extension() -> None:
+    """Remove the lapdog extension if it was installed by us."""
+    if not os.path.isfile(_PI_EXT_DEST):
+        return
+    try:
+        with open(_PI_EXT_DEST, "r") as f:
+            content = f.read()
+        if _PI_EXT_MARKER not in content and "lapdog" not in content[:200]:
+            # Not our file — leave it alone.
+            return
+    except OSError:
+        pass
+    try:
+        os.remove(_PI_EXT_DEST)
+        print(f"[lapdog] Removed pi extension from {_PI_EXT_DEST}")
+    except OSError:
+        pass
+
+
+def _run_pi(args: Optional[List[str]] = None) -> None:
+    """Exec the pi binary, forwarding arguments.  Never returns."""
+    if args is None:
+        args = []
+    pi_bin = shutil.which("pi")
+    if not pi_bin:
+        print("[lapdog] 'pi' not found in PATH", file=sys.stderr)
+        sys.exit(1)
+    os.execv(pi_bin, [pi_bin] + args)
+
+
+def cmd_pi(sub_cmd_args: List[str], forward_data: bool) -> None:
+    """Ensure lapdog is running, install the pi extension, then launch pi."""
+    port = _resolved_port()
+
+    if not _lapdog_alive():
+        if _port_in_use(port):
+            print(
+                f"[lapdog] Port {port} is already in use. Stop the existing instance first (e.g. 'lapdog stop').",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        _start_lapdog_detached(port, forward_data=forward_data)
+
+    _install_pi_extension(port)
+    _run_pi(sub_cmd_args)
 
 
 def _parse_command(cmd_args: List[str]) -> Tuple[List[str], List[str]]:
@@ -295,6 +415,11 @@ def main() -> None:
         cmd_status()
     elif sub_cmd == "claude":
         cmd_claude(
+            sub_cmd_args=sub_cmd_args,
+            forward_data=lapdog_parsed_args.forward
+        )
+    elif sub_cmd == "pi":
+        cmd_pi(
             sub_cmd_args=sub_cmd_args,
             forward_data=lapdog_parsed_args.forward
         )

--- a/ddapm_test_agent/lapdog_cli.py
+++ b/ddapm_test_agent/lapdog_cli.py
@@ -287,6 +287,8 @@ def _install_pi_extension(port: int) -> None:
 
     The extension is patched with the resolved LAPDOG_URL so the user does not
     need to set an environment variable when using a non-default port.
+
+    If the extension is already installed and identical, skip the copy.
     """
     os.makedirs(_PI_GLOBAL_EXT_DIR, exist_ok=True)
 
@@ -304,10 +306,26 @@ def _install_pi_extension(port: int) -> None:
         f'const LAPDOG_URL = process.env.LAPDOG_URL || "{lapdog_url}";',
     )
 
+    # Check if already installed and up-to-date.
+    is_update = False
+    if os.path.isfile(_PI_EXT_DEST):
+        try:
+            with open(_PI_EXT_DEST, "r") as f:
+                existing = f.read()
+            if existing == source:
+                print(f"[lapdog] pi extension already installed at {_PI_EXT_DEST}")
+                return
+            is_update = True
+        except OSError:
+            pass
+
     with open(_PI_EXT_DEST, "w") as f:
         f.write(source)
 
-    print(f"[lapdog] Installed pi extension → {_PI_EXT_DEST}")
+    if is_update:
+        print(f"[lapdog] Updated pi extension → {_PI_EXT_DEST}")
+    else:
+        print(f"[lapdog] Installed pi extension → {_PI_EXT_DEST}")
 
 
 def _uninstall_pi_extension() -> None:

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -1,0 +1,547 @@
+"""Pi Coding Agent Hooks → LLM Observability Spans.
+
+Receives lifecycle events from the pi lapdog extension via HTTP and assembles
+them into LLMObs-format spans.  Reuses the ClaudeHooksAPI's session state and
+span storage so that pi traces appear alongside Claude Code traces in the UI.
+
+Pi extension events and their mapping:
+
+    session_start     → create session, set model
+    agent_start       → start new trace (like UserPromptSubmit)
+    agent_end         → finalize root span (like Stop)
+    message_start     → begin tracking an LLM span
+    message_end       → emit LLM span with token usage
+    tool_execution_start → create pending tool span (like PreToolUse)
+    tool_execution_end   → emit tool span (like PostToolUse)
+    turn_start / turn_end → logged, no span emitted
+    model_select      → update session model
+    session_compact   → mark compaction on current span
+    session_shutdown  → finalize session (like SessionEnd)
+"""
+
+import json
+import logging
+import time
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from aiohttp import web
+from aiohttp.web import Request
+
+from .claude_cost_tracker import compute_cost_metrics
+from .claude_cost_tracker import cost_from_provider_usage
+from .claude_hooks import ClaudeHooksAPI
+from .claude_hooks import PendingToolSpan
+from .claude_hooks import SessionState
+from .claude_hooks import _ML_APP
+from .claude_hooks import _HOSTNAME
+from .claude_hooks import _USERNAME
+from .claude_hooks import _USER_HANDLE
+from .claude_hooks import _format_span_id
+from .claude_hooks import _format_trace_id
+from .claude_hooks import _to_json_str
+from .llmobs_event_platform import with_cors
+
+
+log = logging.getLogger(__name__)
+
+
+class PendingLLMSpan:
+    """Tracks an LLM call between message_start and message_end."""
+
+    def __init__(self, span_id: str, parent_id: str, start_ns: int) -> None:
+        self.span_id = span_id
+        self.parent_id = parent_id
+        self.start_ns = start_ns
+
+
+class PiHooksAPI:
+    """Handler for pi coding agent hook events.
+
+    Delegates to a shared ClaudeHooksAPI for session/span storage and backend
+    forwarding so pi traces are queryable through the same Event Platform APIs.
+    """
+
+    def __init__(self, hooks_api: ClaudeHooksAPI) -> None:
+        self._hooks_api = hooks_api
+        self._raw_events: List[Dict[str, Any]] = []
+        # Pending LLM span per session (pi sends one LLM call at a time)
+        self._pending_llm: Dict[str, PendingLLMSpan] = {}
+
+    # ------------------------------------------------------------------
+    # Helpers — access shared state via hooks_api
+    # ------------------------------------------------------------------
+
+    def _get_or_create_session(self, session_id: str) -> SessionState:
+        return self._hooks_api._get_or_create_session(session_id)
+
+    def _current_parent_id(self, session: SessionState) -> str:
+        return self._hooks_api._current_parent_id(session)
+
+    def _append_span(self, span: Dict[str, Any]) -> None:
+        self._hooks_api._assembled_spans.append(span)
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _handle_session_start(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._get_or_create_session(session_id)
+        model_id = body.get("model_id", "")
+        model_provider = body.get("model_provider", "")
+        if model_id:
+            session.model = model_id
+        log.info("Pi session started: %s (model=%s/%s)", session_id, model_provider, model_id)
+
+    def _handle_model_select(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._get_or_create_session(session_id)
+        model_id = body.get("model_id", "")
+        if model_id:
+            session.model = model_id
+        log.info("Pi model changed: %s → %s/%s", session_id, body.get("model_provider", ""), model_id)
+
+    def _handle_agent_start(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Start a new trace for each user turn (equivalent to UserPromptSubmit)."""
+        session = self._get_or_create_session(session_id)
+
+        # Finalize previous turn if it wasn't finalized
+        if not session.root_span_emitted and getattr(session, "_root_span_ref", None) is not None:
+            self._hooks_api._finalize_interrupted_turn(session)
+
+        # Start fresh trace
+        if session.root_span_emitted:
+            now_ns = int(time.time() * 1_000_000_000)
+            session.trace_id = _format_trace_id()
+            session.root_span_id = _format_span_id()
+            session.start_ns = now_ns
+            session.user_prompts = []
+            session.tools_used = set()
+            session.agent_span_stack = []
+            session.pending_tools = {}
+            session.deferred_agent_spans = {}
+            session.claimed_task_tools = set()
+            session.active_agents = {}
+            session.root_span_emitted = False
+
+        prompt = body.get("user_prompt", "")
+        if prompt:
+            session.user_prompts.append(prompt)
+
+        model_id = body.get("model_id", session.model)
+        model_provider = body.get("model_provider", "")
+        if model_id:
+            session.model = model_id
+
+        root_span: Dict[str, Any] = {
+            "span_id": session.root_span_id,
+            "trace_id": session.trace_id,
+            "parent_id": "undefined",
+            "name": "pi-request",
+            "status": "ok",
+            "start_ns": session.start_ns,
+            "duration": 0,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": [
+                f"ml_app:{_ML_APP}",
+                f"session_id:{session.session_id}",
+                f"service:{_ML_APP}",
+                "env:local",
+                "source:pi-hooks",
+                "language:python",
+                f"hostname:{_HOSTNAME}",
+            ]
+            + ([f"user_handle:{_USER_HANDLE}"] if _USER_HANDLE else []),
+            "meta": {
+                "span": {"kind": "agent"},
+                "input": {"value": prompt},
+                "output": {"value": ""},
+                "model_name": model_id,
+                "model_provider": model_provider,
+            },
+            "metrics": {},
+        }
+        self._append_span(root_span)
+        session._root_span_ref = root_span  # type: ignore[attr-defined]
+
+    def _handle_agent_end(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Finalize the root span for the current turn (equivalent to Stop)."""
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            log.warning("agent_end for unknown session %s", session_id)
+            return
+
+        now_ns = int(time.time() * 1_000_000_000)
+        duration = now_ns - session.start_ns
+        output_value = body.get("output", "")
+        input_value = "\n\n".join(session.user_prompts) if session.user_prompts else ""
+
+        token_usage = self._hooks_api._compute_token_usage(session.trace_id)
+        tool_usage = self._hooks_api._aggregate_tool_usage(session.trace_id)
+
+        root_span: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
+        if not root_span:
+            root_span = next(
+                (s for s in self._hooks_api._assembled_spans if s.get("span_id") == session.root_span_id),
+                None,
+            )
+
+        if root_span:
+            root_span["duration"] = duration
+            root_span["meta"]["input"]["value"] = input_value
+            root_span["meta"]["output"]["value"] = output_value
+            root_span["meta"]["model_name"] = session.model
+            root_span["meta"]["model_provider"] = body.get("model_provider", "anthropic")
+            root_span["metrics"] = token_usage
+            dd_fields: Dict[str, Any] = {}
+            if tool_usage:
+                dd_fields["tool_usage"] = tool_usage
+            dd_fields["agent_manifest"] = {
+                "name": _ML_APP,
+                "model": session.model,
+                "model_provider": body.get("model_provider", "anthropic"),
+                "tools": [{"name": name} for name in sorted(session.tools_used)],
+            }
+            if dd_fields:
+                self._hooks_api._set_hidden_metadata(root_span, **dd_fields)
+        else:
+            # Fallback: create root span
+            root_span = {
+                "span_id": session.root_span_id,
+                "trace_id": session.trace_id,
+                "parent_id": "undefined",
+                "name": "pi-request",
+                "status": "ok",
+                "start_ns": session.start_ns,
+                "duration": duration,
+                "ml_app": _ML_APP,
+                "service": _ML_APP,
+                "env": "local",
+                "session_id": session.session_id,
+                "tags": [
+                    f"ml_app:{_ML_APP}",
+                    f"session_id:{session.session_id}",
+                    f"service:{_ML_APP}",
+                    "env:local",
+                    "source:pi-hooks",
+                    "language:python",
+                    f"hostname:{_HOSTNAME}",
+                ]
+                + ([f"user_handle:{_USER_HANDLE}"] if _USER_HANDLE else []),
+                "meta": {
+                    "span": {"kind": "agent"},
+                    "input": {"value": input_value},
+                    "output": {"value": output_value},
+                    "model_name": session.model,
+                    "model_provider": body.get("model_provider", "anthropic"),
+                },
+                "metrics": token_usage,
+            }
+            self._append_span(root_span)
+
+        session.root_span_emitted = True
+
+    def _handle_message_start(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Begin tracking an LLM call."""
+        session = self._get_or_create_session(session_id)
+        span_id = _format_span_id()
+        parent_id = self._current_parent_id(session)
+        now_ns = int(time.time() * 1_000_000_000)
+        self._pending_llm[session_id] = PendingLLMSpan(
+            span_id=span_id,
+            parent_id=parent_id,
+            start_ns=now_ns,
+        )
+
+    def _handle_message_end(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Emit an LLM span with token usage and tool calls."""
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            return
+
+        now_ns = int(time.time() * 1_000_000_000)
+        pending = self._pending_llm.pop(session_id, None)
+
+        if pending:
+            span_id = pending.span_id
+            parent_id = pending.parent_id
+            start_ns = pending.start_ns
+        else:
+            span_id = _format_span_id()
+            parent_id = self._current_parent_id(session)
+            start_ns = now_ns
+
+        duration = now_ns - start_ns
+
+        model_id = body.get("model_id", session.model)
+        model_provider = body.get("model_provider", "")
+        usage = body.get("usage") or {}
+        output_text = body.get("output_text", "")
+        tool_calls = body.get("tool_calls", [])
+        stop_reason = body.get("stop_reason", "")
+
+        # Build input/output messages in LLMObs format
+        output_messages = []
+        if output_text:
+            output_messages.append({"content": output_text, "role": "assistant"})
+        if tool_calls:
+            for tc in tool_calls:
+                output_messages.append({
+                    "content": json.dumps(tc.get("arguments", {})),
+                    "role": "assistant",
+                    "tool_calls": [{"name": tc.get("name", ""), "arguments": tc.get("arguments", {})}],
+                })
+
+        # Token metrics
+        input_tokens = usage.get("input", 0)
+        output_tokens = usage.get("output", 0)
+        cache_read = usage.get("cacheRead", 0)
+        cache_write = usage.get("cacheWrite", 0)
+        total_tokens = usage.get("totalTokens", 0) or (input_tokens + output_tokens + cache_read + cache_write)
+
+        # Cost: prefer provider-reported cost, fall back to model-based estimate
+        provider_cost = usage.get("cost")
+        cost_metrics: Dict[str, int] = {}
+        if isinstance(provider_cost, dict) and provider_cost.get("total", 0) > 0:
+            cost_metrics = cost_from_provider_usage(provider_cost)
+        else:
+            cost_metrics = compute_cost_metrics(
+                model_id=model_id or "",
+                non_cached_input_tokens=input_tokens,
+                cache_write_tokens=cache_write,
+                cache_read_tokens=cache_read,
+                output_tokens=output_tokens,
+            ) or {}
+
+        span: Dict[str, Any] = {
+            "span_id": span_id,
+            "trace_id": session.trace_id,
+            "parent_id": parent_id,
+            "name": model_id or "unknown",
+            "status": "ok",
+            "start_ns": start_ns,
+            "duration": duration,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": [
+                f"ml_app:{_ML_APP}",
+                f"session_id:{session.session_id}",
+                f"service:{_ML_APP}",
+                "env:local",
+                "source:pi-hooks",
+                "language:python",
+                f"hostname:{_HOSTNAME}",
+            ],
+            "meta": {
+                "span": {"kind": "llm"},
+                "model_name": model_id,
+                "model_provider": model_provider,
+                "input": {"messages": []},
+                "output": {"messages": output_messages},
+                "metadata": {
+                    "stop_reason": stop_reason,
+                },
+            },
+            "metrics": {
+                "input_tokens": input_tokens + cache_read + cache_write,
+                "output_tokens": output_tokens,
+                "total_tokens": total_tokens,
+                "cache_read_input_tokens": cache_read,
+                "cache_write_input_tokens": cache_write,
+                "non_cached_input_tokens": input_tokens,
+                **cost_metrics,
+            },
+        }
+        self._append_span(span)
+
+    def _handle_tool_execution_start(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Create a pending tool span (equivalent to PreToolUse)."""
+        session = self._get_or_create_session(session_id)
+        tool_name = body.get("tool_name", "unknown_tool")
+        tool_call_id = body.get("tool_call_id", tool_name)
+        args = body.get("args", "")
+        session.tools_used.add(tool_name)
+
+        span_id = _format_span_id()
+        parent_id = self._current_parent_id(session)
+        now_ns = int(time.time() * 1_000_000_000)
+
+        # Parse args string back to dict for tool_input if possible
+        tool_input: Any = args
+        if isinstance(args, str):
+            try:
+                tool_input = json.loads(args)
+            except (json.JSONDecodeError, ValueError):
+                tool_input = args
+
+        session.pending_tools[tool_call_id] = PendingToolSpan(
+            span_id=span_id,
+            tool_name=tool_name,
+            tool_input=tool_input,
+            parent_id=parent_id,
+            start_ns=now_ns,
+        )
+
+    def _handle_tool_execution_end(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Emit a tool span (equivalent to PostToolUse/PostToolUseFailure)."""
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            return
+
+        tool_name = body.get("tool_name", "unknown_tool")
+        tool_call_id = body.get("tool_call_id", tool_name)
+        result = body.get("result", "")
+        is_error = body.get("is_error", False)
+
+        now_ns = int(time.time() * 1_000_000_000)
+        pending = session.pending_tools.pop(tool_call_id, None)
+
+        if pending:
+            span_id = pending.span_id
+            parent_id = pending.parent_id
+            start_ns = pending.start_ns
+            input_value = _to_json_str(pending.tool_input) if pending.tool_input else ""
+            actual_tool_name = pending.tool_name
+        else:
+            span_id = _format_span_id()
+            parent_id = self._current_parent_id(session)
+            start_ns = now_ns
+            input_value = ""
+            actual_tool_name = tool_name
+
+        duration = now_ns - start_ns
+        output_str = _to_json_str(result) if result else ""
+
+        span: Dict[str, Any] = {
+            "span_id": span_id,
+            "trace_id": session.trace_id,
+            "parent_id": parent_id,
+            "name": actual_tool_name,
+            "status": "error" if is_error else "ok",
+            "start_ns": start_ns,
+            "duration": duration,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": [
+                f"ml_app:{_ML_APP}",
+                f"session_id:{session.session_id}",
+                f"service:{_ML_APP}",
+                "env:local",
+                "source:pi-hooks",
+                "language:python",
+                f"hostname:{_HOSTNAME}",
+                f"tool_name:{actual_tool_name}",
+            ],
+            "meta": {
+                "span": {"kind": "tool"},
+                "input": {"value": input_value},
+                "output": {"value": output_str},
+                "metadata": {"tool_id": tool_call_id},
+            },
+            "metrics": {},
+        }
+        if is_error:
+            span["meta"]["error"] = {"message": output_str}
+        self._append_span(span)
+
+    def _handle_session_compact(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Mark compaction event on the current active span."""
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            return
+        span_ref = self._hooks_api._current_span_ref(session)
+        if span_ref is None:
+            return
+        dd = span_ref.setdefault("meta", {}).setdefault("metadata", {}).setdefault("_dd", {})
+        dd.setdefault("compactions", []).append({
+            "trigger": "auto" if body.get("from_extension") else "manual",
+        })
+
+    def _handle_turn_start(self, session_id: str, body: Dict[str, Any]) -> None:
+        log.debug("Pi turn_start for session %s: turn_index=%s", session_id, body.get("turn_index"))
+
+    def _handle_turn_end(self, session_id: str, body: Dict[str, Any]) -> None:
+        log.debug("Pi turn_end for session %s: turn_index=%s", session_id, body.get("turn_index"))
+
+    def _handle_session_shutdown(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Finalize session (equivalent to SessionEnd)."""
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            return
+        if not session.root_span_emitted:
+            self._hooks_api._finalize_interrupted_turn(session)
+
+    # ------------------------------------------------------------------
+    # Dispatch
+    # ------------------------------------------------------------------
+
+    _HANDLERS: Dict[str, str] = {
+        "session_start": "_handle_session_start",
+        "session_shutdown": "_handle_session_shutdown",
+        "model_select": "_handle_model_select",
+        "agent_start": "_handle_agent_start",
+        "agent_end": "_handle_agent_end",
+        "turn_start": "_handle_turn_start",
+        "turn_end": "_handle_turn_end",
+        "message_start": "_handle_message_start",
+        "message_end": "_handle_message_end",
+        "tool_execution_start": "_handle_tool_execution_start",
+        "tool_execution_end": "_handle_tool_execution_end",
+        "session_compact": "_handle_session_compact",
+    }
+
+    def _dispatch(self, body: Dict[str, Any]) -> None:
+        session_id = body.get("session_id", "")
+        event_name = body.get("hook_event_name", "")
+        handler_name = self._HANDLERS.get(event_name)
+        if handler_name:
+            handler = getattr(self, handler_name)
+            handler(session_id, body)
+        else:
+            log.debug("Unhandled pi hook event: %s", event_name)
+
+    # ------------------------------------------------------------------
+    # HTTP handlers
+    # ------------------------------------------------------------------
+
+    async def handle_hook(self, request: Request) -> web.Response:
+        """Handle POST /pi/hooks — receives pi extension JSON and dispatches by event name."""
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+
+        session_id = body.get("session_id", "")
+        if not session_id:
+            return web.json_response({"error": "missing session_id"}, status=400)
+
+        self._raw_events.append(body)
+        self._dispatch(body)
+
+        hook_event_name = body.get("hook_event_name", "")
+
+        # Forward completed traces to backend on agent_end or session_shutdown
+        if hook_event_name in ("agent_end", "session_shutdown"):
+            await self._hooks_api._forward_trace_to_backend(session_id)
+            await self._hooks_api._forward_eval_metrics_to_backend(session_id)
+
+        return web.json_response({"status": "ok"})
+
+    async def handle_raw_events(self, request: Request) -> web.Response:
+        """Handle GET /pi/hooks/raw — return all raw received events for debugging."""
+        return web.json_response({"events": self._raw_events})
+
+    def get_routes(self) -> List[web.RouteDef]:
+        """Return the routes for this API."""
+        return [
+            web.post("/pi/hooks", with_cors(self.handle_hook)),
+            web.route("*", "/pi/hooks/raw", with_cors(self.handle_raw_events)),
+        ]

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -9,6 +9,7 @@ Pi extension events and their mapping:
     session_start     → create session, set model
     agent_start       → start new trace (like UserPromptSubmit)
     agent_end         → finalize root span (like Stop)
+    provider_request_context → capture request-side context for next LLM span
     message_start     → begin tracking an LLM span
     message_end       → emit LLM span with token usage
     tool_execution_start → create pending tool span (like PreToolUse)
@@ -37,7 +38,6 @@ from .claude_hooks import PendingToolSpan
 from .claude_hooks import SessionState
 from .claude_hooks import _ML_APP
 from .claude_hooks import _HOSTNAME
-from .claude_hooks import _USERNAME
 from .claude_hooks import _USER_HANDLE
 from .claude_hooks import _format_span_id
 from .claude_hooks import _format_trace_id
@@ -57,6 +57,24 @@ class PendingLLMSpan:
         self.start_ns = start_ns
 
 
+class PendingContextBreakdown:
+    """Tracks normalized request context captured before a provider request."""
+
+    def __init__(
+        self,
+        model_id: str,
+        model_provider: str,
+        context_window_size: int,
+        estimated_input_tokens: Optional[int],
+        sections: List[Dict[str, Any]],
+    ) -> None:
+        self.model_id = model_id
+        self.model_provider = model_provider
+        self.context_window_size = context_window_size
+        self.estimated_input_tokens = estimated_input_tokens
+        self.sections = sections
+
+
 class PiHooksAPI:
     """Handler for pi coding agent hook events.
 
@@ -69,6 +87,7 @@ class PiHooksAPI:
         self._raw_events: List[Dict[str, Any]] = []
         # Pending LLM span per session (pi sends one LLM call at a time)
         self._pending_llm: Dict[str, PendingLLMSpan] = {}
+        self._pending_context: Dict[str, PendingContextBreakdown] = {}
 
     # ------------------------------------------------------------------
     # Helpers — access shared state via hooks_api
@@ -83,6 +102,34 @@ class PiHooksAPI:
     def _append_span(self, span: Dict[str, Any]) -> None:
         self._hooks_api._assembled_spans.append(span)
 
+    def _compute_context_breakdown(
+        self,
+        pending_context: Optional[PendingContextBreakdown],
+        total_input_tokens: int,
+        fallback_model_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        if pending_context is None:
+            return None
+
+        section_bytes_total = sum(section.get("bytes", 0) for section in pending_context.sections) or 1
+        sections: List[Dict[str, Any]] = []
+        for section in pending_context.sections:
+            section_bytes = section.get("bytes", 0)
+            tokens = round(total_input_tokens * section_bytes / section_bytes_total) if total_input_tokens > 0 else 0
+            pct = round(tokens / total_input_tokens * 100, 1) if total_input_tokens > 0 else 0.0
+            sections.append({"name": section.get("name", "unknown"), "tokens": tokens, "pct": pct})
+
+        context_window_size = pending_context.context_window_size
+        context_usage_pct = round(total_input_tokens / context_window_size * 100, 1) if context_window_size > 0 else 0.0
+
+        return {
+            "context_window_size": context_window_size,
+            "total_input_tokens": total_input_tokens,
+            "context_usage_pct": context_usage_pct,
+            "sections": sections,
+            "model_name": pending_context.model_id or fallback_model_id,
+        }
+
     # ------------------------------------------------------------------
     # Event handlers
     # ------------------------------------------------------------------
@@ -93,14 +140,19 @@ class PiHooksAPI:
         model_provider = body.get("model_provider", "")
         if model_id:
             session.model = model_id
+        if model_provider:
+            session.model_provider = model_provider
         log.info("Pi session started: %s (model=%s/%s)", session_id, model_provider, model_id)
 
     def _handle_model_select(self, session_id: str, body: Dict[str, Any]) -> None:
         session = self._get_or_create_session(session_id)
         model_id = body.get("model_id", "")
+        model_provider = body.get("model_provider", "")
         if model_id:
             session.model = model_id
-        log.info("Pi model changed: %s → %s/%s", session_id, body.get("model_provider", ""), model_id)
+        if model_provider:
+            session.model_provider = model_provider
+        log.info("Pi model changed: %s → %s/%s", session_id, model_provider, model_id)
 
     def _handle_agent_start(self, session_id: str, body: Dict[str, Any]) -> None:
         """Start a new trace for each user turn (equivalent to UserPromptSubmit)."""
@@ -109,6 +161,8 @@ class PiHooksAPI:
         # Finalize previous turn if it wasn't finalized
         if not session.root_span_emitted and getattr(session, "_root_span_ref", None) is not None:
             self._hooks_api._finalize_interrupted_turn(session)
+
+        self._pending_context.pop(session_id, None)
 
         # Start fresh trace
         if session.root_span_emitted:
@@ -130,9 +184,11 @@ class PiHooksAPI:
             session.user_prompts.append(prompt)
 
         model_id = body.get("model_id", session.model)
-        model_provider = body.get("model_provider", "")
+        model_provider = body.get("model_provider", session.model_provider)
         if model_id:
             session.model = model_id
+        if model_provider:
+            session.model_provider = model_provider
 
         root_span: Dict[str, Any] = {
             "span_id": session.root_span_id,
@@ -182,6 +238,15 @@ class PiHooksAPI:
 
         token_usage = self._hooks_api._compute_token_usage(session.trace_id)
         tool_usage = self._hooks_api._aggregate_tool_usage(session.trace_id)
+        context_delta = self._hooks_api._compute_context_delta(
+            session.trace_id, session.root_span_id, session.last_known_input_tokens
+        )
+        if context_delta:
+            session.last_known_input_tokens = context_delta["last_input_tokens"]
+
+        model_provider = body.get("model_provider", session.model_provider)
+        if model_provider:
+            session.model_provider = model_provider
 
         root_span: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
         if not root_span:
@@ -195,15 +260,17 @@ class PiHooksAPI:
             root_span["meta"]["input"]["value"] = input_value
             root_span["meta"]["output"]["value"] = output_value
             root_span["meta"]["model_name"] = session.model
-            root_span["meta"]["model_provider"] = body.get("model_provider", "anthropic")
+            root_span["meta"]["model_provider"] = model_provider
             root_span["metrics"] = token_usage
             dd_fields: Dict[str, Any] = {}
+            if context_delta:
+                dd_fields["context_delta"] = context_delta
             if tool_usage:
                 dd_fields["tool_usage"] = tool_usage
             dd_fields["agent_manifest"] = {
                 "name": _ML_APP,
                 "model": session.model,
-                "model_provider": body.get("model_provider", "anthropic"),
+                "model_provider": model_provider,
                 "tools": [{"name": name} for name in sorted(session.tools_used)],
             }
             if dd_fields:
@@ -237,13 +304,55 @@ class PiHooksAPI:
                     "input": {"value": input_value},
                     "output": {"value": output_value},
                     "model_name": session.model,
-                    "model_provider": body.get("model_provider", "anthropic"),
+                    "model_provider": model_provider,
                 },
                 "metrics": token_usage,
             }
+            if context_delta:
+                self._hooks_api._set_hidden_metadata(root_span, context_delta=context_delta)
             self._append_span(root_span)
 
         session.root_span_emitted = True
+
+    def _handle_provider_request_context(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Track normalized request context for the next LLM span."""
+        session = self._get_or_create_session(session_id)
+        model_id = body.get("model_id", session.model)
+        model_provider = body.get("model_provider", session.model_provider)
+        if model_id:
+            session.model = model_id
+        if model_provider:
+            session.model_provider = model_provider
+
+        raw_sections = body.get("sections") or []
+        sections: List[Dict[str, Any]] = []
+        if isinstance(raw_sections, list):
+            for item in raw_sections:
+                if not isinstance(item, dict):
+                    continue
+                name = item.get("name")
+                bytes_value = item.get("bytes")
+                if not isinstance(name, str) or not isinstance(bytes_value, int):
+                    continue
+                if bytes_value <= 0:
+                    continue
+                sections.append({"name": name, "bytes": bytes_value})
+
+        estimated_input_tokens = body.get("estimated_input_tokens")
+        if not isinstance(estimated_input_tokens, int):
+            estimated_input_tokens = None
+
+        context_window_size = body.get("context_window_size")
+        if not isinstance(context_window_size, int):
+            context_window_size = 0
+
+        self._pending_context[session_id] = PendingContextBreakdown(
+            model_id=model_id,
+            model_provider=model_provider,
+            context_window_size=context_window_size,
+            estimated_input_tokens=estimated_input_tokens,
+            sections=sections,
+        )
 
     def _handle_message_start(self, session_id: str, body: Dict[str, Any]) -> None:
         """Begin tracking an LLM call."""
@@ -278,11 +387,17 @@ class PiHooksAPI:
         duration = now_ns - start_ns
 
         model_id = body.get("model_id", session.model)
-        model_provider = body.get("model_provider", "")
+        model_provider = body.get("model_provider", session.model_provider)
         usage = body.get("usage") or {}
         output_text = body.get("output_text", "")
         tool_calls = body.get("tool_calls", [])
         stop_reason = body.get("stop_reason", "")
+        pending_context = self._pending_context.pop(session_id, None)
+
+        if model_id:
+            session.model = model_id
+        if model_provider:
+            session.model_provider = model_provider
 
         # Build input/output messages in LLMObs format
         output_messages = []
@@ -301,7 +416,8 @@ class PiHooksAPI:
         output_tokens = usage.get("output", 0)
         cache_read = usage.get("cacheRead", 0)
         cache_write = usage.get("cacheWrite", 0)
-        total_tokens = usage.get("totalTokens", 0) or (input_tokens + output_tokens + cache_read + cache_write)
+        total_input_tokens = input_tokens + cache_read + cache_write
+        total_tokens = usage.get("totalTokens", 0) or (total_input_tokens + output_tokens)
 
         # Cost: prefer provider-reported cost, fall back to model-based estimate
         provider_cost = usage.get("cost")
@@ -316,6 +432,12 @@ class PiHooksAPI:
                 cache_read_tokens=cache_read,
                 output_tokens=output_tokens,
             ) or {}
+
+        context_breakdown = self._compute_context_breakdown(
+            pending_context,
+            total_input_tokens if total_input_tokens > 0 else (pending_context.estimated_input_tokens if pending_context else 0),
+            model_id or session.model,
+        )
 
         span: Dict[str, Any] = {
             "span_id": span_id,
@@ -349,7 +471,7 @@ class PiHooksAPI:
                 },
             },
             "metrics": {
-                "input_tokens": input_tokens + cache_read + cache_write,
+                "input_tokens": total_input_tokens,
                 "output_tokens": output_tokens,
                 "total_tokens": total_tokens,
                 "cache_read_input_tokens": cache_read,
@@ -358,6 +480,8 @@ class PiHooksAPI:
                 **cost_metrics,
             },
         }
+        if context_breakdown:
+            self._hooks_api._set_hidden_metadata(span, context_breakdown=context_breakdown)
         self._append_span(span)
 
     def _handle_tool_execution_start(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -476,6 +600,7 @@ class PiHooksAPI:
         session = self._hooks_api._sessions.get(session_id)
         if not session:
             return
+        self._pending_context.pop(session_id, None)
         if not session.root_span_emitted:
             self._hooks_api._finalize_interrupted_turn(session)
 
@@ -491,6 +616,7 @@ class PiHooksAPI:
         "agent_end": "_handle_agent_end",
         "turn_start": "_handle_turn_start",
         "turn_end": "_handle_turn_end",
+        "provider_request_context": "_handle_provider_request_context",
         "message_start": "_handle_message_start",
         "message_end": "_handle_message_end",
         "tool_execution_start": "_handle_tool_execution_start",

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -112,14 +112,14 @@ class PiHooksAPI:
             return None
 
         section_bytes_total = sum(section.get("bytes", 0) for section in pending_context.sections) or 1
+        context_window_size = pending_context.context_window_size
         sections: List[Dict[str, Any]] = []
         for section in pending_context.sections:
             section_bytes = section.get("bytes", 0)
             tokens = round(total_input_tokens * section_bytes / section_bytes_total) if total_input_tokens > 0 else 0
-            pct = round(tokens / total_input_tokens * 100, 1) if total_input_tokens > 0 else 0.0
+            pct = round(tokens / context_window_size * 100, 1) if context_window_size > 0 else 0.0
             sections.append({"name": section.get("name", "unknown"), "tokens": tokens, "pct": pct})
 
-        context_window_size = pending_context.context_window_size
         context_usage_pct = round(total_input_tokens / context_window_size * 100, 1) if context_window_size > 0 else 0.0
 
         return {

--- a/ddapm_test_agent/pi_lapdog_extension.ts
+++ b/ddapm_test_agent/pi_lapdog_extension.ts
@@ -1,0 +1,247 @@
+/**
+ * Lapdog Extension for Pi Coding Agent
+ *
+ * Sends agent lifecycle events to the dd-apm-test-agent (lapdog) for
+ * LLM Observability tracing. Creates LLMObs spans for:
+ *   - Agent turns (root agent span per user prompt → agent_end)
+ *   - LLM calls (assistant message_start → message_end with token usage)
+ *   - Tool executions (tool_execution_start → tool_execution_end)
+ *
+ * Install: copy to ~/.pi/agent/extensions/lapdog.ts
+ * Configure: set LAPDOG_URL to override the default http://localhost:8126
+ *
+ * All HTTP posts are fire-and-forget with a 2 s timeout so a lapdog outage
+ * never blocks the agent.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const LAPDOG_URL = process.env.LAPDOG_URL || "http://localhost:8126";
+const HOOKS_ENDPOINT = `${LAPDOG_URL}/pi/hooks`;
+const MAX_OUTPUT_BYTES = 128 * 1024; // 128 KB cap for tool output / message content
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(value: unknown, maxBytes: number = MAX_OUTPUT_BYTES): string {
+	const str = typeof value === "string" ? value : JSON.stringify(value ?? "");
+	if (str.length <= maxBytes) return str;
+	return str.slice(0, maxBytes) + `\n... (truncated, ${str.length} bytes total)`;
+}
+
+/** Fire-and-forget POST. Errors are silently swallowed. */
+function post(event: string, sessionId: string, data: Record<string, unknown>): void {
+	try {
+		fetch(HOOKS_ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ hook_event_name: event, session_id: sessionId, ...data }),
+			signal: AbortSignal.timeout(2000),
+		}).catch(() => {});
+	} catch {
+		// fetch itself can throw synchronously in some edge cases
+	}
+}
+
+/**
+ * Extract text from user message content (string or content array).
+ */
+function extractUserText(content: string | Array<{ type: string; text?: string }>): string {
+	if (typeof content === "string") return content;
+	return content
+		.filter((c): c is { type: "text"; text: string } => c.type === "text" && typeof c.text === "string")
+		.map((c) => c.text)
+		.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function lapdog(pi: ExtensionAPI): void {
+	let sessionId = "";
+	let currentModel = "";
+	let currentProvider = "";
+
+	// Track the user prompt that started the current agent run so we can
+	// attach it to the agent_start event (input event fires before agent_start).
+	let pendingUserPrompt = "";
+
+	// ------------------------------------------------------------------
+	// Session lifecycle
+	// ------------------------------------------------------------------
+
+	pi.on("session_start", (_event, ctx) => {
+		sessionId = ctx.sessionManager.getSessionId();
+		const model = ctx.model;
+		if (model) {
+			currentModel = model.id;
+			currentProvider = model.provider;
+		}
+		post("session_start", sessionId, {
+			model: model ? `${model.provider}/${model.id}` : "",
+			model_provider: currentProvider,
+			model_id: currentModel,
+		});
+	});
+
+	pi.on("session_shutdown", () => {
+		post("session_shutdown", sessionId, {});
+	});
+
+	// ------------------------------------------------------------------
+	// Model changes
+	// ------------------------------------------------------------------
+
+	pi.on("model_select", (event) => {
+		currentModel = event.model.id;
+		currentProvider = event.model.provider;
+		post("model_select", sessionId, {
+			model: `${event.model.provider}/${event.model.id}`,
+			model_provider: event.model.provider,
+			model_id: event.model.id,
+			previous_model: event.previousModel
+				? `${event.previousModel.provider}/${event.previousModel.id}`
+				: undefined,
+		});
+	});
+
+	// ------------------------------------------------------------------
+	// User input → agent turn lifecycle
+	// ------------------------------------------------------------------
+
+	pi.on("input", (event) => {
+		pendingUserPrompt = event.text;
+	});
+
+	pi.on("agent_start", () => {
+		post("agent_start", sessionId, {
+			user_prompt: pendingUserPrompt,
+			model: `${currentProvider}/${currentModel}`,
+			model_provider: currentProvider,
+			model_id: currentModel,
+		});
+		pendingUserPrompt = "";
+	});
+
+	pi.on("agent_end", (event) => {
+		// Extract the final assistant text from the last assistant message
+		let outputText = "";
+		for (let i = event.messages.length - 1; i >= 0; i--) {
+			const msg = event.messages[i];
+			if (msg.role === "assistant") {
+				const textParts = (msg.content as Array<{ type: string; text?: string }>)
+					.filter((c) => c.type === "text" && c.text)
+					.map((c) => c.text!);
+				outputText = textParts.join("\n");
+				break;
+			}
+		}
+		post("agent_end", sessionId, {
+			output: truncate(outputText),
+			num_messages: event.messages.length,
+		});
+	});
+
+	// ------------------------------------------------------------------
+	// Turn lifecycle
+	// ------------------------------------------------------------------
+
+	pi.on("turn_start", (event) => {
+		post("turn_start", sessionId, {
+			turn_index: event.turnIndex,
+			timestamp: event.timestamp,
+		});
+	});
+
+	pi.on("turn_end", (event) => {
+		post("turn_end", sessionId, {
+			turn_index: event.turnIndex,
+		});
+	});
+
+	// ------------------------------------------------------------------
+	// LLM message lifecycle (creates LLM spans)
+	// ------------------------------------------------------------------
+
+	pi.on("message_start", (event) => {
+		if (event.message.role !== "assistant") return;
+		post("message_start", sessionId, {
+			message_role: "assistant",
+		});
+	});
+
+	pi.on("message_end", (event) => {
+		if (event.message.role !== "assistant") return;
+
+		const msg = event.message as {
+			role: "assistant";
+			content: Array<{ type: string; text?: string; id?: string; name?: string; arguments?: unknown }>;
+			model?: string;
+			provider?: string;
+			api?: string;
+			usage?: {
+				input: number;
+				output: number;
+				cacheRead: number;
+				cacheWrite: number;
+				totalTokens: number;
+				cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+			};
+			stopReason?: string;
+		};
+
+		// Extract tool_use blocks for span linking
+		const toolCalls = msg.content
+			.filter((c) => c.type === "toolCall")
+			.map((c) => ({ id: c.id, name: c.name, arguments: c.arguments }));
+
+		// Extract text output
+		const textParts = msg.content
+			.filter((c) => c.type === "text" && c.text)
+			.map((c) => c.text!);
+
+		post("message_end", sessionId, {
+			message_role: "assistant",
+			model_id: msg.model || currentModel,
+			model_provider: msg.provider || currentProvider,
+			api: msg.api,
+			usage: msg.usage ?? null,
+			stop_reason: msg.stopReason ?? "",
+			tool_calls: toolCalls,
+			output_text: truncate(textParts.join("\n")),
+		});
+	});
+
+	// ------------------------------------------------------------------
+	// Tool execution lifecycle (creates tool spans)
+	// ------------------------------------------------------------------
+
+	pi.on("tool_execution_start", (event) => {
+		post("tool_execution_start", sessionId, {
+			tool_call_id: event.toolCallId,
+			tool_name: event.toolName,
+			args: truncate(event.args),
+		});
+	});
+
+	pi.on("tool_execution_end", (event) => {
+		post("tool_execution_end", sessionId, {
+			tool_call_id: event.toolCallId,
+			tool_name: event.toolName,
+			result: truncate(event.result),
+			is_error: event.isError,
+		});
+	});
+
+	// ------------------------------------------------------------------
+	// Context compaction
+	// ------------------------------------------------------------------
+
+	pi.on("session_compact", (event) => {
+		post("session_compact", sessionId, {
+			from_extension: event.fromExtension,
+		});
+	});
+}

--- a/ddapm_test_agent/pi_lapdog_extension.ts
+++ b/ddapm_test_agent/pi_lapdog_extension.ts
@@ -48,6 +48,14 @@ function pushSection(sections: Array<{ name: string; bytes: number }>, name: str
 	if (bytes > 0) sections.push({ name, bytes });
 }
 
+function pushOtherSection(
+	sections: Array<{ name: string; bytes: number }>,
+	value: unknown,
+): void {
+	const bytes = byteLength(value);
+	if (bytes > 0) sections.push({ name: "other", bytes });
+}
+
 function normalizeProviderContext(payload: unknown): Array<{ name: string; bytes: number }> {
 	if (!isRecord(payload)) return [];
 
@@ -61,10 +69,19 @@ function normalizeProviderContext(payload: unknown): Array<{ name: string; bytes
 		const userMessages = messages.filter((m) => m.role === "user");
 		const assistantMessages = messages.filter((m) => m.role === "assistant");
 		const toolMessages = messages.filter((m) => m.role === "tool");
+		const otherMessages = messages.filter(
+			(m) => m.role !== "system" && m.role !== "developer" && m.role !== "user" && m.role !== "assistant" && m.role !== "tool",
+		);
 		pushSection(sections, "system", payload.system ?? systemMessages);
 		pushSection(sections, "user_messages", userMessages);
 		pushSection(sections, "assistant_messages", assistantMessages);
 		pushSection(sections, "tool_messages", toolMessages);
+		pushOtherSection(sections, {
+			...payload,
+			tools: undefined,
+			system: undefined,
+			messages: otherMessages.length > 0 ? otherMessages : undefined,
+		});
 		return sections;
 	}
 
@@ -77,6 +94,12 @@ function normalizeProviderContext(payload: unknown): Array<{ name: string; bytes
 		pushSection(sections, "user_messages", userMessages);
 		pushSection(sections, "assistant_messages", assistantMessages);
 		pushSection(sections, "tool_messages", toolMessages);
+		pushOtherSection(sections, {
+			...payload,
+			tools: undefined,
+			systemInstruction: undefined,
+			contents: undefined,
+		});
 		return sections;
 	}
 

--- a/ddapm_test_agent/pi_lapdog_extension.ts
+++ b/ddapm_test_agent/pi_lapdog_extension.ts
@@ -42,18 +42,26 @@ function byteLength(value: unknown): number {
 	}
 }
 
-function pushSection(sections: Array<{ name: string; bytes: number }>, name: string, value: unknown): void {
-	if (value === undefined || value === null) return;
-	const bytes = byteLength(value);
-	if (bytes > 0) sections.push({ name, bytes });
+function addSectionBytes(sections: Array<{ name: string; bytes: number }>, name: string, bytes: number): void {
+	if (bytes <= 0) return;
+	const existing = sections.find((section) => section.name === name);
+	if (existing) {
+		existing.bytes += bytes;
+		return;
+	}
+	sections.push({ name, bytes });
 }
 
-function pushOtherSection(
+function pushSection(sections: Array<{ name: string; bytes: number }>, name: string, value: unknown): void {
+	if (value === undefined || value === null) return;
+	addSectionBytes(sections, name, byteLength(value));
+}
+
+function pushNonToolContextToUserSection(
 	sections: Array<{ name: string; bytes: number }>,
 	value: unknown,
 ): void {
-	const bytes = byteLength(value);
-	if (bytes > 0) sections.push({ name: "other", bytes });
+	addSectionBytes(sections, "user_messages", byteLength(value));
 }
 
 function normalizeProviderContext(payload: unknown): Array<{ name: string; bytes: number }> {
@@ -76,7 +84,7 @@ function normalizeProviderContext(payload: unknown): Array<{ name: string; bytes
 		pushSection(sections, "user_messages", userMessages);
 		pushSection(sections, "assistant_messages", assistantMessages);
 		pushSection(sections, "tool_messages", toolMessages);
-		pushOtherSection(sections, {
+		pushNonToolContextToUserSection(sections, {
 			...payload,
 			tools: undefined,
 			system: undefined,
@@ -94,7 +102,7 @@ function normalizeProviderContext(payload: unknown): Array<{ name: string; bytes
 		pushSection(sections, "user_messages", userMessages);
 		pushSection(sections, "assistant_messages", assistantMessages);
 		pushSection(sections, "tool_messages", toolMessages);
-		pushOtherSection(sections, {
+		pushNonToolContextToUserSection(sections, {
 			...payload,
 			tools: undefined,
 			systemInstruction: undefined,

--- a/ddapm_test_agent/pi_lapdog_extension.ts
+++ b/ddapm_test_agent/pi_lapdog_extension.ts
@@ -30,6 +30,67 @@ function truncate(value: unknown, maxBytes: number = MAX_OUTPUT_BYTES): string {
 	return str.slice(0, maxBytes) + `\n... (truncated, ${str.length} bytes total)`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function byteLength(value: unknown): number {
+	try {
+		return new TextEncoder().encode(JSON.stringify(value ?? null)).length;
+	} catch {
+		return 0;
+	}
+}
+
+function pushSection(sections: Array<{ name: string; bytes: number }>, name: string, value: unknown): void {
+	if (value === undefined || value === null) return;
+	const bytes = byteLength(value);
+	if (bytes > 0) sections.push({ name, bytes });
+}
+
+function normalizeProviderContext(payload: unknown): Array<{ name: string; bytes: number }> {
+	if (!isRecord(payload)) return [];
+
+	const sections: Array<{ name: string; bytes: number }> = [];
+	const tools = payload.tools;
+	pushSection(sections, "tools", tools);
+
+	if (Array.isArray(payload.messages)) {
+		const messages = payload.messages.filter(isRecord);
+		const systemMessages = messages.filter((m) => m.role === "system" || m.role === "developer");
+		const userMessages = messages.filter((m) => m.role === "user");
+		const assistantMessages = messages.filter((m) => m.role === "assistant");
+		const toolMessages = messages.filter((m) => m.role === "tool");
+		pushSection(sections, "system", payload.system ?? systemMessages);
+		pushSection(sections, "user_messages", userMessages);
+		pushSection(sections, "assistant_messages", assistantMessages);
+		pushSection(sections, "tool_messages", toolMessages);
+		return sections;
+	}
+
+	if (Array.isArray(payload.contents)) {
+		const contents = payload.contents.filter(isRecord);
+		const userMessages = contents.filter((m) => m.role === "user");
+		const assistantMessages = contents.filter((m) => m.role === "model");
+		const toolMessages = contents.filter((m) => m.role !== "user" && m.role !== "model");
+		pushSection(sections, "system", payload.systemInstruction);
+		pushSection(sections, "user_messages", userMessages);
+		pushSection(sections, "assistant_messages", assistantMessages);
+		pushSection(sections, "tool_messages", toolMessages);
+		return sections;
+	}
+
+	pushSection(sections, "request", payload);
+	return sections;
+}
+
+function resolvePayloadModel(payload: unknown, currentModel: string): string {
+	if (isRecord(payload) && typeof payload.model === "string" && payload.model.length > 0) {
+		return payload.model;
+	}
+	return currentModel;
+}
+
 /** Fire-and-forget POST. Errors are silently swallowed. */
 function post(event: string, sessionId: string, data: Record<string, unknown>): void {
 	try {
@@ -42,17 +103,6 @@ function post(event: string, sessionId: string, data: Record<string, unknown>): 
 	} catch {
 		// fetch itself can throw synchronously in some edge cases
 	}
-}
-
-/**
- * Extract text from user message content (string or content array).
- */
-function extractUserText(content: string | Array<{ type: string; text?: string }>): string {
-	if (typeof content === "string") return content;
-	return content
-		.filter((c): c is { type: "text"; text: string } => c.type === "text" && typeof c.text === "string")
-		.map((c) => c.text)
-		.join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -141,6 +191,7 @@ export default function lapdog(pi: ExtensionAPI): void {
 		post("agent_end", sessionId, {
 			output: truncate(outputText),
 			num_messages: event.messages.length,
+			model_provider: currentProvider,
 		});
 	});
 
@@ -162,8 +213,26 @@ export default function lapdog(pi: ExtensionAPI): void {
 	});
 
 	// ------------------------------------------------------------------
-	// LLM message lifecycle (creates LLM spans)
+	// Provider request context + LLM message lifecycle
 	// ------------------------------------------------------------------
+
+	pi.on("before_provider_request", (event, ctx) => {
+		const model = ctx.model;
+		if (model) {
+			currentModel = model.id;
+			currentProvider = model.provider;
+		}
+		const contextUsage = ctx.getContextUsage();
+		const payload = event.payload;
+		const modelId = resolvePayloadModel(payload, currentModel);
+		post("provider_request_context", sessionId, {
+			model_id: modelId,
+			model_provider: currentProvider,
+			context_window_size: contextUsage?.contextWindow ?? 0,
+			estimated_input_tokens: contextUsage?.tokens ?? null,
+			sections: normalizeProviderContext(payload),
+		});
+	});
 
 	pi.on("message_start", (event) => {
 		if (event.message.role !== "assistant") return;

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description_content_type="text/markdown",
     license="BSD 3",
     packages=find_packages(exclude=["tests*", "releasenotes", "scripts"]),
-    package_data={"ddapm_test_agent": ["py.typed", "templates/*", "static/*", "claude_intercept.mjs"]},
+    package_data={"ddapm_test_agent": ["py.typed", "templates/*", "static/*", "claude_intercept.mjs", "pi_lapdog_extension.ts"]},
     python_requires=">=3.8",
     install_requires=[
         "aiohttp",

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -60,13 +60,12 @@ async def test_pi_llm_span_gets_context_breakdown_and_root_gets_context_delta(ag
             "hook_event_name": "provider_request_context",
             "model_id": "gpt-4.1",
             "model_provider": "openai",
-            "context_window_size": 128000,
+            "context_window_size": 1000,
             "estimated_input_tokens": 700,
             "sections": [
                 {"name": "system", "bytes": 100},
                 {"name": "tools", "bytes": 200},
-                {"name": "user_messages", "bytes": 400},
-                {"name": "other", "bytes": 300},
+                {"name": "user_messages", "bytes": 700},
             ],
         },
     )
@@ -107,12 +106,16 @@ async def test_pi_llm_span_gets_context_breakdown_and_root_gets_context_delta(ag
     assert len(llm_spans) == 1
     llm_span = llm_spans[0]
     context_breakdown = llm_span["meta"]["metadata"]["_dd"]["context_breakdown"]
-    assert context_breakdown["context_window_size"] == 128000
+    assert context_breakdown["context_window_size"] == 1000
     assert context_breakdown["total_input_tokens"] == 620
+    assert context_breakdown["context_usage_pct"] == 62.0
     assert context_breakdown["model_name"] == "gpt-4.1"
-    assert [section["name"] for section in context_breakdown["sections"]] == ["system", "tools", "user_messages", "other"]
-    other_section = next(section for section in context_breakdown["sections"] if section["name"] == "other")
-    assert other_section["tokens"] > 0
+    assert [section["name"] for section in context_breakdown["sections"]] == ["system", "tools", "user_messages"]
+    assert context_breakdown["sections"] == [
+        {"name": "system", "tokens": 62, "pct": 6.2},
+        {"name": "tools", "tokens": 124, "pct": 12.4},
+        {"name": "user_messages", "tokens": 434, "pct": 43.4},
+    ]
 
     root_spans = [span for span in spans if span["meta"]["span"]["kind"] == "agent"]
     assert len(root_spans) == 1
@@ -122,7 +125,7 @@ async def test_pi_llm_span_gets_context_breakdown_and_root_gets_context_delta(ag
     assert context_delta["first_input_tokens"] == 0
     assert context_delta["last_input_tokens"] == 620
     assert context_delta["delta_tokens"] == 620
-    assert context_delta["context_window_size"] == 128000
+    assert context_delta["context_window_size"] == 1000
     assert context_delta["last_sections"] == context_breakdown["sections"]
 
 

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -66,6 +66,7 @@ async def test_pi_llm_span_gets_context_breakdown_and_root_gets_context_delta(ag
                 {"name": "system", "bytes": 100},
                 {"name": "tools", "bytes": 200},
                 {"name": "user_messages", "bytes": 400},
+                {"name": "other", "bytes": 300},
             ],
         },
     )
@@ -109,7 +110,9 @@ async def test_pi_llm_span_gets_context_breakdown_and_root_gets_context_delta(ag
     assert context_breakdown["context_window_size"] == 128000
     assert context_breakdown["total_input_tokens"] == 620
     assert context_breakdown["model_name"] == "gpt-4.1"
-    assert [section["name"] for section in context_breakdown["sections"]] == ["system", "tools", "user_messages"]
+    assert [section["name"] for section in context_breakdown["sections"]] == ["system", "tools", "user_messages", "other"]
+    other_section = next(section for section in context_breakdown["sections"] if section["name"] == "other")
+    assert other_section["tokens"] > 0
 
     root_spans = [span for span in spans if span["meta"]["span"]["kind"] == "agent"]
     assert len(root_spans) == 1

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -1,0 +1,269 @@
+import json
+
+
+async def _post_pi_hook(agent, event):
+    return await agent.post(
+        "/pi/hooks",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps(event),
+    )
+
+
+async def test_pi_hook_endpoint_returns_ok(agent):
+    resp = await _post_pi_hook(
+        agent,
+        {
+            "session_id": "pi-sess-1",
+            "hook_event_name": "session_start",
+            "model_id": "gpt-4.1",
+            "model_provider": "openai",
+        },
+    )
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["status"] == "ok"
+
+
+async def test_pi_hook_missing_session_id(agent):
+    resp = await _post_pi_hook(agent, {"hook_event_name": "session_start"})
+    assert resp.status == 400
+    body = await resp.json()
+    assert "session_id" in body["error"]
+
+
+async def test_pi_llm_span_gets_context_breakdown_and_root_gets_context_delta(agent):
+    session_id = "pi-context-single-turn"
+
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "session_start",
+            "model_id": "gpt-4.1",
+            "model_provider": "openai",
+        },
+    )
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "agent_start",
+            "user_prompt": "Summarize this project",
+            "model_id": "gpt-4.1",
+            "model_provider": "openai",
+        },
+    )
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "provider_request_context",
+            "model_id": "gpt-4.1",
+            "model_provider": "openai",
+            "context_window_size": 128000,
+            "estimated_input_tokens": 700,
+            "sections": [
+                {"name": "system", "bytes": 100},
+                {"name": "tools", "bytes": 200},
+                {"name": "user_messages", "bytes": 400},
+            ],
+        },
+    )
+    await _post_pi_hook(agent, {"session_id": session_id, "hook_event_name": "message_start"})
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "message_end",
+            "model_id": "gpt-4.1",
+            "model_provider": "openai",
+            "usage": {
+                "input": 500,
+                "output": 80,
+                "cacheRead": 100,
+                "cacheWrite": 20,
+                "totalTokens": 700,
+            },
+            "output_text": "Here is the summary.",
+        },
+    )
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "agent_end",
+            "output": "Here is the summary.",
+            "model_provider": "openai",
+        },
+    )
+
+    resp = await agent.get("/claude/hooks/spans")
+    assert resp.status == 200
+    body = await resp.json()
+    spans = [span for span in body["spans"] if span.get("session_id") == session_id]
+
+    llm_spans = [span for span in spans if span["meta"]["span"]["kind"] == "llm"]
+    assert len(llm_spans) == 1
+    llm_span = llm_spans[0]
+    context_breakdown = llm_span["meta"]["metadata"]["_dd"]["context_breakdown"]
+    assert context_breakdown["context_window_size"] == 128000
+    assert context_breakdown["total_input_tokens"] == 620
+    assert context_breakdown["model_name"] == "gpt-4.1"
+    assert [section["name"] for section in context_breakdown["sections"]] == ["system", "tools", "user_messages"]
+
+    root_spans = [span for span in spans if span["meta"]["span"]["kind"] == "agent"]
+    assert len(root_spans) == 1
+    root_span = root_spans[0]
+    assert root_span["meta"]["model_provider"] == "openai"
+    context_delta = root_span["meta"]["metadata"]["_dd"]["context_delta"]
+    assert context_delta["first_input_tokens"] == 0
+    assert context_delta["last_input_tokens"] == 620
+    assert context_delta["delta_tokens"] == 620
+    assert context_delta["context_window_size"] == 128000
+    assert context_delta["last_sections"] == context_breakdown["sections"]
+
+
+async def test_pi_context_delta_persists_across_turns(agent):
+    session_id = "pi-context-two-turns"
+
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "session_start",
+            "model_id": "gpt-4.1",
+            "model_provider": "openai",
+        },
+    )
+
+    async def run_turn(input_tokens, output_text):
+        await _post_pi_hook(
+            agent,
+            {
+                "session_id": session_id,
+                "hook_event_name": "agent_start",
+                "user_prompt": "continue",
+                "model_id": "gpt-4.1",
+                "model_provider": "openai",
+            },
+        )
+        await _post_pi_hook(
+            agent,
+            {
+                "session_id": session_id,
+                "hook_event_name": "provider_request_context",
+                "model_id": "gpt-4.1",
+                "model_provider": "openai",
+                "context_window_size": 128000,
+                "estimated_input_tokens": input_tokens,
+                "sections": [
+                    {"name": "system", "bytes": 100},
+                    {"name": "user_messages", "bytes": 300},
+                    {"name": "assistant_messages", "bytes": 200},
+                ],
+            },
+        )
+        await _post_pi_hook(agent, {"session_id": session_id, "hook_event_name": "message_start"})
+        await _post_pi_hook(
+            agent,
+            {
+                "session_id": session_id,
+                "hook_event_name": "message_end",
+                "model_id": "gpt-4.1",
+                "model_provider": "openai",
+                "usage": {
+                    "input": input_tokens,
+                    "output": 50,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                    "totalTokens": input_tokens + 50,
+                },
+                "output_text": output_text,
+            },
+        )
+        await _post_pi_hook(
+            agent,
+            {
+                "session_id": session_id,
+                "hook_event_name": "agent_end",
+                "output": output_text,
+                "model_provider": "openai",
+            },
+        )
+
+    await run_turn(620, "turn one")
+    await run_turn(900, "turn two")
+
+    resp = await agent.get("/claude/hooks/spans")
+    assert resp.status == 200
+    body = await resp.json()
+    root_spans = [
+        span
+        for span in body["spans"]
+        if span.get("session_id") == session_id and span["meta"]["span"]["kind"] == "agent"
+    ]
+    assert len(root_spans) == 2
+
+    root_spans.sort(key=lambda span: span["start_ns"])
+    first_delta = root_spans[0]["meta"]["metadata"]["_dd"]["context_delta"]
+    second_delta = root_spans[1]["meta"]["metadata"]["_dd"]["context_delta"]
+
+    assert first_delta["first_input_tokens"] == 0
+    assert first_delta["last_input_tokens"] == 620
+    assert first_delta["delta_tokens"] == 620
+
+    assert second_delta["first_input_tokens"] == 620
+    assert second_delta["last_input_tokens"] == 900
+    assert second_delta["delta_tokens"] == 280
+
+
+async def test_pi_compaction_metadata_is_preserved(agent):
+    session_id = "pi-compaction"
+
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "session_start",
+            "model_id": "gpt-4.1",
+            "model_provider": "openai",
+        },
+    )
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "agent_start",
+            "user_prompt": "compact now",
+            "model_id": "gpt-4.1",
+            "model_provider": "openai",
+        },
+    )
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "session_compact",
+            "from_extension": True,
+        },
+    )
+    await _post_pi_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "agent_end",
+            "output": "done",
+            "model_provider": "openai",
+        },
+    )
+
+    resp = await agent.get("/claude/hooks/spans")
+    assert resp.status == 200
+    body = await resp.json()
+    root_span = next(
+        span
+        for span in body["spans"]
+        if span.get("session_id") == session_id and span["meta"]["span"]["kind"] == "agent"
+    )
+    compactions = root_span["meta"]["metadata"]["_dd"]["compactions"]
+    assert compactions == [{"trigger": "auto"}]


### PR DESCRIPTION
## Summary
- capture provider request context from the pi lapdog extension and attach context_breakdown metadata to pi LLM spans
- compute root-span context_delta from pi turns using the reported context window, and preserve model provider state across events
- keep pi compaction metadata covered with dedicated hook tests

<img width="469" height="277" alt="Screenshot 2026-04-14 at 3 48 43 PM" src="https://github.com/user-attachments/assets/266866d9-fa0e-427f-a71e-05f55020733d" />


[trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Alapdog%20%40event_type%3Aspan%20%40parent_id%3Aundefined%20user_handle%3Atom.shen%40datadoghq.com&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&is_llm_session=false&is_llm_sessions_list=true&refresh_mode=sliding&selectedTab=overview&sp=%5B%7B%22mp%22%3A%7B%22className%22%3A%22llm-obs-panel_WDDTtW_isSessionExpanded%22%7D%2C%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ2NSU_1tvtMdgAAABhBWjJOU1VfMUFBRHZpTEFIZXdoT0FBQUEAAAAkZjE5ZDhkNGYtOWMzYy00NzUwLWE0YTEtZWJkZTMwNzY5NzUxAAI5AA%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=17333947153418726705&start=1775591299668&end=1776196099668&paused=false)

## Testing
- python -m pytest tests/test_pi_hooks.py -v

Follow-up to #325.