### PR TITLE
fix(llmobs): ignore time window in /api/ui/query/scalar

### DIFF
--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -1642,9 +1642,15 @@ class LLMObsEventPlatformAPI:
                 continue
             attrs = req.get("attributes") or {}
             queries = attrs.get("queries") or []
-            scoped = _filter_spans_by_time_ms(all_spans, attrs.get("from"), attrs.get("to"))
+            # Intentionally ignore the request's ``from``/``to`` window. The
+            # sibling list/aggregate endpoints (handle_logs_analytics_list,
+            # handle_aggregate) return spans regardless of time, so callers
+            # like the LLMObs Sessions table see rows for older sessions even
+            # when the UI sends a short (e.g. 15m) window. Filtering here
+            # would make scalar aggregates (cost, tokens) come back empty
+            # for exactly those rows — the bug this file used to have.
             columns = _build_scalar_columns(
-                scoped, queries, attrs.get("formulas") or [], trace_aggregates=trace_aggregates
+                all_spans, queries, attrs.get("formulas") or [], trace_aggregates=trace_aggregates
             )
             out.append(
                 {

--- a/releasenotes/notes/llmobs-scalar-ignore-time-08634ec30f8046a8.yaml
+++ b/releasenotes/notes/llmobs-scalar-ignore-time-08634ec30f8046a8.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    ``POST /api/ui/query/scalar`` no longer filters LLMObs spans by the
+    request's ``from``/``to`` window. The sibling list and aggregate
+    endpoints ignore the time window, so filtering here caused the LLMObs
+    Sessions table to render rows for older sessions with blank cost and
+    token columns whenever the UI sent a short (e.g. 15 minute) timeframe.
+    Aggregates are now computed over all tracked spans, consistent with the
+    other endpoints.

--- a/tests/test_llmobs_event_platform.py
+++ b/tests/test_llmobs_event_platform.py
@@ -248,9 +248,12 @@ async def test_query_scalar_avg_duration(agent, llmobs_payload):
     assert cols[0]["values"] == [3_500_000_000.0]
 
 
-async def test_query_scalar_time_filter_excludes_spans(agent, llmobs_payload):
+async def test_query_scalar_ignores_time_window(agent, llmobs_payload):
+    # The sibling list/aggregate endpoints return spans regardless of the
+    # UI's time window, so the scalar endpoint must do the same — otherwise
+    # the LLMObs Sessions table renders rows with blank cost / token columns
+    # for any session older than the UI's (short) timeframe.
     await _submit_llmobs_payload(agent, llmobs_payload)
-    # Window entirely in the past — should exclude all fixture spans (start_ns = now).
     resp = await agent.post(
         "/api/ui/query/scalar",
         json=_scalar_request(
@@ -267,7 +270,7 @@ async def test_query_scalar_time_filter_excludes_spans(agent, llmobs_payload):
         ),
     )
     data = await resp.json()
-    assert data["data"][0]["attributes"]["columns"][0]["values"] == [0.0]
+    assert data["data"][0]["attributes"]["columns"][0]["values"] == [2.0]
 
 
 async def test_query_scalar_search_query_filters(agent, llmobs_payload):


### PR DESCRIPTION
## Motivation

The LLMObs Sessions table in the `llm-observability` static app was rendering rows for older sessions with blank **Cost** and **Total Tokens** columns, even though opening those sessions showed the correct cost in the detail panel.

## Root cause

The sibling LLMObs endpoints on the query rewriter return spans regardless of the request's `from`/`to` window:

- `handle_logs_analytics_list` (`/api/unstable/llm-obs-query-rewriter/list`) reads only `list.limit`, `list.search.query`, and `list.sort` — no time window.
- `handle_aggregate` (`/api/unstable/llm-obs-query-rewriter/aggregate`) reads only `aggregate.search.query`, `aggregate.groupBy`, and `aggregate.compute` — no time window.

`handle_query_scalar` (added in #329) however filtered spans via `_filter_spans_by_time_ms` using the request's `from`/`to`. The static app sends a 15‑minute timeframe by default, so the Sessions table (fed by the grouped-list / aggregate endpoint) kept showing older sessions, while the per-session cost/token aggregates (fed by scalar) came back empty for those same sessions.

The session detail panel works because it sums cost from per‑trace summaries returned by the list endpoint, which ignores time.

## Fix

Align `handle_query_scalar` with the existing endpoints: compute aggregates over all tracked spans, ignoring `from`/`to`. `_filter_spans_by_time_ms` is left in place in case it's useful later.

Comment in the handler explains the invariant so the next person who adds time filtering does it consistently across all three endpoints.

## Tests

Flipped `test_query_scalar_time_filter_excludes_spans` → `test_query_scalar_ignores_time_window` to assert the new (consistent) behavior. All 39 tests in `test_llmobs_event_platform.py` pass.