### PR TITLE
Emit step span kind from pi hooks

### DIFF
--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -7,16 +7,22 @@ span storage so that pi traces appear alongside Claude Code traces in the UI.
 Pi extension events and their mapping:
 
     session_start     → create session, set model
-    agent_start       → start new trace (like UserPromptSubmit)
-    agent_end         → finalize root span (like Stop)
-    message_start     → begin tracking an LLM span
+    agent_start       → start new trace / root agent span (proposal "turn")
+    agent_end         → finalize root span
+    turn_start        → open a step span (proposal "step" = one inference cycle)
+    turn_end          → finalize step span
+    message_start     → begin tracking an LLM span (child of step)
     message_end       → emit LLM span with token usage
-    tool_execution_start → create pending tool span (like PreToolUse)
-    tool_execution_end   → emit tool span (like PostToolUse)
-    turn_start / turn_end → logged, no span emitted
+    tool_execution_start → create pending tool span (child of step)
+    tool_execution_end   → emit tool span
     model_select      → update session model
     session_compact   → mark compaction on current span
     session_shutdown  → finalize session (like SessionEnd)
+
+Terminology mapping (pi → trajectory-dev proposal):
+    pi agent_start/agent_end  →  proposal "turn" (full response to one user input)
+    pi turn_start/turn_end    →  proposal "step" (one inference cycle + its tools)
+    pi message_start/end      →  proposal LLM call within a step
 """
 
 import json
@@ -26,6 +32,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 from aiohttp import web
 from aiohttp.web import Request
@@ -55,6 +62,61 @@ class PendingLLMSpan:
         self.start_ns = start_ns
 
 
+class ActiveStepSpan:
+    """Tracks the active step (inference cycle) for a session.
+
+    A step groups one LLM call and its downstream tool executions.
+    It maps to a ``turn_start`` / ``turn_end`` pair in pi's event model and
+    to the ``step`` span kind in the trajectory-dev proposal.
+    """
+
+    def __init__(
+        self,
+        span_id: str,
+        parent_id: str,
+        start_ns: int,
+        message_index: int,
+        turn_index: Optional[int] = None,
+    ) -> None:
+        self.span_id = span_id
+        self.parent_id = parent_id
+        self.start_ns = start_ns
+        self.message_index = message_index
+        self.turn_index = turn_index
+        self.output_text = ""
+        self.tool_use_ids: List[str] = []
+        self.has_thinking = False
+        self.stop_reason = ""
+        self.span_ref: Optional[Dict[str, Any]] = None
+
+
+def _extract_output_text_and_tool_calls(
+    content: List[Dict[str, Any]],
+) -> Tuple[str, List[Dict[str, Any]], List[str], bool]:
+    """Parse assistant message content blocks.
+
+    Returns ``(output_text, tool_calls, tool_use_ids, has_thinking)``.
+    """
+    text_parts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
+    tool_use_ids: List[str] = []
+    has_thinking = False
+
+    for block in content:
+        btype = block.get("type", "")
+        if btype == "text" and block.get("text"):
+            text_parts.append(block["text"])
+        elif btype == "toolCall":
+            tid = block.get("id", "")
+            tool_calls.append({"id": tid, "name": block.get("name"), "arguments": block.get("arguments")})
+            if tid:
+                tool_use_ids.append(tid)
+        elif btype in ("thinking", "reasoning"):
+            has_thinking = True
+
+    return "\n".join(text_parts), tool_calls, tool_use_ids, has_thinking
+
+
 class PiHooksAPI:
     """Handler for pi coding agent hook events.
 
@@ -67,6 +129,12 @@ class PiHooksAPI:
         self._raw_events: List[Dict[str, Any]] = []
         # Pending LLM span per session (pi sends one LLM call at a time)
         self._pending_llm: Dict[str, PendingLLMSpan] = {}
+        # Active step span per session (one inference cycle)
+        self._active_steps: Dict[str, ActiveStepSpan] = {}
+        # Per-session step counter (resets each agent cycle)
+        self._step_indexes: Dict[str, int] = {}
+        # Per-session turn index from extension events
+        self._turn_indexes: Dict[str, Optional[int]] = {}
 
     # ------------------------------------------------------------------
     # Helpers — access shared state via hooks_api
@@ -80,6 +148,117 @@ class PiHooksAPI:
 
     def _append_span(self, span: Dict[str, Any]) -> None:
         self._hooks_api._assembled_spans.append(span)
