### PR TITLE
feat(lapdog): tag spans per coding agent and default fallback to lapdog

### DIFF
--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -126,7 +126,7 @@ def remap_sdk_span_to_ui_format(span: Dict[str, Any], event_ml_app: str = "") ->
     tags = span.get("tags", [])
     extracted = extract_fields_from_tags(tags)
 
-    ml_app = extracted.get("ml_app") or event_ml_app or span.get("ml_app", "unknown")
+    ml_app = extracted.get("ml_app") or event_ml_app or span.get("ml_app") or "lapdog"
     span["ml_app"] = ml_app
 
     if "service" not in span or not span["service"]:

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -27,6 +27,7 @@ Terminology mapping (pi → trajectory-dev proposal):
 
 import json
 import logging
+import os
 from typing import Any
 from typing import Dict
 from typing import List
@@ -43,7 +44,6 @@ from .claude_hooks import ClaudeHooksAPI
 from .claude_hooks import PendingToolSpan
 from .claude_hooks import SessionState
 from .claude_hooks import _HOSTNAME
-from .claude_hooks import _ML_APP
 from .claude_hooks import _USER_HANDLE
 from .claude_hooks import _format_span_id
 from .claude_hooks import _format_trace_id
@@ -51,6 +51,8 @@ from .claude_hooks import _to_json_str
 from .llmobs_event_platform import with_cors
 
 log = logging.getLogger(__name__)
+
+_ML_APP = os.environ.get("DD_PI_CODING_AGENT_ML_APP", "pi-coding-agent")
 
 
 class PendingLLMSpan:

--- a/releasenotes/notes/ml-app-per-coding-agent-8624a89fd5069d16.yaml
+++ b/releasenotes/notes/ml-app-per-coding-agent-8624a89fd5069d16.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Pi coding agent spans now default ``ml_app`` to ``pi-coding-agent`` instead
+    of inheriting the Claude Code value. Override with
+    ``DD_PI_CODING_AGENT_ML_APP``.
+fixes:
+  - |
+    LLMObs events that arrive without an explicit ``ml_app`` tag now fall back
+    to ``lapdog`` (previously ``unknown``), so unattributed lapdog traffic is
+    grouped under a meaningful app name.


### PR DESCRIPTION
## Summary

- Pi coding agent spans were inheriting `claude-code` as their `ml_app` because `pi_hooks.py` imported `_ML_APP` from `claude_hooks.py`. Pi now has its own default of `pi-coding-agent` (overridable via `DD_PI_CODING_AGENT_ML_APP`).
- LLMObs event-platform fallback in `remap_sdk_span_to_ui_format` changed from `"unknown"` to `"lapdog"` so unattributed lapdog traffic shows up under a meaningful app name.
- Claude Code behavior is unchanged — still defaults to `claude-code` via `DD_CLAUDE_CODE_ML_APP`.

## Test plan

- [x] `python -m pytest tests/test_pi_hooks.py tests/test_llmobs_event_platform.py tests/test_claude_hooks.py` — 71 passed
- [x] `mypy` / `flake8` clean on both modified modules
- [ ] Smoke test: send events to `/claude/hooks` and `/pi/hooks`, confirm resulting spans carry `ml_app=claude-code` and `ml_app=pi-coding-agent` respectively
- [ ] Submit an LLMObs event via `evp_proxy` with no `ml_app` tag and confirm the span surfaces as `lapdog`

Claude session: `d0cc4c0b-4ccf-410d-915a-59d3ae9d2fba`
Resume: `claude --resume d0cc4c0b-4ccf-410d-915a-59d3ae9d2fba`