### PR TITLE
chore(lapdog): add startup ascii word art to coding agent session instrumentations

### DIFF
--- a/ddapm_test_agent/__init__.py
+++ b/ddapm_test_agent/__init__.py
@@ -7,4 +7,4 @@ def _get_version() -> str:
     except PackageNotFoundError:
         import pkg_resources
 
-        return pkg_resources.get_distribution(__name__).version
+        return str(pkg_resources.get_distribution(__name__).version)

--- a/ddapm_test_agent/__init__.py
+++ b/ddapm_test_agent/__init__.py
@@ -1,4 +1,10 @@
-def _get_version():
-    import pkg_resources
+def _get_version() -> str:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version
 
-    return pkg_resources.get_distribution(__name__).version
+    try:
+        return version(__name__)
+    except PackageNotFoundError:
+        import pkg_resources
+
+        return pkg_resources.get_distribution(__name__).version

--- a/ddapm_test_agent/_lapdog_ascii_art.py
+++ b/ddapm_test_agent/_lapdog_ascii_art.py
@@ -142,7 +142,7 @@ def _build_running_banner() -> str:
         f"{bold}lapdog{reset} {dim}v{_get_version()}{reset}",
         "",
         f"{dim}Lapdog has started and is listening for data.{reset}",
-        f"{dim}Open {reset}{face}https://lapdog.datadoghq.com{reset}{dim} to view data{reset}",
+        f"{dim}Open {reset}{face}https://lapdog.datadoghq.com{reset}{dim} to view insights,{reset}",
         f"{dim}costs, optimizations and more related to this coding session.{reset}",
     ]
     # Vertically center the text block against the art.