+
+    def _active_step_parent_id(self, session: SessionState) -> str:
+        """Return active step span_id if one exists, else fall back to root/agent parent."""
+        active = self._active_steps.get(session.session_id)
+        if active:
+            return active.span_id
+        return self._current_parent_id(session)
+
+    # ------------------------------------------------------------------
+    # Step lifecycle helpers
+    # ------------------------------------------------------------------
+
+    def _start_step(self, session: SessionState, turn_index: Optional[int] = None) -> ActiveStepSpan:
+        """Open a new step span.  Finalizes any prior active step first."""
+        sid = session.session_id
+        # Finalize prior step if still open
+        self._finalize_active_step(sid)
+
+        # Use current counter value as 0-based index, then advance.
+        # After this, _step_indexes[sid] is always (last emitted index + 1).
+        idx = self._step_indexes.get(sid, 0)
+        self._step_indexes[sid] = idx + 1
+
+        now_ns = int(time.time() * 1_000_000_000)
+        span_id = _format_span_id()
+        parent_id = self._current_parent_id(session)
+
+        tags = [
+            f"ml_app:{_ML_APP}",
+            f"session_id:{session.session_id}",
+            f"service:{_ML_APP}",
+            "env:local",
+            "source:pi-hooks",
+            "language:python",
+            f"hostname:{_HOSTNAME}",
+            "trajectory.semantic_type:agent_message",
+        ]
+        if _USER_HANDLE:
+            tags.append(f"user_handle:{_USER_HANDLE}")
+
+        step_span: Dict[str, Any] = {
+            "span_id": span_id,
+            "trace_id": session.trace_id,
+            "parent_id": parent_id,
+            "name": f"inference-{idx}",
+            "status": "ok",
+            "start_ns": now_ns,
+            "duration": 0,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": tags,
+            "meta": {
+                "span": {"kind": "step"},
+                "input": {},
+                "output": {"value": ""},
+                "metadata": {},
+            },
+            "metrics": {},
+        }
+        self._append_span(step_span)
+
+        active = ActiveStepSpan(
+            span_id=span_id,
+            parent_id=parent_id,
+            start_ns=now_ns,
+            message_index=idx,
+            turn_index=turn_index,
+        )
+        active.span_ref = step_span
+        self._active_steps[sid] = active
+        return active
+
+    def _finalize_active_step(self, session_id: str, end_ns: Optional[int] = None) -> None:
+        """Close the active step span, updating its metadata in-place."""
+        active = self._active_steps.pop(session_id, None)
+        if not active:
+            return
+
+        if end_ns is None:
+            end_ns = int(time.time() * 1_000_000_000)
+
+        ref = active.span_ref
+        if ref is None:
+            return
+
+        ref["duration"] = end_ns - active.start_ns
+        ref["meta"]["output"]["value"] = active.output_text
+
+        metadata = ref["meta"].setdefault("metadata", {})
+        metadata["message_index"] = active.message_index
+        if active.turn_index is not None:
+            metadata["turn_index"] = active.turn_index
+        if active.tool_use_ids:
+            metadata["tool_use_ids"] = active.tool_use_ids
+        if active.has_thinking:
+            metadata["has_thinking"] = True
+        if active.stop_reason:
+            metadata["stop_reason"] = active.stop_reason
+
+    def _clear_pi_state(self, session_id: str) -> None:
+        """Reset all pi-local tracking state for a session.
+
+        Call ``_finalize_active_step`` first if the active step should be
+        properly closed; this method drops state without finalizing.
+        """
+        self._active_steps.pop(session_id, None)
+        self._step_indexes[session_id] = 0
+        self._turn_indexes.pop(session_id, None)
+        self._pending_llm.pop(session_id, None)
 
     # ------------------------------------------------------------------
     # Event handlers
@@ -110,12 +289,22 @@ class PiHooksAPI:
         log.info("Pi model changed: %s → %s/%s", session_id, model_provider, model_id)
 
     def _handle_agent_start(self, session_id: str, body: Dict[str, Any]) -> None:
-        """Start a new trace for each user turn (equivalent to UserPromptSubmit)."""
+        """Start a new trace for each user turn (equivalent to UserPromptSubmit).
+
+        The root agent span represents the proposal's "turn" — the full agentic
+        response to one user input.
+        """
         session = self._get_or_create_session(session_id)
 
         # Finalize previous turn if it wasn't finalized
         if not session.root_span_emitted and getattr(session, "_root_span_ref", None) is not None:
