### PR TITLE
chore(ownership): add CODEOWNERS for unowned files [SCMGMT-741]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DataDog/ml-observability


### PR DESCRIPTION
## Summary

Adds a catch-all CODEOWNERS entry assigning all files to `@DataDog/ml-observability` (SCMGMT-741).

No existing CODEOWNERS file was present. Owner determined by maintain-level repo access + contributor analysis (4/4 top contributors are members of `ml-observability`).

## Test plan
- [ ] Review that `@DataDog/ml-observability` is the correct owner
- [ ] Verify no specific paths need different ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)