### PR TITLE
fix(llmobs): support min/max aggregations and fix trace token double-counting

### DIFF
--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -419,7 +419,6 @@ class ClaudeHooksAPI:
                 None,
             )
 
-        token_usage = self._compute_token_usage(session.trace_id)
         input_value = "\n\n".join(session.user_prompts) if session.user_prompts else ""
 
         if root_span:
@@ -429,7 +428,11 @@ class ClaudeHooksAPI:
             root_span["meta"]["error"] = {"message": "interrupted by user"}
             root_span["meta"]["model_name"] = session.model
             root_span["meta"]["model_provider"] = "anthropic"
-            root_span["metrics"] = token_usage
+            # Do not roll token_usage up onto root_span["metrics"] —
+            # production stores trace rollups in a separate `@trace.*`
+            # document, not on the root span. Mirroring it here caused
+            # `_build_trace_aggregates` to double-count tokens (root's
+            # rollup + each LLM span's own value).
 
         session.root_span_emitted = True
         log.info("Finalized interrupted turn for session %s (trace %s)", session.session_id, session.trace_id)
@@ -1011,8 +1014,6 @@ class ClaudeHooksAPI:
                 (s for s in self._assembled_spans if s.get("span_id") == session.root_span_id),
                 None,
             )
-        # Compute aggregate token usage from LLM spans in this trace
-        token_usage = self._compute_token_usage(session.trace_id)
         tool_usage = self._aggregate_tool_usage(session.trace_id)
         context_delta = self._compute_context_delta(
             session.trace_id, session.root_span_id, session.last_known_input_tokens
@@ -1051,7 +1052,8 @@ class ClaudeHooksAPI:
             if tool_usage:
                 dd_fields["tool_usage"] = tool_usage
             self._set_hidden_metadata(root_span, **dd_fields)
-            root_span["metrics"] = token_usage
+            # See comment above: skip the root-span metrics rollup to
+            # avoid double-counting in `_build_trace_aggregates`.
         else:
             # No eagerly-emitted root span found — create one as fallback
             root_span = {
@@ -1089,7 +1091,7 @@ class ClaudeHooksAPI:
                         "model_provider": "anthropic",
                     },
                 },
-                "metrics": token_usage,
+                # Intentionally no "metrics" key — see comment above.
             }
             dd_fields = {"agent_manifest": agent_manifest}
             if context_delta:

--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -453,11 +453,7 @@ def get_span_field_value(span: Dict[str, Any], field: str) -> Optional[Any]:
         # `start_ns` in nanoseconds — convert here so downstream
         # aggregations (min/max/earliest/latest on `timestamp`) match
         # production semantics.
-        "timestamp": lambda s: (
-            s["start_ns"] / 1_000_000
-            if isinstance(s.get("start_ns"), (int, float))
-            else None
-        ),
+        "timestamp": lambda s: (s["start_ns"] / 1_000_000 if isinstance(s.get("start_ns"), (int, float)) else None),
     }
     if field in direct_fields:
         return direct_fields[field](span)
@@ -1250,9 +1246,7 @@ class LLMObsEventPlatformAPI:
                             elif aggregation == "sum":
                                 metrics[output] = sum(numeric_values)
                             elif aggregation == "avg":
-                                metrics[output] = (
-                                    sum(numeric_values) / len(numeric_values)
-                                )
+                                metrics[output] = sum(numeric_values) / len(numeric_values)
                     elif "list" in compute_item:
                         cfg = compute_item["list"]
                         output = cfg.get("output", "")

--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -448,6 +448,16 @@ def get_span_field_value(span: Dict[str, Any], field: str) -> Optional[Any]:
         "duration": lambda s: s.get("duration", 0),
         "session_id": lambda s: s.get("session_id", ""),
         "hostname": lambda s: s.get("hostname", ""),
+        # Span timestamp in milliseconds. The LLMObs UI treats the
+        # `timestamp` facet as ms since epoch, but span payloads store
+        # `start_ns` in nanoseconds — convert here so downstream
+        # aggregations (min/max/earliest/latest on `timestamp`) match
+        # production semantics.
+        "timestamp": lambda s: (
+            s["start_ns"] / 1_000_000
+            if isinstance(s.get("start_ns"), (int, float))
+            else None
+        ),
     }
     if field in direct_fields:
         return direct_fields[field](span)
@@ -1216,9 +1226,33 @@ class LLMObsEventPlatformAPI:
                         if aggregation == "count":
                             metrics[output] = len(group_spans)
                         elif aggregation == "earliest":
-                            metrics[output] = str(get_span_field_value(earliest_span, metric_field) or "")
+                            _val = get_span_field_value(earliest_span, metric_field)
+                            metrics[output] = "" if _val is None else str(_val)
                         elif aggregation == "latest":