+            self._finalize_active_step(session_id)
             self._hooks_api._finalize_interrupted_turn(session)
+
+        # Clear pi-local state for the new agent cycle.
+        # _finalize_active_step already ran above (if needed), so this
+        # second pop from _active_steps is a harmless no-op.
+        self._clear_pi_state(session_id)
 
         # Start fresh trace
         if session.root_span_emitted:
@@ -146,6 +335,19 @@ class PiHooksAPI:
         if model_provider:
             session.model_provider = model_provider
 
+        tags = [
+            f"ml_app:{_ML_APP}",
+            f"session_id:{session.session_id}",
+            f"service:{_ML_APP}",
+            "env:local",
+            "source:pi-hooks",
+            "language:python",
+            f"hostname:{_HOSTNAME}",
+            "trajectory.semantic_type:turn",
+        ]
+        if _USER_HANDLE:
+            tags.append(f"user_handle:{_USER_HANDLE}")
+
         root_span: Dict[str, Any] = {
             "span_id": session.root_span_id,
             "trace_id": session.trace_id,
@@ -158,16 +360,7 @@ class PiHooksAPI:
             "service": _ML_APP,
             "env": "local",
             "session_id": session.session_id,
-            "tags": [
-                f"ml_app:{_ML_APP}",
-                f"session_id:{session.session_id}",
-                f"service:{_ML_APP}",
-                "env:local",
-                "source:pi-hooks",
-                "language:python",
-                f"hostname:{_HOSTNAME}",
-            ]
-            + ([f"user_handle:{_USER_HANDLE}"] if _USER_HANDLE else []),
+            "tags": tags,
             "meta": {
                 "span": {"kind": "agent"},
                 "input": {"value": prompt},
@@ -187,6 +380,9 @@ class PiHooksAPI:
         if not session:
             log.warning("agent_end for unknown session %s", session_id)
             return
+
+        # Finalize any open step before closing the turn
+        self._finalize_active_step(session_id)
 
         now_ns = int(time.time() * 1_000_000_000)
         duration = now_ns - session.start_ns
@@ -241,6 +437,18 @@ class PiHooksAPI:
                 self._hooks_api._set_hidden_metadata(root_span, **dd_fields)
         else:
             # Fallback: create root span
+            tags = [
+                f"ml_app:{_ML_APP}",
+                f"session_id:{session.session_id}",
+                f"service:{_ML_APP}",
+                "env:local",
+                "source:pi-hooks",
+                "language:python",
+                f"hostname:{_HOSTNAME}",
+                "trajectory.semantic_type:turn",
+            ]
+            if _USER_HANDLE:
+                tags.append(f"user_handle:{_USER_HANDLE}")
             root_span = {
                 "span_id": session.root_span_id,
                 "trace_id": session.trace_id,
@@ -253,16 +461,7 @@ class PiHooksAPI:
                 "service": _ML_APP,
                 "env": "local",
                 "session_id": session.session_id,
-                "tags": [
-                    f"ml_app:{_ML_APP}",
-                    f"session_id:{session.session_id}",
-                    f"service:{_ML_APP}",
-                    "env:local",
-                    "source:pi-hooks",
-                    "language:python",
-                    f"hostname:{_HOSTNAME}",
-                ]
-                + ([f"user_handle:{_USER_HANDLE}"] if _USER_HANDLE else []),
+                "tags": tags,
                 "meta": {
                     "span": {"kind": "agent"},
                     "input": {"value": input_value},
@@ -277,11 +476,35 @@ class PiHooksAPI:
 
         session.root_span_emitted = True
 
-    def _handle_message_start(self, session_id: str, body: Dict[str, Any]) -> None:
-        """Begin tracking an LLM call."""
+    def _handle_turn_start(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Open a step span for this inference cycle (primary step open point)."""
         session = self._get_or_create_session(session_id)
+        turn_index = body.get("turn_index")
+        if turn_index is not None:
+            self._turn_indexes[session_id] = turn_index
+        self._start_step(session, turn_index=turn_index)
+        log.debug("Pi turn_start for session %s: turn_index=%s", session_id, turn_index)
+
+    def _handle_turn_end(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Finalize the active step span (primary step finalization point)."""
+        self._finalize_active_step(session_id)
+        log.debug("Pi turn_end for session %s: turn_index=%s", session_id, body.get("turn_index"))
+
+    def _handle_message_start(self, session_id: str, body: Dict[str, Any]) -> None:
+        """Begin tracking an LLM call.
+
+        If no step is active (e.g. ``message_start`` arrived without a preceding
+        ``turn_start``), opens a fallback step so tools still have a parent.
+        """
+        session = self._get_or_create_session(session_id)
+
+        # Ensure a step exists (fallback if turn_start was missed)
+        if session_id not in self._active_steps:
+            turn_index = self._turn_indexes.get(session_id)
+            self._start_step(session, turn_index=turn_index)
+
+        parent_id = self._active_step_parent_id(session)
         span_id = _format_span_id()
-        parent_id = self._current_parent_id(session)
         now_ns = int(time.time() * 1_000_000_000)
         self._pending_llm[session_id] = PendingLLMSpan(
             span_id=span_id,
@@ -290,7 +513,13 @@ class PiHooksAPI:
         )
 
     def _handle_message_end(self, session_id: str, body: Dict[str, Any]) -> None:
-        """Emit an LLM span with token usage and tool calls."""
+        """Emit an LLM span with token usage and tool calls.
+
+        Also updates the active step's metadata with the assistant response
+        content (output text, tool_use_ids, stop_reason, etc.).  The step
+        itself is NOT finalized here — it stays open so downstream tool spans
+        can parent to it.  ``turn_end`` or ``agent_end`` finalizes it.
+        """
         session = self._hooks_api._sessions.get(session_id)
         if not session:
             return
@@ -304,7 +533,7 @@ class PiHooksAPI:
             start_ns = pending.start_ns
         else:
             span_id = _format_span_id()
-            parent_id = self._current_parent_id(session)
+            parent_id = self._active_step_parent_id(session)
             start_ns = now_ns
 
         duration = now_ns - start_ns
@@ -314,22 +543,25 @@ class PiHooksAPI:
         usage = body.get("usage") or {}
         stop_reason = body.get("stop_reason", "")
 
-        # Extract tool calls and output text from the content array (processing moved from extension)
+        # Extract tool calls and output text from the content array
         content = body.get("content", [])
-        tool_calls: List[Dict[str, Any]] = []
-        output_text = ""
         if content:
-            text_parts = []
-            for c in content:
-                if c.get("type") == "toolCall":
-                    tool_calls.append({"id": c.get("id"), "name": c.get("name"), "arguments": c.get("arguments")})
-                elif c.get("type") == "text" and c.get("text"):
-                    text_parts.append(c["text"])
-            output_text = "\n".join(text_parts)
+            output_text, tool_calls, tool_use_ids, has_thinking = _extract_output_text_and_tool_calls(content)
         else:
             # Fallback for older extension format
             output_text = body.get("output_text", "")
-            tool_calls = body.get("tool_calls", [])
+            raw_tool_calls = body.get("tool_calls", [])
+            tool_calls = raw_tool_calls
+            tool_use_ids = [tc.get("id", "") for tc in raw_tool_calls if tc.get("id")]
+            has_thinking = False
+
+        # Update active step metadata
+        active = self._active_steps.get(session_id)
+        if active:
+            active.output_text = output_text
+            active.tool_use_ids = tool_use_ids
+            active.has_thinking = has_thinking
+            active.stop_reason = stop_reason
 
         # Build input/output messages in LLMObs format
         output_messages: List[Dict[str, Any]] = []
@@ -413,7 +645,11 @@ class PiHooksAPI:
         self._append_span(span)
 
     def _handle_tool_execution_start(self, session_id: str, body: Dict[str, Any]) -> None:
-        """Create a pending tool span (equivalent to PreToolUse)."""
+        """Create a pending tool span (equivalent to PreToolUse).
+
+        Parent is set to the active step span so tools nest under the inference
+        cycle that requested them.
+        """
         session = self._get_or_create_session(session_id)
         tool_name = body.get("tool_name", "unknown_tool")
         tool_call_id = body.get("tool_call_id", tool_name)
@@ -421,7 +657,7 @@ class PiHooksAPI:
         session.tools_used.add(tool_name)
 
         span_id = _format_span_id()
-        parent_id = self._current_parent_id(session)
+        parent_id = self._active_step_parent_id(session)
         now_ns = int(time.time() * 1_000_000_000)
 
         # Parse args string back to dict for tool_input if possible
@@ -462,7 +698,7 @@ class PiHooksAPI:
             actual_tool_name = pending.tool_name
         else:
             span_id = _format_span_id()
-            parent_id = self._current_parent_id(session)
+            parent_id = self._active_step_parent_id(session)
             start_ns = now_ns
             input_value = ""
             actual_tool_name = tool_name
@@ -521,17 +757,13 @@ class PiHooksAPI:
             }
         )
 
-    def _handle_turn_start(self, session_id: str, body: Dict[str, Any]) -> None:
-        log.debug("Pi turn_start for session %s: turn_index=%s", session_id, body.get("turn_index"))
-
-    def _handle_turn_end(self, session_id: str, body: Dict[str, Any]) -> None:
-        log.debug("Pi turn_end for session %s: turn_index=%s", session_id, body.get("turn_index"))
-
     def _handle_session_shutdown(self, session_id: str, body: Dict[str, Any]) -> None:
         """Finalize session (equivalent to SessionEnd)."""
         session = self._hooks_api._sessions.get(session_id)
         if not session:
             return
+        # Finalize any open step before closing the session
+        self._finalize_active_step(session_id)
         if not session.root_span_emitted:
             self._hooks_api._finalize_interrupted_turn(session)
 

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -50,6 +50,7 @@ from .claude_hooks import _format_trace_id
 from .claude_hooks import _to_json_str
 from .llmobs_event_platform import with_cors
 
+
 log = logging.getLogger(__name__)
 
 

--- a/releasenotes/notes/emit-step-spans-for-pi-7d3447e7a1b7f7c2.yaml
+++ b/releasenotes/notes/emit-step-spans-for-pi-7d3447e7a1b7f7c2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Emit step spans for pi coding agent sessions.

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -260,7 +260,7 @@ async def test_multiple_steps(agent):
     assert step_names == ["inference-0", "inference-1"]
 
     # Each LLM parents to its own step
-    llm_parents = {l["parent_id"] for l in llms}
+    llm_parents = {llm["parent_id"] for llm in llms}
     step_ids = {s["span_id"] for s in steps}
     assert llm_parents == step_ids
 

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -1,0 +1,487 @@
+"""Tests for pi coding agent hooks — step span kind emission."""
+
+import json
+
+
+async def _post(agent, event):
+    return await agent.post(
+        "/pi/hooks",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps(event),
+    )
+
+
+def _spans(body):
+    """Return spans from /claude/hooks/spans response body."""
+    return body["spans"]
+
+
+def _by_kind(spans, kind):
+    return [s for s in spans if s.get("meta", {}).get("span", {}).get("kind") == kind]
+
+
+def _has_tag(span, tag):
+    return tag in span.get("tags", [])
+
+
+SESSION = "pi-test-sess"
+
+
+def _session_start(
+    session_id=SESSION,
+    model_id="claude-sonnet-4-20250514",
+    model_provider="anthropic",
+):
+    return {
+        "session_id": session_id,
+        "hook_event_name": "session_start",
+        "model_id": model_id,
+        "model_provider": model_provider,
+    }
+
+
+def _agent_start(session_id=SESSION, prompt="hello"):
+    return {
+        "session_id": session_id,
+        "hook_event_name": "agent_start",
+        "user_prompt": prompt,
+        "model_id": "claude-sonnet-4-20250514",
+        "model_provider": "anthropic",
+    }
+
+
+def _agent_end(session_id=SESSION, messages=None):
+    return {"session_id": session_id, "hook_event_name": "agent_end", "messages": messages or []}
+
+
+def _turn_start(session_id=SESSION, turn_index=0):
+    return {"session_id": session_id, "hook_event_name": "turn_start", "turn_index": turn_index}
+
+
+def _turn_end(session_id=SESSION, turn_index=0):
+    return {"session_id": session_id, "hook_event_name": "turn_end", "turn_index": turn_index}
+
+
+def _message_start(session_id=SESSION):
+    return {"session_id": session_id, "hook_event_name": "message_start", "message_role": "assistant"}
+
+
+def _message_end(session_id=SESSION, content=None, usage=None, stop_reason="end_turn"):
+    return {
+        "session_id": session_id,
+        "hook_event_name": "message_end",
+        "message_role": "assistant",
+        "model_id": "claude-sonnet-4-20250514",
+        "model_provider": "anthropic",
+        "content": content or [{"type": "text", "text": "Hello!"}],
+        "usage": usage or {"input": 100, "output": 50, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 150},
+        "stop_reason": stop_reason,
+    }
+
+
+def _tool_start(
+    session_id=SESSION,
+    tool_call_id="tool-1",
+    tool_name="read",
+    args="{}",
+):
+    return {
+        "session_id": session_id,
+        "hook_event_name": "tool_execution_start",
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "args": args,
+    }
+
+
+def _tool_end(
+    session_id=SESSION,
+    tool_call_id="tool-1",
+    tool_name="read",
+    result="ok",
+    is_error=False,
+):
+    return {
+        "session_id": session_id,
+        "hook_event_name": "tool_execution_end",
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "result": result,
+        "is_error": is_error,
+    }
+
+
+def _session_shutdown(session_id=SESSION):
+    return {"session_id": session_id, "hook_event_name": "session_shutdown"}
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+async def test_single_step_with_llm_no_tools(agent):
+    """One turn_start/turn_end cycle produces: agent → step → llm."""
+    sid = "pi-single-step"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid, turn_index=0))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid, turn_index=0))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    assert resp.status == 200
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    roots = [s for s in session_spans if s["parent_id"] == "undefined"]
+    assert len(roots) == 1
+    root = roots[0]
+
+    steps = _by_kind(session_spans, "step")
+    assert len(steps) == 1
+    step = steps[0]
+
+    llms = _by_kind(session_spans, "llm")
+    assert len(llms) == 1
+    llm = llms[0]
+
+    # Parenting: root → step → llm
+    assert step["parent_id"] == root["span_id"]
+    assert llm["parent_id"] == step["span_id"]
+
+    # Kinds
+    assert root["meta"]["span"]["kind"] == "agent"
+    assert step["meta"]["span"]["kind"] == "step"
+    assert llm["meta"]["span"]["kind"] == "llm"
+
+    # Step has non-zero duration (covers turn_start → turn_end)
+    assert step["duration"] > 0
+
+    # Step name
+    assert step["name"] == "inference-0"
+
+
+async def test_tools_parent_under_step(agent):
+    """Tool spans should be children of the step, not the root agent."""
+    sid = "pi-tools-step"
+    content = [
+        {"type": "text", "text": "Let me read that file."},
+        {"type": "toolCall", "id": "tc-1", "name": "read", "arguments": {"path": "foo.py"}},
+        {"type": "toolCall", "id": "tc-2", "name": "bash", "arguments": {"command": "ls"}},
+    ]
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid, turn_index=0))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, content=content, stop_reason="tool_use"))
+    await _post(agent, _tool_start(sid, "tc-1", "read", '{"path": "foo.py"}'))
+    await _post(agent, _tool_end(sid, "tc-1", "read", "contents"))
+    await _post(agent, _tool_start(sid, "tc-2", "bash", '{"command": "ls"}'))
+    await _post(agent, _tool_end(sid, "tc-2", "bash", "file1\nfile2"))
+    await _post(agent, _turn_end(sid, turn_index=0))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    steps = _by_kind(session_spans, "step")
+    assert len(steps) == 1
+    step = steps[0]
+
+    tools = _by_kind(session_spans, "tool")
+    assert len(tools) == 2
+
+    # Both tools parent to the step
+    for tool in tools:
+        assert tool["parent_id"] == step["span_id"]
+
+    # LLM also parents to the step
+    llms = _by_kind(session_spans, "llm")
+    assert len(llms) == 1
+    assert llms[0]["parent_id"] == step["span_id"]
+
+    # Step metadata includes tool_use_ids
+    step_meta = step["meta"].get("metadata", {})
+    assert "tc-1" in step_meta.get("tool_use_ids", [])
+    assert "tc-2" in step_meta.get("tool_use_ids", [])
+    assert step_meta.get("stop_reason") == "tool_use"
+
+
+async def test_multiple_steps(agent):
+    """Two turn_start/turn_end cycles produce two sibling step spans."""
+    sid = "pi-multi-step"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+
+    # First step: model calls a tool
+    content1 = [
+        {"type": "text", "text": "Reading file..."},
+        {"type": "toolCall", "id": "tc-a", "name": "read", "arguments": {}},
+    ]
+    await _post(agent, _turn_start(sid, turn_index=0))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, content=content1, stop_reason="tool_use"))
+    await _post(agent, _tool_start(sid, "tc-a", "read"))
+    await _post(agent, _tool_end(sid, "tc-a", "read", "file contents"))
+    await _post(agent, _turn_end(sid, turn_index=0))
+
+    # Second step: model responds with text only
+    content2 = [{"type": "text", "text": "Done!"}]
+    await _post(agent, _turn_start(sid, turn_index=1))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, content=content2, stop_reason="end_turn"))
+    await _post(agent, _turn_end(sid, turn_index=1))
+
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    root = [s for s in session_spans if s["parent_id"] == "undefined"][0]
+    steps = _by_kind(session_spans, "step")
+    llms = _by_kind(session_spans, "llm")
+    tools = _by_kind(session_spans, "tool")
+
+    assert len(steps) == 2
+    assert len(llms) == 2
+    assert len(tools) == 1
+
+    # Both steps parent to root
+    for step in steps:
+        assert step["parent_id"] == root["span_id"]
+
+    # Steps are named sequentially
+    step_names = sorted(s["name"] for s in steps)
+    assert step_names == ["inference-0", "inference-1"]
+
+    # Each LLM parents to its own step
+    llm_parents = {l["parent_id"] for l in llms}
+    step_ids = {s["span_id"] for s in steps}
+    assert llm_parents == step_ids
+
+    # Tool parents to the first step (the one that called it)
+    step0 = next(s for s in steps if s["name"] == "inference-0")
+    assert tools[0]["parent_id"] == step0["span_id"]
+
+
+async def test_trajectory_tags(agent):
+    """Root has trajectory.semantic_type:turn, step has trajectory.semantic_type:agent_message."""
+    sid = "pi-tags"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    root = [s for s in session_spans if s["parent_id"] == "undefined"][0]
+    step = _by_kind(session_spans, "step")[0]
+
+    assert _has_tag(root, "trajectory.semantic_type:turn")
+    assert _has_tag(step, "trajectory.semantic_type:agent_message")
+
+
+async def test_list_api_filters_step_kind(agent):
+    """The LLMObs list API can filter spans by @meta.span.kind:step."""
+    sid = "pi-list-step"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": f"@meta.span.kind:step session_id:{sid}"}, "limit": 50}},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["hitCount"] == 1
+    assert data["result"]["events"][0]["event"]["custom"]["meta"]["span"]["kind"] == "step"
+
+
+async def test_step_finalized_on_agent_end_without_turn_end(agent):
+    """If turn_end is missed, agent_end still finalizes the active step."""
+    sid = "pi-no-turn-end"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    # No turn_end — go straight to agent_end
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    steps = _by_kind(session_spans, "step")
+    assert len(steps) == 1
+    assert steps[0]["duration"] > 0
+
+    # LLM still parents under step
+    llms = _by_kind(session_spans, "llm")
+    assert len(llms) == 1
+    assert llms[0]["parent_id"] == steps[0]["span_id"]
+
+
+async def test_message_start_without_turn_start_creates_fallback_step(agent):
+    """If message_start arrives without turn_start, a fallback step is created."""
+    sid = "pi-no-turn-start"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    # No turn_start — message_start directly
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    steps = _by_kind(session_spans, "step")
+    assert len(steps) == 1
+
+    llms = _by_kind(session_spans, "llm")
+    assert len(llms) == 1
+    assert llms[0]["parent_id"] == steps[0]["span_id"]
+
+
+async def test_step_finalized_on_session_shutdown(agent):
+    """session_shutdown finalizes any open step."""
+    sid = "pi-shutdown"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    # No turn_end, no agent_end — session_shutdown
+    await _post(agent, _session_shutdown(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    steps = _by_kind(session_spans, "step")
+    assert len(steps) == 1
+    assert steps[0]["duration"] > 0
+
+
+async def test_step_metadata_fields(agent):
+    """Step span metadata includes message_index, output text, and turn_index."""
+    sid = "pi-step-meta"
+    content = [
+        {"type": "text", "text": "I'll help with that."},
+        {"type": "toolCall", "id": "tc-x", "name": "edit", "arguments": {"path": "a.py"}},
+    ]
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid, turn_index=3))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, content=content, stop_reason="tool_use"))
+    await _post(agent, _turn_end(sid, turn_index=3))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    step = _by_kind(session_spans, "step")[0]
+    meta = step["meta"]
+
+    assert meta["output"]["value"] == "I'll help with that."
+    md = meta["metadata"]
+    assert md["message_index"] == 0
+    assert md["turn_index"] == 3
+    assert md["tool_use_ids"] == ["tc-x"]
+    assert md["stop_reason"] == "tool_use"
+
+
+async def test_cancelled_turn_no_message(agent):
+    """turn_start followed by turn_end with no message is a no-op step."""
+    sid = "pi-cancelled-turn"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    # No message_start/end
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    # Step still emitted (empty) — this is fine
+    steps = _by_kind(session_spans, "step")
+    assert len(steps) == 1
+    # No LLM or tool spans
+    assert len(_by_kind(session_spans, "llm")) == 0
+    assert len(_by_kind(session_spans, "tool")) == 0
+
+
+async def test_second_agent_cycle_resets_step_index(agent):
+    """Step index resets on each agent_start so the second turn starts at inference-0."""
+    sid = "pi-reset-idx"
+    await _post(agent, _session_start(sid))
+
+    # First agent cycle — one step
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    # Second agent cycle — step index should reset
+    await _post(agent, _agent_start(sid, prompt="second"))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+    steps = _by_kind(session_spans, "step")
+
+    # Both cycles should have inference-0
+    assert len(steps) == 2
+    assert all(s["name"] == "inference-0" for s in steps)
+
+
+async def test_thinking_block_sets_has_thinking(agent):
+    """Content blocks with type 'thinking' set has_thinking on the step."""
+    sid = "pi-thinking"
+    content = [
+        {"type": "thinking", "text": "Let me think..."},
+        {"type": "text", "text": "Here's my answer."},
+    ]
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, content=content))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    step = _by_kind(session_spans, "step")[0]
+    assert step["meta"]["metadata"].get("has_thinking") is True
+    # Thinking text should NOT appear in output (only text blocks)
+    assert step["meta"]["output"]["value"] == "Here's my answer."