--- a/ddapm_test_agent/_lapdog_ascii_art.py
+++ b/ddapm_test_agent/_lapdog_ascii_art.py
@@ -1,0 +1,161 @@
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from . import _get_version
+
+# Letter masks (5 rows tall). '#' = filled, ' ' = blank. All letters share the
+# same height so they can be rendered side-by-side with a drop shadow.
+_LAPDOG_LETTERS = (
+    (
+        "##    ",
+        "##    ",
+        "##    ",
+        "##    ",
+        "######",
+    ),
+    (
+        " ##### ",
+        "##   ##",
+        "#######",
+        "##   ##",
+        "##   ##",
+    ),
+    (
+        "###### ",
+        "##   ##",
+        "###### ",
+        "##     ",
+        "##     ",
+    ),
+    (
+        "###### ",
+        "##   ##",
+        "##   ##",
+        "##   ##",
+        "###### ",
+    ),
+    (
+        " ##### ",
+        "##   ##",
+        "##   ##",
+        "##   ##",
+        " ##### ",
+    ),
+    (
+        " ##### ",
+        "##     ",
+        "##  ###",
+        "##   ##",
+        " ##### ",
+    ),
+)
+
+
+def _render_lapdog_art(face: str, shadow: str, reset: str) -> List[str]:
+    """Render LAPDOG word art as colored lines with a 1-cell drop shadow.
+
+    Produces a mask of filled cells by concatenating the letter masks with one
+    blank column between each letter, then draws a shadow copy offset +1 col /
+    +1 row behind the face so the letters appear to have depth.
+    """
+    gap = 1
+    height = len(_LAPDOG_LETTERS[0])
+    # Build a single filled/blank grid across all letters.
+    rows: List[str] = [""] * height
+    for i, letter in enumerate(_LAPDOG_LETTERS):
+        for y in range(height):
+            rows[y] += letter[y]
+        if i != len(_LAPDOG_LETTERS) - 1:
+            for y in range(height):
+                rows[y] += " " * gap
+
+    w = len(rows[0])
+    # Shadow canvas is one row taller and one column wider (shadow offset).
+    out_h = height + 1
+    out_w = w + 1
+
+    def filled(y: int, x: int) -> bool:
+        if 0 <= y < height and 0 <= x < w:
+            return rows[y][x] == "#"
+        return False
+
+    # Flood-fill from outside the canvas to identify "outside" blank cells.
+    # Shadows should only be drawn on outside cells, never inside letter holes
+    # (the interiors of O, D, P, A, G).
+    outside = [[False] * out_w for _ in range(out_h)]
+    # Seed the flood fill from every non-filled cell on the border so letters
+    # that touch the top-left corner (like 'L') don't block the fill.
+    stack: List[Tuple[int, int]] = []
+    for x in range(out_w):
+        stack.append((0, x))
+        stack.append((out_h - 1, x))
+    for y in range(out_h):
+        stack.append((y, 0))
+        stack.append((y, out_w - 1))
+    while stack:
+        y, x = stack.pop()
+        if not (0 <= y < out_h and 0 <= x < out_w):
+            continue
+        if outside[y][x] or filled(y, x):
+            continue
+        outside[y][x] = True
+        stack.extend([(y + 1, x), (y - 1, x), (y, x + 1), (y, x - 1)])
+
+    lines: List[str] = []
+    for y in range(out_h):
+        segments: List[str] = []
+        current: Optional[str] = None  # None | "face" | "shadow"
+        buf: List[str] = []
+
+        def flush() -> None:
+            if not buf:
+                return
+            color = face if current == "face" else shadow if current == "shadow" else ""
+            segments.append(f"{color}{''.join(buf)}{reset}" if color else "".join(buf))
+
+        for x in range(out_w):
+            is_face = filled(y, x)
+            is_shadow = (not is_face) and outside[y][x] and filled(y - 1, x - 1)
+            kind = "face" if is_face else "shadow" if is_shadow else None
+            ch = "█" if (is_face or is_shadow) else " "
+            if kind != current:
+                flush()
+                buf = []
+                current = kind
+            buf.append(ch)
+        flush()
+        lines.append("".join(segments))
+    return lines
+
+
+def _build_running_banner() -> str:
+    face = "\033[38;5;177m"  # light purple
+    shadow = "\033[38;5;54m"  # deep purple
+    dim = "\033[2m"
+    bold = "\033[1m"
+    reset = "\033[0m"
+
+    art_lines = _render_lapdog_art(face, shadow, reset)
+
+    right_lines = [
+        f"{bold}lapdog{reset} {dim}v{_get_version()}{reset}",
+        "",
+        f"{dim}Lapdog has started and is listening for data.{reset}",
+        f"{dim}Open {reset}{face}https://lapdog.datadoghq.com{reset}{dim} to view data{reset}",
+        f"{dim}related to this coding session.{reset}",
+    ]
+    # Vertically center the text block against the art.
+    pad_top = max((len(art_lines) - len(right_lines)) // 2, 0)
+    padded_right = [""] * pad_top + right_lines
+    while len(padded_right) < len(art_lines):
+        padded_right.append("")
+
+    lines = [""]
+    for art, text in zip(art_lines, padded_right):
+        lines.append(f"  {art}  {text}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+LAPDOG_RUNNING = _build_running_banner()

--- a/ddapm_test_agent/_lapdog_ascii_art.py
+++ b/ddapm_test_agent/_lapdog_ascii_art.py
@@ -143,7 +143,7 @@ def _build_running_banner() -> str:
         "",
         f"{dim}Lapdog has started and is listening for data.{reset}",
         f"{dim}Open {reset}{face}https://lapdog.datadoghq.com{reset}{dim} to view data{reset}",
-        f"{dim}related to this coding session.{reset}",
+        f"{dim}costs, optimizations and more related to this coding session.{reset}",
     ]
     # Vertically center the text block against the art.
     pad_top = max((len(art_lines) - len(right_lines)) // 2, 0)

--- a/ddapm_test_agent/lapdog_cli.py
+++ b/ddapm_test_agent/lapdog_cli.py
@@ -11,18 +11,53 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+from . import _get_version
+
 import requests
 
 LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi"]
 LAPDOG_USAGE = (
     "Usage: lapdog [OPTIONS] <command> [command-args...]\n"
     "Options must appear before <command>. Arguments after <command> are forwarded.\n"
-    "  run     Start lapdog (background)\n"
+    "  start   Start lapdog (background)\n"
     "  stop    Stop lapdog (started by 'lapdog start' or 'lapdog claude')\n"
     "  status  Show lapdog status (from /info)\n"
     "  claude  Start lapdog in background if needed, then launch Claude with intercept\n"
     "  pi      Start lapdog in background if needed, install extension, then launch pi"
 )
+_LAPDOG_ART = (
+    "██      █████  ██████  ██████   ██████   ██████ ",
+    "██     ██   ██ ██   ██ ██   ██ ██    ██ ██      ",
+    "██     ███████ ██████  ██   ██ ██    ██ ██  ███ ",
+    "██     ██   ██ ██      ██   ██ ██    ██ ██   ██ ",
+    "██████ ██   ██ ██      ██████   ██████   ██████ ",
+)
+
+
+def _build_running_banner() -> str:
+    right_lines = [
+        f"\033[1mlapdog\033[0m v{_get_version()}",
+        "",
+        "Lapdog has started and is listening for data.",
+        "Open https://lapdog.datadoghq.com to view data",
+        "related to this coding session.",
+    ]
+    # Pad right_lines to match art height, centering vertically.
+    pad_top = (len(_LAPDOG_ART) - len(right_lines)) // 2
+    padded_right = [""] * max(pad_top, 0) + right_lines
+    while len(padded_right) < len(_LAPDOG_ART):
+        padded_right.append("")
+
+    purple = "\033[38;5;177m"
+    reset = "\033[0m"
+    lines = [""]
+    for art, text in zip(_LAPDOG_ART, padded_right):
+        lines.append(f"  {purple}{art}{reset}  {text}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+LAPDOG_CODING_AGENT_RUNNING = _build_running_banner()
 
 
 def _resolved_port(cli_args: Optional[List[str]] = None) -> int:
@@ -105,8 +140,8 @@ def _remove_pid_file() -> None:
             pass
 
 
-def _start_lapdog(port: int, extra_args: Optional[List[str]] = None, forward_data: bool = False) -> None:
-    """Start lapdog in background with logs to the log file; wait until ready or exit on timeout. Return (process, log_path)."""
+def _start_lapdog(port: int, extra_args: Optional[List[str]] = None, forward_data: bool = False) -> Tuple[int, int, str]:
+    """Start lapdog in background with logs to the log file; wait until ready or exit on timeout. Return (pid, port, log_path)."""
     log_path = _log_file_path()
     os.makedirs(os.path.dirname(log_path), exist_ok=True)
     args = [sys.executable, "-m", "ddapm_test_agent.agent", "--enable-claude-code-hooks"]
@@ -127,7 +162,7 @@ def _start_lapdog(port: int, extra_args: Optional[List[str]] = None, forward_dat
     _write_pid_file(proc.pid, port)
     _wait_for_lapdog(proc, log_path)
 
-    print(f"[lapdog] Lapdog running at {_url_for_port(port)} (pid={proc.pid}, logs: {log_path})")
+    return proc.pid, port, log_path
 
 
 def _port_in_use(port: Optional[int] = None) -> bool:
@@ -188,7 +223,9 @@ def cmd_start(sub_cmd_args: List[str], forward_data: bool) -> None:
             file=sys.stderr,
         )
         sys.exit(1)
-    _start_lapdog(port, sub_cmd_args, forward_data)
+    pid, port, log_path = _start_lapdog(port, sub_cmd_args, forward_data)
+
+    print(f"[lapdog] Lapdog running at {_url_for_port(port)} (pid={pid}, logs: {log_path})")
 
 
 def cmd_stop() -> None:
@@ -267,6 +304,7 @@ def cmd_claude(sub_cmd_args: List[str], forward_data: bool) -> None:
             sys.exit(1)
         _start_lapdog_detached(port, forward_data=forward_data)
 
+    print(LAPDOG_CODING_AGENT_RUNNING)
     _run_claude(sub_cmd_args)
 
 
@@ -341,6 +379,8 @@ def cmd_pi(sub_cmd_args: List[str], forward_data: bool) -> None:
         _start_lapdog_detached(port, forward_data=forward_data)
 
     _install_pi_extension()
+
+    print(LAPDOG_CODING_AGENT_RUNNING)
     _run_pi(sub_cmd_args, port)
 
 

--- a/ddapm_test_agent/lapdog_cli.py
+++ b/ddapm_test_agent/lapdog_cli.py
@@ -11,7 +11,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-from . import _get_version
+from ddapm_test_agent._lapdog_ascii_art import LAPDOG_RUNNING
 
 import requests
 
@@ -25,39 +25,6 @@ LAPDOG_USAGE = (
     "  claude  Start lapdog in background if needed, then launch Claude with intercept\n"
     "  pi      Start lapdog in background if needed, install extension, then launch pi"
 )
-_LAPDOG_ART = (
-    "██      █████  ██████  ██████   ██████   ██████ ",
-    "██     ██   ██ ██   ██ ██   ██ ██    ██ ██      ",
-    "██     ███████ ██████  ██   ██ ██    ██ ██  ███ ",
-    "██     ██   ██ ██      ██   ██ ██    ██ ██   ██ ",
-    "██████ ██   ██ ██      ██████   ██████   ██████ ",
-)
-
-
-def _build_running_banner() -> str:
-    right_lines = [
-        f"\033[1mlapdog\033[0m v{_get_version()}",
-        "",
-        "Lapdog has started and is listening for data.",
-        "Open https://lapdog.datadoghq.com to view data",
-        "related to this coding session.",
-    ]
-    # Pad right_lines to match art height, centering vertically.
-    pad_top = (len(_LAPDOG_ART) - len(right_lines)) // 2
-    padded_right = [""] * max(pad_top, 0) + right_lines
-    while len(padded_right) < len(_LAPDOG_ART):
-        padded_right.append("")
-
-    purple = "\033[38;5;177m"
-    reset = "\033[0m"
-    lines = [""]
-    for art, text in zip(_LAPDOG_ART, padded_right):
-        lines.append(f"  {purple}{art}{reset}  {text}")
-    lines.append("")
-    return "\n".join(lines)
-
-
-LAPDOG_CODING_AGENT_RUNNING = _build_running_banner()
 
 
 def _resolved_port(cli_args: Optional[List[str]] = None) -> int:
@@ -304,7 +271,7 @@ def cmd_claude(sub_cmd_args: List[str], forward_data: bool) -> None:
             sys.exit(1)
         _start_lapdog_detached(port, forward_data=forward_data)
 
-    print(LAPDOG_CODING_AGENT_RUNNING)
+    print(LAPDOG_RUNNING)
     _run_claude(sub_cmd_args)
 
 
@@ -380,7 +347,7 @@ def cmd_pi(sub_cmd_args: List[str], forward_data: bool) -> None:
 
     _install_pi_extension()
 
-    print(LAPDOG_CODING_AGENT_RUNNING)
+    print(LAPDOG_RUNNING)
     _run_pi(sub_cmd_args, port)
 
 


### PR DESCRIPTION
Adds the following ASCII art to `lapdog` coding agent startup commands.

<img width="734" height="118" alt="Screenshot 2026-04-28 at 12 37 23 PM" src="https://github.com/user-attachments/assets/93c54e69-ea12-480f-a97a-5d2d77b4306d" />
