### PR TITLE
Implement /api/ui/query/scalar for LLMObs data sources

### DIFF
--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -6,6 +6,7 @@ import gzip
 import json
 import logging
 import re
+import statistics
 import time
 from typing import Any
 from typing import Awaitable
@@ -540,6 +541,315 @@ def _build_trace_aggregates(
             ),
         }
     return result
+
+
+_LLMOBS_SCALAR_DATA_SOURCES = {"llm_observability", "llm_observability_stream"}
+
+
+def _filter_spans_by_time_ms(
+    spans: List[Dict[str, Any]],
+    from_ms: Optional[Any],
+    to_ms: Optional[Any],
+) -> List[Dict[str, Any]]:
+    """Filter spans by ``start_ns`` using millisecond bounds from the UI.
+
+    Either bound may be ``None``/missing, in which case that side of the
+    window is open. Values that don't parse as numbers are ignored.
+    """
+    def _to_ns(value: Any) -> Optional[int]:
+        try:
+            return int(float(value)) * 1_000_000
+        except (TypeError, ValueError):
+            return None
+
+    lo = _to_ns(from_ms)
+    hi = _to_ns(to_ms)
+    if lo is None and hi is None:
+        return spans
+    out = []
+    for s in spans:
+        start = s.get("start_ns", 0) or 0
+        if lo is not None and start < lo:
+            continue
+        if hi is not None and start > hi:
+            continue
+        out.append(s)
+    return out
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _scalar_compute(
+    spans: List[Dict[str, Any]],
+    aggregation: str,
+    metric_field: Optional[str],
+) -> float:
+    """Compute a single scalar value for a list of spans.
+
+    Supported aggregations: ``count``, ``cardinality``, ``sum``, ``avg``,
+    ``min``, ``max``, ``median``, ``pc75``/``pc90``/``pc95``/``pc99``,
+    ``latest``, ``earliest``. Unknown aggregations return ``0.0``.
+    """
+    agg = (aggregation or "count").lower()
+
+    if agg == "count":
+        return float(len(spans))
+
+    if not metric_field:
+        return 0.0
+    field = metric_field.lstrip("@")
+
+    if agg == "cardinality":
+        seen = set()
+        for s in spans:
+            v = get_span_field_value(s, field)
+            if v is not None:
+                seen.add(v)
+        return float(len(seen))
+
+    if agg in ("latest", "earliest"):
+        if not spans:
+            return 0.0
+        # get_llmobs_spans sorts desc by start_ns; first = latest, last = earliest.
+        pick = spans[0] if agg == "latest" else spans[-1]
+        return _coerce_float(get_span_field_value(pick, field)) or 0.0
+
+    values: List[float] = []
+    for s in spans:
+        fv = _coerce_float(get_span_field_value(s, field))
+        if fv is not None:
+            values.append(fv)
+
+    if not values:
+        return 0.0
+    if agg == "sum":
+        return sum(values)
+    if agg == "avg":
+        return sum(values) / len(values)
+    if agg == "min":
+        return min(values)
+    if agg == "max":
+        return max(values)
+    if agg == "median":
+        return float(statistics.median(values))
+    if agg.startswith("pc"):
+        try:
+            pct = int(agg[2:])
+        except ValueError:
+            return 0.0
+        if len(values) == 1:
+            return values[0]
+        vs = sorted(values)
+        # Nearest-rank percentile — simple and good enough for tests.
+        idx = max(0, min(len(vs) - 1, int(round((pct / 100.0) * (len(vs) - 1)))))
+        return vs[idx]
+    return 0.0
+
+
+def _query_compute_spec(query: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise the compute portion of a scalar query.
+
+    Handles both the dashboard-style ``{aggregator, metric}`` shape and the
+    logs/LLMObs ``{compute: {aggregation, metric}}`` shape.
+    """
+    if isinstance(query.get("compute"), dict):
+        c = query["compute"]
+        return {
+            "aggregation": c.get("aggregation") or c.get("aggregator") or "count",
+            "metric": c.get("metric"),
+        }
+    return {
+        "aggregation": query.get("aggregator") or query.get("aggregation") or "count",
+        "metric": query.get("metric"),
+    }
+
+
+def _query_group_by_fields(query: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Normalise group_by entries into ``{field, limit, sort}`` dicts."""
+    result: List[Dict[str, Any]] = []
+    for gb in query.get("group_by") or []:
+        if not isinstance(gb, dict):
+            continue
+        raw_field = gb.get("facet") or gb.get("field") or ""
+        if isinstance(raw_field, dict):
+            raw_field = raw_field.get("id") or raw_field.get("name") or ""
+        if not raw_field:
+            continue
+        sort_cfg = gb.get("sort") or {}
+        result.append(
+            {
+                "name": raw_field,
+                "field": raw_field.lstrip("@"),
+                "limit": gb.get("limit", 50),
+                "sort_order": sort_cfg.get("order", "desc") if isinstance(sort_cfg, dict) else "desc",
+                "sort_aggregation": sort_cfg.get("aggregation") if isinstance(sort_cfg, dict) else None,
+            }
+        )
+    return result
+
+
+def _query_column_name(query: Dict[str, Any]) -> str:
+    spec = _query_compute_spec(query)
+    name = query.get("name")
+    if name:
+        return str(name)
+    agg = spec["aggregation"]
+    metric = spec["metric"]
+    return f"{agg}({metric})" if metric else agg
+
+
+def _build_scalar_columns(
+    spans: List[Dict[str, Any]],
+    queries: List[Dict[str, Any]],
+    formulas: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Build the ``columns`` array for a single scalar_response.
+
+    Only the first query drives group_by dimensions and row order; additional
+    queries reuse those groups (null-filled if missing). Formulas are
+    supported as direct references to a query ``name`` (no arithmetic yet).
+    """
+    if not queries:
+        return []
+
+    # Partition queries into LLMObs-backed and unsupported (still emit a column).
+    supported_spans_by_query: List[List[Dict[str, Any]]] = []
+    for q in queries:
+        if (q.get("data_source") or "").lower() in _LLMOBS_SCALAR_DATA_SOURCES:
+            query_str = (q.get("search") or {}).get("query") if isinstance(q.get("search"), dict) else None
+            if query_str:
+                supported_spans_by_query.append(apply_filters(spans, parse_filter_query(query_str)))
+            else:
+                supported_spans_by_query.append(list(spans))
+        else:
+            supported_spans_by_query.append([])
+
+    # Group-by based on the first query's dimensions.
+    group_defs = _query_group_by_fields(queries[0])
+    columns: List[Dict[str, Any]] = []
+
+    if not group_defs:
+        # No grouping: one row, one number column per query/formula.
+        number_values_by_query: Dict[str, float] = {}
+        for i, q in enumerate(queries):
+            spec = _query_compute_spec(q)
+            val = _scalar_compute(supported_spans_by_query[i], spec["aggregation"], spec["metric"])
+            number_values_by_query[str(q.get("name") or f"query{i + 1}")] = val
+            if not formulas:
+                columns.append(
+                    {
+                        "name": _query_column_name(q),
+                        "type": "number",
+                        "meta": {"unit": None},
+                        "values": [val],
+                    }
+                )
+        if formulas:
+            for f in formulas:
+                ref = str(f.get("formula") or "")
+                val = number_values_by_query.get(ref, 0.0)
+                columns.append(
+                    {
+                        "name": str(f.get("alias") or ref),
+                        "type": "number",
+                        "meta": {"unit": None},
+                        "values": [val],
+                    }
+                )
+        return columns
+
+    # Grouped: bucket the first query's spans, then compute per-group values.
+    first_spans = supported_spans_by_query[0]
+
+    def _group_key(span: Dict[str, Any]) -> tuple:  # type: ignore[type-arg]
+        return tuple(
+            str(get_span_field_value(span, gd["field"]) or "") for gd in group_defs
+        )
+
+    buckets: Dict[tuple, List[Dict[str, Any]]] = {}  # type: ignore[type-arg]
+    order: List[tuple] = []  # type: ignore[type-arg]
+    for s in first_spans:
+        k = _group_key(s)
+        if k not in buckets:
+            buckets[k] = []
+            order.append(k)
+        buckets[k].append(s)
+
+    # Sort by first query's compute (descending by default) so the biggest groups win.
+    primary_spec = _query_compute_spec(queries[0])
+    primary_values = {
+        k: _scalar_compute(buckets[k], primary_spec["aggregation"], primary_spec["metric"])
+        for k in order
+    }
+    sort_order = group_defs[0]["sort_order"]
+    order.sort(key=lambda k: primary_values[k], reverse=(sort_order == "desc"))
+
+    # Apply the first dimension's limit (Datadog applies per-dimension limits;
+    # for v1 we just cap total rows at the minimum configured limit).
+    row_limit = min((gd["limit"] for gd in group_defs if isinstance(gd.get("limit"), int)), default=50)
+    order = order[:row_limit]
+
+    # Emit group columns (one per dimension).
+    for i, gd in enumerate(group_defs):
+        columns.append(
+            {
+                "name": gd["name"],
+                "type": "group",
+                "meta": None,
+                "values": [[k[i]] for k in order],
+            }
+        )
+
+    # For non-first queries, re-bucket their (independently-filtered) spans by
+    # the same group key so the rows line up.
+    per_query_values: List[List[float]] = []
+    for qi, q in enumerate(queries):
+        spec = _query_compute_spec(q)
+        if qi == 0:
+            per_query_values.append([primary_values[k] for k in order])
+            continue
+        qbuckets: Dict[tuple, List[Dict[str, Any]]] = {k: [] for k in order}  # type: ignore[type-arg]
+        for s in supported_spans_by_query[qi]:
+            k = _group_key(s)
+            if k in qbuckets:
+                qbuckets[k].append(s)
+        per_query_values.append(
+            [_scalar_compute(qbuckets[k], spec["aggregation"], spec["metric"]) for k in order]
+        )
+
+    if formulas:
+        name_to_idx = {str(q.get("name") or f"query{i + 1}"): i for i, q in enumerate(queries)}
+        for f in formulas:
+            ref = str(f.get("formula") or "")
+            idx = name_to_idx.get(ref)
+            vals = per_query_values[idx] if idx is not None else [0.0 for _ in order]
+            columns.append(
+                {
+                    "name": str(f.get("alias") or ref),
+                    "type": "number",
+                    "meta": {"unit": None},
+                    "values": vals,
+                }
+            )
+    else:
+        for qi, q in enumerate(queries):
+            columns.append(
+                {
+                    "name": _query_column_name(q),
+                    "type": "number",
+                    "meta": {"unit": None},
+                    "values": per_query_values[qi],
+                }
+            )
+
+    return columns
 
 
 def build_event_platform_list_response(
@@ -1264,19 +1574,53 @@ class LLMObsEventPlatformAPI:
             return web.json_response({"error": str(e)}, status=500)
 
     async def handle_query_scalar(self, request: Request) -> web.Response:
-        """Handle POST /api/ui/query/scalar endpoint."""
-        return web.json_response(
-            {
-                "data": [
-                    {
-                        "type": "scalar_response",
-                        "attributes": {
-                            "columns": [],
-                        },
-                    }
-                ],
-            }
-        )
+        """Handle POST /api/ui/query/scalar endpoint.
+
+        Implements a subset of the Datadog formulas-and-functions scalar API
+        against the LLMObs spans tracked in-memory by the test agent.
+
+        Supports ``data_source`` values ``llm_observability`` and
+        ``llm_observability_stream``; unknown data sources return a single
+        zero-valued number column so tiles render "no data" instead of erroring.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+
+        requests = body.get("data") if isinstance(body, dict) else None
+        if not requests:
+            # Preserve legacy empty-in / empty-out behaviour.
+            return web.json_response(
+                {
+                    "data": [
+                        {
+                            "type": "scalar_response",
+                            "attributes": {"columns": []},
+                        }
+                    ],
+                }
+            )
+
+        all_spans = self.get_llmobs_spans()
+        out: List[Dict[str, Any]] = []
+
+        for req in requests:
+            if not isinstance(req, dict):
+                out.append({"type": "scalar_response", "attributes": {"columns": []}})
+                continue
+            attrs = req.get("attributes") or {}
+            queries = attrs.get("queries") or []
+            scoped = _filter_spans_by_time_ms(all_spans, attrs.get("from"), attrs.get("to"))
+            columns = _build_scalar_columns(scoped, queries, attrs.get("formulas") or [])
+            out.append(
+                {
+                    "type": "scalar_response",
+                    "attributes": {"columns": columns},
+                }
+            )
+
+        return web.json_response({"data": out})
 
     def get_routes(self) -> List[web.RouteDef]:
         """Return the routes for this API (all handlers wrapped with CORS support)."""

--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -517,28 +517,14 @@ def _build_trace_aggregates(
             )
             for span in trace_spans
         )
-        number_of_errors = sum(
-            1 for span in trace_spans if span.get("status") == "error"
-        )
+        number_of_errors = sum(1 for span in trace_spans if span.get("status") == "error")
         result[tid] = {
             "num_evaluations_failed": num_evaluations_failed,
             "number_of_errors": number_of_errors,
-            "input_tokens": sum(
-                span.get("metrics", {}).get("input_tokens", 0)
-                for span in trace_spans
-            ),
-            "output_tokens": sum(
-                span.get("metrics", {}).get("output_tokens", 0)
-                for span in trace_spans
-            ),
-            "total_tokens": sum(
-                span.get("metrics", {}).get("total_tokens", 0)
-                for span in trace_spans
-            ),
-            "estimated_total_cost": sum(
-                span.get("metrics", {}).get("estimated_total_cost", 0)
-                for span in trace_spans
-            ),
+            "input_tokens": sum(span.get("metrics", {}).get("input_tokens", 0) for span in trace_spans),
+            "output_tokens": sum(span.get("metrics", {}).get("output_tokens", 0) for span in trace_spans),
+            "total_tokens": sum(span.get("metrics", {}).get("total_tokens", 0) for span in trace_spans),
+            "estimated_total_cost": sum(span.get("metrics", {}).get("estimated_total_cost", 0) for span in trace_spans),
         }
     return result
 
@@ -555,7 +541,7 @@ def _resolve_field_value(
 
     ``@trace.*`` paths are served from pre-computed per-trace aggregates
     (mirrors what the production query rewriter does via Trino). All other
-    paths fall back to :func:`get_span_field_value`.
+    paths fall back to ``get_span_field_value``.
     """
     if not field:
         return None
@@ -564,7 +550,7 @@ def _resolve_field_value(
         agg = trace_aggregates.get(span.get("trace_id", ""))
         if not agg:
             return None
-        return agg.get(stripped[len("trace."):])
+        return agg.get(stripped[len("trace.") :])
     return get_span_field_value(span, stripped)
 
 
@@ -578,6 +564,7 @@ def _filter_spans_by_time_ms(
     Either bound may be ``None``/missing, in which case that side of the
     window is open. Values that don't parse as numbers are ignored.
     """
+
     def _to_ns(value: Any) -> Optional[int]:
         try:
             return int(float(value)) * 1_000_000
@@ -741,7 +728,7 @@ def _query_column_name(query: Dict[str, Any]) -> str:
     name = query.get("name")
     if name:
         return str(name)
-    agg = spec["aggregation"]
+    agg = str(spec["aggregation"])
     metric = spec["metric"]
     return f"{agg}({metric})" if metric else agg
 
@@ -814,10 +801,7 @@ def _build_scalar_columns(
     first_spans = supported_spans_by_query[0]
 
     def _group_key(span: Dict[str, Any]) -> tuple:  # type: ignore[type-arg]
-        return tuple(
-            str(_resolve_field_value(span, gd["field"], trace_aggregates) or "")
-            for gd in group_defs
-        )
+        return tuple(str(_resolve_field_value(span, gd["field"], trace_aggregates) or "") for gd in group_defs)
 
     buckets: Dict[tuple, List[Dict[str, Any]]] = {}  # type: ignore[type-arg]
     order: List[tuple] = []  # type: ignore[type-arg]
@@ -1240,7 +1224,9 @@ class LLMObsEventPlatformAPI:
                         output = cfg.get("output", "")
                         columns = cfg.get("columns", [])
                         sort_cfg = cfg.get("sort", {})
-                        sort_order = sort_cfg.get("time", {}).get("order", "desc") if isinstance(sort_cfg, dict) else "desc"
+                        sort_order = (
+                            sort_cfg.get("time", {}).get("order", "desc") if isinstance(sort_cfg, dict) else "desc"
+                        )
                         sorted_spans = group_spans if sort_order == "desc" else list(reversed(group_spans))
                         rows = []
                         for s in sorted_spans:

--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -546,6 +546,28 @@ def _build_trace_aggregates(
 _LLMOBS_SCALAR_DATA_SOURCES = {"llm_observability", "llm_observability_stream"}
 
 
+def _resolve_field_value(
+    span: Dict[str, Any],
+    field: Optional[str],
+    trace_aggregates: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> Optional[Any]:
+    """Resolve a facet path, with trace-level rollup support.
+
+    ``@trace.*`` paths are served from pre-computed per-trace aggregates
+    (mirrors what the production query rewriter does via Trino). All other
+    paths fall back to :func:`get_span_field_value`.
+    """
+    if not field:
+        return None
+    stripped = field.lstrip("@")
+    if stripped.startswith("trace.") and trace_aggregates is not None:
+        agg = trace_aggregates.get(span.get("trace_id", ""))
+        if not agg:
+            return None
+        return agg.get(stripped[len("trace."):])
+    return get_span_field_value(span, stripped)
+
+
 def _filter_spans_by_time_ms(
     spans: List[Dict[str, Any]],
     from_ms: Optional[Any],
@@ -590,12 +612,17 @@ def _scalar_compute(
     spans: List[Dict[str, Any]],
     aggregation: str,
     metric_field: Optional[str],
+    trace_aggregates: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> float:
     """Compute a single scalar value for a list of spans.
 
     Supported aggregations: ``count``, ``cardinality``, ``sum``, ``avg``,
     ``min``, ``max``, ``median``, ``pc75``/``pc90``/``pc95``/``pc99``,
     ``latest``, ``earliest``. Unknown aggregations return ``0.0``.
+
+    When ``metric_field`` is a ``@trace.*`` path, spans are deduplicated by
+    ``trace_id`` before aggregation so trace-rollup metrics aren't
+    multi-counted.
     """
     agg = (aggregation or "count").lower()
 
@@ -605,25 +632,39 @@ def _scalar_compute(
     if not metric_field:
         return 0.0
     field = metric_field.lstrip("@")
+    is_trace_field = field.startswith("trace.")
+
+    # Trace-level rollups are one value per trace; dedupe before aggregating.
+    source_spans: List[Dict[str, Any]] = spans
+    if is_trace_field:
+        seen_traces: set = set()  # type: ignore[type-arg]
+        deduped: List[Dict[str, Any]] = []
+        for s in spans:
+            tid = s.get("trace_id", "")
+            if tid in seen_traces:
+                continue
+            seen_traces.add(tid)
+            deduped.append(s)
+        source_spans = deduped
 
     if agg == "cardinality":
         seen = set()
-        for s in spans:
-            v = get_span_field_value(s, field)
+        for s in source_spans:
+            v = _resolve_field_value(s, field, trace_aggregates)
             if v is not None:
                 seen.add(v)
         return float(len(seen))
 
     if agg in ("latest", "earliest"):
-        if not spans:
+        if not source_spans:
             return 0.0
         # get_llmobs_spans sorts desc by start_ns; first = latest, last = earliest.
-        pick = spans[0] if agg == "latest" else spans[-1]
-        return _coerce_float(get_span_field_value(pick, field)) or 0.0
+        pick = source_spans[0] if agg == "latest" else source_spans[-1]
+        return _coerce_float(_resolve_field_value(pick, field, trace_aggregates)) or 0.0
 
     values: List[float] = []
-    for s in spans:
-        fv = _coerce_float(get_span_field_value(s, field))
+    for s in source_spans:
+        fv = _coerce_float(_resolve_field_value(s, field, trace_aggregates))
         if fv is not None:
             values.append(fv)
 
@@ -709,6 +750,7 @@ def _build_scalar_columns(
     spans: List[Dict[str, Any]],
     queries: List[Dict[str, Any]],
     formulas: List[Dict[str, Any]],
+    trace_aggregates: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
     """Build the ``columns`` array for a single scalar_response.
 
@@ -731,6 +773,9 @@ def _build_scalar_columns(
         else:
             supported_spans_by_query.append([])
 
+    def _compute(spans_: List[Dict[str, Any]], spec: Dict[str, Any]) -> float:
+        return _scalar_compute(spans_, spec["aggregation"], spec["metric"], trace_aggregates)
+
     # Group-by based on the first query's dimensions.
     group_defs = _query_group_by_fields(queries[0])
     columns: List[Dict[str, Any]] = []
@@ -740,7 +785,7 @@ def _build_scalar_columns(
         number_values_by_query: Dict[str, float] = {}
         for i, q in enumerate(queries):
             spec = _query_compute_spec(q)
-            val = _scalar_compute(supported_spans_by_query[i], spec["aggregation"], spec["metric"])
+            val = _compute(supported_spans_by_query[i], spec)
             number_values_by_query[str(q.get("name") or f"query{i + 1}")] = val
             if not formulas:
                 columns.append(
@@ -770,7 +815,8 @@ def _build_scalar_columns(
 
     def _group_key(span: Dict[str, Any]) -> tuple:  # type: ignore[type-arg]
         return tuple(
-            str(get_span_field_value(span, gd["field"]) or "") for gd in group_defs
+            str(_resolve_field_value(span, gd["field"], trace_aggregates) or "")
+            for gd in group_defs
         )
 
     buckets: Dict[tuple, List[Dict[str, Any]]] = {}  # type: ignore[type-arg]
@@ -784,10 +830,7 @@ def _build_scalar_columns(
 
     # Sort by first query's compute (descending by default) so the biggest groups win.
     primary_spec = _query_compute_spec(queries[0])
-    primary_values = {
-        k: _scalar_compute(buckets[k], primary_spec["aggregation"], primary_spec["metric"])
-        for k in order
-    }
+    primary_values = {k: _compute(buckets[k], primary_spec) for k in order}
     sort_order = group_defs[0]["sort_order"]
     order.sort(key=lambda k: primary_values[k], reverse=(sort_order == "desc"))
 
@@ -820,9 +863,7 @@ def _build_scalar_columns(
             k = _group_key(s)
             if k in qbuckets:
                 qbuckets[k].append(s)
-        per_query_values.append(
-            [_scalar_compute(qbuckets[k], spec["aggregation"], spec["metric"]) for k in order]
-        )
+        per_query_values.append([_compute(qbuckets[k], spec) for k in order])
 
     if formulas:
         name_to_idx = {str(q.get("name") or f"query{i + 1}"): i for i, q in enumerate(queries)}
@@ -1603,6 +1644,10 @@ class LLMObsEventPlatformAPI:
             )
 
         all_spans = self.get_llmobs_spans()
+        # Pre-compute @trace.* rollups once over the unscoped span set. The UI
+        # sums/avgs these values per trace (a trace’s rollup is identical
+        # regardless of time window), so computing once is correct and cheaper.
+        trace_aggregates = _build_trace_aggregates(all_spans)
         out: List[Dict[str, Any]] = []
 
         for req in requests:
@@ -1612,7 +1657,9 @@ class LLMObsEventPlatformAPI:
             attrs = req.get("attributes") or {}
             queries = attrs.get("queries") or []
             scoped = _filter_spans_by_time_ms(all_spans, attrs.get("from"), attrs.get("to"))
-            columns = _build_scalar_columns(scoped, queries, attrs.get("formulas") or [])
+            columns = _build_scalar_columns(
+                scoped, queries, attrs.get("formulas") or [], trace_aggregates=trace_aggregates
+            )
             out.append(
                 {
                     "type": "scalar_response",

--- a/releasenotes/notes/query-scalar-endpoint-345b70b4ce99fb61.yaml
+++ b/releasenotes/notes/query-scalar-endpoint-345b70b4ce99fb61.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Implement ``POST /api/ui/query/scalar`` for LLM Observability data sources.
+    Supports count/cardinality/sum/avg/min/max/median/percentile aggregations,
+    group_by, search filters, per-request time windows, and formula references
+    over the spans tracked by the test agent. Unknown data sources return a
+    zero-valued scalar response instead of erroring.

--- a/tests/test_llmobs_event_platform.py
+++ b/tests/test_llmobs_event_platform.py
@@ -159,6 +159,225 @@ async def test_query_scalar_options(agent):
     assert resp.headers.get("Access-Control-Allow-Origin") == _TEST_ORIGIN
 
 
+def _scalar_request(queries, from_ms=None, to_ms=None, formulas=None):
+    attrs = {"queries": queries}
+    if from_ms is not None:
+        attrs["from"] = from_ms
+    if to_ms is not None:
+        attrs["to"] = to_ms
+    if formulas is not None:
+        attrs["formulas"] = formulas
+    return {"data": [{"type": "scalar_request", "attributes": attrs}]}
+
+
+async def test_query_scalar_count_no_groupby(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    resp = await agent.post(
+        "/api/ui/query/scalar",
+        json=_scalar_request(
+            [
+                {
+                    "name": "query1",
+                    "data_source": "llm_observability",
+                    "indexes": ["llmobs"],
+                    "search": {"query": ""},
+                    "compute": {"aggregation": "count"},
+                }
+            ]
+        ),
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert len(data["data"]) == 1
+    cols = data["data"][0]["attributes"]["columns"]
+    assert len(cols) == 1
+    assert cols[0]["type"] == "number"
+    assert cols[0]["values"] == [2.0]
+
+
+async def test_query_scalar_group_by_kind(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    resp = await agent.post(
+        "/api/ui/query/scalar",
+        json=_scalar_request(
+            [
+                {
+                    "name": "query1",
+                    "data_source": "llm_observability",
+                    "indexes": ["llmobs"],
+                    "search": {"query": ""},
+                    "compute": {"aggregation": "count"},
+                    "group_by": [
+                        {"facet": "@meta.span.kind", "limit": 10, "sort": {"order": "desc"}}
+                    ],
+                }
+            ]
+        ),
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    cols = data["data"][0]["attributes"]["columns"]
+    assert len(cols) == 2
+    group_col, num_col = cols
+    assert group_col["type"] == "group"
+    assert group_col["name"] == "@meta.span.kind"
+    # Two kinds present in fixture: agent and llm, one span each.
+    assert sorted([v[0] for v in group_col["values"]]) == ["agent", "llm"]
+    assert num_col["type"] == "number"
+    assert num_col["values"] == [1.0, 1.0]
+
+
+async def test_query_scalar_avg_duration(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    resp = await agent.post(
+        "/api/ui/query/scalar",
+        json=_scalar_request(
+            [
+                {
+                    "name": "query1",
+                    "data_source": "llm_observability",
+                    "indexes": ["llmobs"],
+                    "compute": {"aggregation": "avg", "metric": "@duration"},
+                }
+            ]
+        ),
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    cols = data["data"][0]["attributes"]["columns"]
+    assert len(cols) == 1
+    # Fixture durations: 5e9 + 2e9 averaged = 3.5e9.
+    assert cols[0]["values"] == [3_500_000_000.0]
+
+
+async def test_query_scalar_time_filter_excludes_spans(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    # Window entirely in the past — should exclude all fixture spans (start_ns = now).
+    resp = await agent.post(
+        "/api/ui/query/scalar",
+        json=_scalar_request(
+            [
+                {
+                    "name": "query1",
+                    "data_source": "llm_observability",
+                    "indexes": ["llmobs"],
+                    "compute": {"aggregation": "count"},
+                }
+            ],
+            from_ms=1,
+            to_ms=1000,
+        ),
+    )
+    data = await resp.json()
+    assert data["data"][0]["attributes"]["columns"][0]["values"] == [0.0]
+
+
+async def test_query_scalar_search_query_filters(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    resp = await agent.post(
+        "/api/ui/query/scalar",
+        json=_scalar_request(
+            [
+                {
+                    "name": "query1",
+                    "data_source": "llm_observability",
+                    "indexes": ["llmobs"],
+                    "search": {"query": "@meta.span.kind:llm"},
+                    "compute": {"aggregation": "count"},
+                }
+            ]
+        ),
+    )
+    data = await resp.json()
+    assert data["data"][0]["attributes"]["columns"][0]["values"] == [1.0]
+
+
+async def test_query_scalar_unknown_data_source(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    resp = await agent.post(
+        "/api/ui/query/scalar",
+        json=_scalar_request(
+            [
+                {
+                    "name": "query1",
+                    "data_source": "metrics",
+                    "query": "sum:foo{*}",
+                    "aggregator": "sum",
+                }
+            ]
+        ),
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    cols = data["data"][0]["attributes"]["columns"]
+    assert len(cols) == 1
+    assert cols[0]["type"] == "number"
+    assert cols[0]["values"] == [0.0]
+
+
+async def test_query_scalar_multi_request(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    body = {
+        "data": [
+            {
+                "type": "scalar_request",
+                "attributes": {
+                    "queries": [
+                        {
+                            "name": "query1",
+                            "data_source": "llm_observability",
+                            "indexes": ["llmobs"],
+                            "compute": {"aggregation": "count"},
+                        }
+                    ]
+                },
+            },
+            {
+                "type": "scalar_request",
+                "attributes": {
+                    "queries": [
+                        {
+                            "name": "query1",
+                            "data_source": "llm_observability",
+                            "indexes": ["llmobs"],
+                            "compute": {"aggregation": "sum", "metric": "@metrics.total_tokens"},
+                        }
+                    ]
+                },
+            },
+        ]
+    }
+    resp = await agent.post("/api/ui/query/scalar", json=body)
+    data = await resp.json()
+    assert len(data["data"]) == 2
+    assert data["data"][0]["attributes"]["columns"][0]["values"] == [2.0]
+    # Fixture total_tokens: 30 + 15 = 45.
+    assert data["data"][1]["attributes"]["columns"][0]["values"] == [45.0]
+
+
+async def test_query_scalar_formulas_reference_query(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    resp = await agent.post(
+        "/api/ui/query/scalar",
+        json=_scalar_request(
+            [
+                {
+                    "name": "q1",
+                    "data_source": "llm_observability",
+                    "indexes": ["llmobs"],
+                    "compute": {"aggregation": "count"},
+                }
+            ],
+            formulas=[{"formula": "q1", "alias": "span_count"}],
+        ),
+    )
+    data = await resp.json()
+    cols = data["data"][0]["attributes"]["columns"]
+    assert len(cols) == 1
+    assert cols[0]["name"] == "span_count"
+    assert cols[0]["values"] == [2.0]
+
+
 # Functional tests (testing actual span data flow)
 
 

--- a/tests/test_llmobs_event_platform.py
+++ b/tests/test_llmobs_event_platform.py
@@ -355,6 +355,30 @@ async def test_query_scalar_multi_request(agent, llmobs_payload):
     assert data["data"][1]["attributes"]["columns"][0]["values"] == [45.0]
 
 
+async def test_query_scalar_trace_rollup_metric(agent, llmobs_payload):
+    # Fixture has 2 spans on the same trace with token counts 30 and 15.
+    # @trace.total_tokens rolls up per-trace: sum across spans = 45, but
+    # because both spans share trace-123, sum(@trace.total_tokens) over all
+    # spans must dedupe to 45 (not 90).
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    resp = await agent.post(
+        "/api/ui/query/scalar",
+        json=_scalar_request(
+            [
+                {
+                    "name": "query1",
+                    "data_source": "llm_observability",
+                    "indexes": ["llmobs"],
+                    "compute": {"aggregation": "sum", "metric": "@trace.total_tokens"},
+                }
+            ]
+        ),
+    )
+    data = await resp.json()
+    cols = data["data"][0]["attributes"]["columns"]
+    assert cols[0]["values"] == [45.0]
+
+
 async def test_query_scalar_formulas_reference_query(agent, llmobs_payload):
     await _submit_llmobs_payload(agent, llmobs_payload)
     resp = await agent.post(

--- a/tests/test_llmobs_event_platform.py
+++ b/tests/test_llmobs_event_platform.py
@@ -207,9 +207,7 @@ async def test_query_scalar_group_by_kind(agent, llmobs_payload):
                     "indexes": ["llmobs"],
                     "search": {"query": ""},
                     "compute": {"aggregation": "count"},
-                    "group_by": [
-                        {"facet": "@meta.span.kind", "limit": 10, "sort": {"order": "desc"}}
-                    ],
+                    "group_by": [{"facet": "@meta.span.kind", "limit": 10, "sort": {"order": "desc"}}],
                 }
             ]
         ),


### PR DESCRIPTION
## Summary

Replaces the stub `POST /api/ui/query/scalar` handler with a real implementation backed by the in-memory LLMObs spans tracked by the test agent. This unblocks lapdog local-dev tiles (Application Overview, AI Agents Console, trace detail panels) that currently get empty data back.

## What's supported

- **Data sources**: `llm_observability` and `llm_observability_stream`. Unknown data sources return a zero-valued number column instead of a 500 so tiles render "no data".
- **Aggregations**: `count`, `cardinality`, `sum`, `avg`, `min`, `max`, `median`, `pc75`/`pc90`/`pc95`/`pc99`, `latest`, `earliest`.
- **group_by** with per-dimension sort order + row limit.
- **search.query** via the existing `apply_filters` / `parse_filter_query` helpers (same syntax used by `/aggregate` and `/list`).
- **Per-request time windows** (`from`/`to` in ms).
- **Formulas** as direct query-name references (e.g. `{formula: 'q1', alias: 'span_count'}`). Arithmetic formulas are deferred.

## Tests

8 new tests in `tests/test_llmobs_event_platform.py` covering: count w/o group_by, group_by kind, avg(@duration), time-window filtering, search.query filtering, unknown data source fallback, multi-request bodies, and formula references.

Legacy empty-input behaviour (`{data: []}` → one empty `scalar_response`) is preserved so the existing stub tests still pass. All 38 tests in the file pass; flake8 and mypy are clean for the touched files.

## Out of scope / follow-ups

- Formula arithmetic (`query1 / query2`, literals, parens) — punt until a caller actually needs it.
- Timeseries endpoint (`/api/ui/query/timeseries`) — separate endpoint, separate PR.
- Per-session scoping via `test_session_token` — matches current `/aggregate` behaviour; add together if/when we retrofit both.