### PR DESCRIPTION
## What

Introduce synthetic `step` spans in pi hooks that group each inference cycle (one LLM call + its downstream tool calls) within a pi agent turn.

This follows the [trajectory-dev proposal](https://github.com/DataDog/trajectory-dev/blob/main/docs/proposals/LLMOBS-TURN-SPAN-KIND.md) (LLMOBS-TURN-SPAN-KIND.md).

## Trace shape

```
agent(turn)                          ← agent_start / agent_end
  step                               ← turn_start / turn_end
    llm                              ← message_start / message_end
    tool
    tool
  step
    llm
    tool
  step                               ← final response, no tools
    llm
```

## Key changes

### `ddapm_test_agent/pi_hooks.py`
- New `ActiveStepSpan` class tracks the active inference cycle per session
- New `_extract_output_text_and_tool_calls()` parses assistant content blocks
- `_start_step()` / `_finalize_active_step()` manage step span lifecycle
- `turn_start` opens a step span (primary); `message_start` opens a fallback step if none exists
- `turn_end` finalizes the step (primary); `agent_end` / `session_shutdown` catch unflushed steps
- LLM spans (`message_end`) and tool spans parent under the active step
- Root agent span tagged `trajectory.semantic_type:turn`
- Step spans tagged `trajectory.semantic_type:agent_message`
- Step metadata includes `message_index`, `turn_index`, `tool_use_ids`, `has_thinking`, `stop_reason`

### `tests/test_pi_hooks.py` (new)
12 tests covering:
- Basic parenting: `agent → step → llm`
- Tools parent under step
- Multiple sibling steps
- Trajectory tags
- LLMObs list API filtering by `@meta.span.kind:step`
- Finalization on `agent_end` (no `turn_end`), `session_shutdown`
- Fallback step when `message_start` arrives without `turn_start`
- Step index reset across agent cycles
- Thinking block detection
- Cancelled turn (no message)

## Terminology mapping

| Pi event | Proposal concept | Span kind |
|----------|-----------------|-----------|
| `agent_start` / `agent_end` | **turn** | `agent` |
| `turn_start` / `turn_end` | **step** | `step` |
| `message_start` / `message_end` | LLM call | `llm` |