-                            metrics[output] = str(get_span_field_value(latest_span, metric_field) or "")
+                            _val = get_span_field_value(latest_span, metric_field)
+                            metrics[output] = "" if _val is None else str(_val)
+                        elif aggregation in ("min", "max", "sum", "avg"):
+                            numeric_values = []
+                            for s in group_spans:
+                                v = get_span_field_value(s, metric_field)
+                                try:
+                                    if v is None or v == "":
+                                        continue
+                                    numeric_values.append(float(v))
+                                except (TypeError, ValueError):
+                                    continue
+                            if not numeric_values:
+                                metrics[output] = 0
+                            elif aggregation == "min":
+                                metrics[output] = min(numeric_values)
+                            elif aggregation == "max":
+                                metrics[output] = max(numeric_values)
+                            elif aggregation == "sum":
+                                metrics[output] = sum(numeric_values)
+                            elif aggregation == "avg":
+                                metrics[output] = (
+                                    sum(numeric_values) / len(numeric_values)
+                                )
                     elif "list" in compute_item:
                         cfg = compute_item["list"]
                         output = cfg.get("output", "")

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -406,7 +406,6 @@ class PiHooksAPI:
         else:
             output_value = body.get("output", "")  # fallback for older extension format
 
-        token_usage = self._hooks_api._compute_token_usage(session.trace_id)
         tool_usage = self._hooks_api._aggregate_tool_usage(session.trace_id)
 
         root_span: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
@@ -423,7 +422,10 @@ class PiHooksAPI:
             root_span["meta"]["model_name"] = session.model
             root_span["meta"]["model_provider"] = session.model_provider
             root_span["meta"].setdefault("metadata", {})["models_used"] = session.models[:]
-            root_span["metrics"] = token_usage
+            # Do not roll token_usage up onto root_span["metrics"] —
+            # production stores trace rollups in a separate `@trace.*`
+            # document, not on the root span. Mirroring it here caused
+            # `_build_trace_aggregates` to double-count tokens.
             dd_fields: Dict[str, Any] = {}
             if tool_usage:
                 dd_fields["tool_usage"] = tool_usage
@@ -471,7 +473,7 @@ class PiHooksAPI:
                     "model_provider": session.model_provider,
                     "metadata": {"models_used": session.models[:]},
                 },
-                "metrics": token_usage,
+                # Intentionally no "metrics" key — see comment above.
             }
             self._append_span(root_span)
 

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -50,7 +50,6 @@ from .claude_hooks import _format_trace_id
 from .claude_hooks import _to_json_str
 from .llmobs_event_platform import with_cors
 
-
 log = logging.getLogger(__name__)
 
 

--- a/releasenotes/notes/llmobs-aggregate-min-max-timestamp-a8e014ba41262f44.yaml
+++ b/releasenotes/notes/llmobs-aggregate-min-max-timestamp-a8e014ba41262f44.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    llmobs: support ``min``/``max``/``sum``/``avg`` aggregations on the
+    ``/api/v1/logs-analytics/aggregate`` endpoint and expose ``timestamp``
+    (``start_ns`` in milliseconds) as a resolvable field so the static app's
+    sessions table can compute session duration. Also fixes ``earliest`` /
+    ``latest`` so a value of ``0`` is no longer collapsed to an empty string.
+  - |
+    llmobs: stop rolling up aggregated ``token_usage`` onto the root (agent)
+    span's ``metrics`` dict from the claude and pi hook handlers. The trace
+    aggregate builder sums ``metrics.total_tokens`` across every span in the
+    trace, so writing the rollup on the root caused session-table token totals
+    to double-count relative to the per-span values.

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,17 +1,15 @@
 import json
 import os
-import tempfile
 from pathlib import Path
+import tempfile
 from typing import Any
 from typing import Dict
 from typing import cast
 
-from ddapm_test_agent.claude_hooks import (
-    CLAUDE_CODE_DEFAULT_MATCHER,
-    CLAUDE_CODE_HOOK,
-    CLAUDE_CODE_EVENTS,
-    write_claude_code_hooks,
-)
+from ddapm_test_agent.claude_hooks import CLAUDE_CODE_DEFAULT_MATCHER
+from ddapm_test_agent.claude_hooks import CLAUDE_CODE_EVENTS
+from ddapm_test_agent.claude_hooks import CLAUDE_CODE_HOOK
+from ddapm_test_agent.claude_hooks import write_claude_code_hooks
 
 
 def _read_settings(path: Path) -> Dict[str, Any]:
@@ -741,9 +739,7 @@ async def test_concurrent_subagents_parent_correctly(agent):
     assert len(root_spans) == 1
     root = root_spans[0]
 
-    agent_spans = [
-        s for s in session_spans if s["meta"]["span"]["kind"] == "agent" and s["parent_id"] != "undefined"
-    ]
+    agent_spans = [s for s in session_spans if s["meta"]["span"]["kind"] == "agent" and s["parent_id"] != "undefined"]
     assert len(agent_spans) == 2, f"Expected 2 subagent spans, got {len(agent_spans)}"
 
     # Both subagents should be parented to root — not to each other


### PR DESCRIPTION
## Motivation

Two LLMObs-aggregate issues surfaced while wiring the static-app's sessions
table (web-ui) against the local test agent.

### 1. `min` / `max` aggregations + `timestamp` facet were missing

`handle_aggregate` (`/api/v1/logs-analytics/aggregate`) only implemented
`count`, `earliest`, and `latest`. The sessions table uses
`min(timestamp)` / `max(timestamp)` to compute session duration, and
`latest(@duration)` to get the last trace's duration. Two problems:

- The `timestamp` facet wasn't wired to any span field, so aggregations
  on it resolved to `None`.
- `min`/`max` weren't handled at all — requests for those keys just
  silently omitted the corresponding metric from the response.

### 2. Table token totals were ~2× the side panel's

The LLMObs sessions table sums `@trace.total_tokens` across root spans
and was returning roughly twice what the session side panel showed.
Cost didn't exhibit the same bug.

Root cause: `claude_hooks._handle_stop` /
`claude_hooks._finalize_interrupted_turn` /
`pi_hooks._handle_agent_end` all roll a `_compute_token_usage`
aggregate onto the root (agent) span's `metrics` dict. Later,
`_build_trace_aggregates` (in `llmobs_event_platform.py`) sums
`span.metrics.total_tokens` across every span in a trace, so the
rolled-up value on the root was counted **in addition to** each LLM
span's own tokens. Cost was unaffected because the hook handlers don't
write `estimated_total_cost` to the root.

Production stores trace-level rollups in a separate `@trace.*` document
— the root span's `metrics` dict stays scoped to that span only.

## Changes

`ddapm_test_agent/llmobs_event_platform.py`:

- `get_span_field_value`: added `timestamp` → `start_ns / 1_000_000`
  (ms since epoch, matching production semantics for the `timestamp`
  facet).
- `handle_aggregate`: added a `min` / `max` / `sum` / `avg` branch that
  coerces each span's field to `float` (skipping missing / non-numeric
  values) and falls back to `0` when there are no numeric values.
  Existing `count` / `earliest` / `latest` behavior is unchanged.
- `handle_aggregate`: the `earliest` / `latest` branches no longer
  collapse a real `0` to the empty string via `or ""` — only `None`
  falls back to `""`.

`ddapm_test_agent/claude_hooks.py`:

- `_handle_stop` (normal finalize): dropped the
  `root_span["metrics"] = token_usage` assignment and the
  `"metrics": token_usage` field in the fallback root-span
  construction.
- `_finalize_interrupted_turn`: dropped the
  `root_span["metrics"] = token_usage` assignment on the interrupted
  root.
- Removed the now-unused `_compute_token_usage` call sites in those two
  paths. `_compute_token_usage` itself is kept.

`ddapm_test_agent/pi_hooks.py`:

- `_handle_agent_end`: dropped the `root_span["metrics"] = token_usage`
  assignment on the existing root span and the
  `"metrics": token_usage` field in the fallback construction. Removed
  the unused `token_usage = ...` call (kept `tool_usage`).

Net behavior:
- `_build_trace_aggregates` continues to sum `metrics.total_tokens`
  across every span in the trace — but now only LLM-kind spans carry
  token metrics, so the sum equals the per-trace total exactly once
  (no more doubling).
- Nothing else in the codebase reads
  `root_span["metrics"]["total_tokens"]` (grep verified); only the
  three now-removed write sites referenced it.

## Testing

With the local test agent rebuilt:

```
curl -s http://localhost:8126/api/v1/logs-analytics/aggregate?type=llmobs \
  -H 'Content-Type: application/json' -X POST -d '{"aggregate":{
    "compute":[
      {"total":{"metric":"timestamp","output":"minTs","aggregation":"min"}},
      {"total":{"metric":"timestamp","output":"maxTs","aggregation":"max"}},
      {"total":{"metric":"@duration","output":"latestDur","aggregation":"latest"}},
      {"total":{"metric":"","output":"c","aggregation":"count"}}
    ],
    "groupBy":[{"field":{"id":"@session_id","output":"@session_id","limit":10}}],
    "time":{"from":"now-15d","to":"now"},"indexes":["llmobs"],
    "search":{"query":"@event_type:span @parent_id:undefined"}
  }}'
```

Returns `minTs` and `maxTs` as millisecond timestamps (e.g.
`1776799775530.923`) rather than being absent, and `c` reflects the
per-session root-span count.

The web-ui LLMObs sessions table, pointed at the local test agent, now
populates the Initial Input / Total Traces / Cost / Time & Duration
columns with values that match the session side panel. No token-count
doubling between the table and the side panel.

## Blast Radius

- Affects only the local LLMObs test-agent data paths.
- No change to how spans are stored, only to how aggregates and the
  hook-generated root spans are shaped before being served.
- Static-app consumers (and anything else reading `@trace.total_tokens`
  via `_build_trace_aggregates`) get smaller, correct totals rather
  than the previous 2× value. Consumers reading individual span
  `metrics` are unaffected — LLM spans still carry their own metrics.
