### PR TITLE
fix(pi-hooks): capture system + user/tool messages on LLM spans

### DIFF
--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -58,10 +58,17 @@ _ML_APP = os.environ.get("DD_PI_CODING_AGENT_ML_APP", "pi-coding-agent")
 class PendingLLMSpan:
     """Tracks an LLM call between message_start and message_end."""
 
-    def __init__(self, span_id: str, parent_id: str, start_ns: int) -> None:
+    def __init__(
+        self,
+        span_id: str,
+        parent_id: str,
+        start_ns: int,
+        input_messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
         self.span_id = span_id
         self.parent_id = parent_id
         self.start_ns = start_ns
+        self.input_messages: List[Dict[str, Any]] = input_messages or []
 
 
 class ActiveStepSpan:
@@ -90,6 +97,96 @@ class ActiveStepSpan:
         self.has_thinking = False
         self.stop_reason = ""
         self.span_ref: Optional[Dict[str, Any]] = None
+
+
+def _pi_content_to_text(content: Any) -> str:
+    """Flatten a pi message ``content`` field to plain text.
+
+    pi messages use either a string or a list of typed content blocks
+    (``text``, ``image``, ``thinking``, ``toolCall``).  For the LLMObs span
+    input we want a single string — image and thinking blocks are summarized
+    as ``[image]`` / ``[thinking]`` placeholders so they don't get dropped
+    silently.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: List[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type", "")
+        if btype == "text":
+            text = block.get("text", "")
+            if text:
+                parts.append(text)
+        elif btype == "image":
+            parts.append("[image]")
+        elif btype in ("thinking", "reasoning"):
+            parts.append("[thinking]")
+    return "\n".join(parts)
+
+
+def _pi_messages_to_llmobs_input(
+    system_prompt: str,
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Convert pi's conversation messages into LLMObs ``input.messages`` format.
+
+    Mapping:
+        * Prepend a ``{role: system}`` message when ``system_prompt`` is set.
+        * pi ``user`` → LLMObs ``{role: "user", content: <text>}``.
+        * pi ``assistant`` → ``{role: "assistant", content, tool_calls}``
+          where ``tool_calls`` mirrors the format used by ``claude_proxy.py``.
+        * pi ``toolResult`` → ``{role: "tool", content, tool_id}``.
+        * Other extended message types (bashExecution, custom, branchSummary,
+          compactionSummary) are skipped — they are not part of the LLM
+          conversation context.
+    """
+    out: List[Dict[str, Any]] = []
+    if system_prompt:
+        out.append({"role": "system", "content": system_prompt})
+
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "")
+
+        if role == "user":
+            out.append({"role": "user", "content": _pi_content_to_text(msg.get("content"))})
+
+        elif role == "assistant":
+            content = msg.get("content", [])
+            text, tool_calls, _tool_use_ids, _has_thinking = _extract_output_text_and_tool_calls(
+                content if isinstance(content, list) else []
+            )
+            entry: Dict[str, Any] = {"role": "assistant", "content": text}
+            if tool_calls:
+                entry["tool_calls"] = [
+                    {
+                        "name": tc.get("name", ""),
+                        "arguments": tc.get("arguments", {}),
+                        "tool_id": tc.get("id", ""),
+                        "type": "tool_use",
+                    }
+                    for tc in tool_calls
+                ]
+            out.append(entry)
+
+        elif role == "toolResult":
+            out.append(
+                {
+                    "role": "tool",
+                    "content": _pi_content_to_text(msg.get("content")),
+                    "tool_id": msg.get("toolCallId", ""),
+                }
+            )
+        # Extended message types (bashExecution / custom / branchSummary /
+        # compactionSummary) are intentionally skipped — they aren't sent to
+        # the LLM as standalone messages.
+
+    return out
 
 
 def _extract_output_text_and_tool_calls(
@@ -510,10 +607,21 @@ class PiHooksAPI:
         parent_id = self._active_step_parent_id(session)
         span_id = _format_span_id()
         now_ns = monotonic_wall_ns()
+
+        # The extension snapshots `system_prompt` and the pre-call `messages`
+        # array (from the pi `context` event) and forwards both on every
+        # assistant message_start so we can populate `input.messages` on the
+        # LLM span.
+        input_messages = _pi_messages_to_llmobs_input(
+            body.get("system_prompt", "") or "",
+            body.get("messages", []) or [],
+        )
+
         self._pending_llm[session_id] = PendingLLMSpan(
             span_id=span_id,
             parent_id=parent_id,
             start_ns=now_ns,
+            input_messages=input_messages,
         )
 
     def _handle_message_end(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -535,10 +643,18 @@ class PiHooksAPI:
             span_id = pending.span_id
             parent_id = pending.parent_id
             start_ns = pending.start_ns
+            input_messages = pending.input_messages
         else:
             span_id = _format_span_id()
             parent_id = self._active_step_parent_id(session)
             start_ns = now_ns
+            # Fallback path — message_start was missed, so we have no
+            # context-event snapshot. Build a minimal input from system_prompt
+            # + messages on this event if present, else leave empty.
+            input_messages = _pi_messages_to_llmobs_input(
+                body.get("system_prompt", "") or "",
+                body.get("messages", []) or [],
+            )
 
         duration = now_ns - start_ns
 
@@ -630,7 +746,7 @@ class PiHooksAPI:
                 "span": {"kind": "llm"},
                 "model_name": model_id,
                 "model_provider": model_provider,
-                "input": {"messages": []},
+                "input": {"messages": input_messages},
                 "output": {"messages": output_messages},
                 "metadata": {
                     "stop_reason": stop_reason,

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -132,17 +132,21 @@ def _pi_messages_to_llmobs_input(
     system_prompt: str,
     messages: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    """Convert pi's conversation messages into LLMObs ``input.messages`` format.
+    """Convert pi's LLM-shaped messages into LLMObs ``input.messages`` format.
+
+    The extension runs pi's own ``convertToLlm()`` on the ``context`` event
+    payload before sending, so by the time messages reach this function they
+    are already reduced to plain ``user`` / ``assistant`` / ``toolResult``
+    entries — i.e. exactly what the provider receives. Extended types
+    (``bashExecution``, ``custom``, ``branchSummary``, ``compactionSummary``)
+    have been inlined as user text upstream.
 
     Mapping:
-        * Prepend a ``{role: system}`` message when ``system_prompt`` is set.
-        * pi ``user`` → LLMObs ``{role: "user", content: <text>}``.
-        * pi ``assistant`` → ``{role: "assistant", content, tool_calls}``
-          where ``tool_calls`` mirrors the format used by ``claude_proxy.py``.
+        * Prepend ``{role: "system"}`` when ``system_prompt`` is non-empty.
+        * pi ``user`` → ``{role: "user", content: <text>}``.
+        * pi ``assistant`` → ``{role: "assistant", content, tool_calls}``,
+          tool_calls shaped like ``claude_proxy.py``'s output.
         * pi ``toolResult`` → ``{role: "tool", content, tool_id}``.
-        * Other extended message types (bashExecution, custom, branchSummary,
-          compactionSummary) are skipped — they are not part of the LLM
-          conversation context.
     """
     out: List[Dict[str, Any]] = []
     if system_prompt:
@@ -182,9 +186,6 @@ def _pi_messages_to_llmobs_input(
                     "tool_id": msg.get("toolCallId", ""),
                 }
             )
-        # Extended message types (bashExecution / custom / branchSummary /
-        # compactionSummary) are intentionally skipped — they aren't sent to
-        # the LLM as standalone messages.
 
     return out
 

--- a/ddapm_test_agent/pi_lapdog_extension.ts
+++ b/ddapm_test_agent/pi_lapdog_extension.ts
@@ -14,7 +14,7 @@
  * never blocks the agent.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { convertToLlm, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 const LAPDOG_URL = process.env.LAPDOG_URL || "http://localhost:8126";
 const HOOKS_ENDPOINT = `${LAPDOG_URL}/pi/hooks`;
@@ -41,27 +41,23 @@ function post(event: string, sessionId: string, data: Record<string, unknown>): 
 // Extension
 // ---------------------------------------------------------------------------
 
-// Pi message types — copied from pi-coding-agent docs/session.md so we can
-// inspect them in the `context` hook without depending on the SDK's exports.
+// Pi LLM message types after `convertToLlm()`. Pi reduces every extended
+// AgentMessage type (bashExecution, custom, branchSummary, compactionSummary)
+// down to one of these three, so this matches what's actually sent to the
+// model.
 type TextContent = { type: "text"; text: string };
 type ImageContent = { type: "image"; data: string; mimeType: string };
-type ThinkingContent = { type: "thinking"; thinking: string };
-type ToolCall = { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> };
 
-type PiMessage =
+type LlmMessage =
 	| { role: "user"; content: string | (TextContent | ImageContent)[] }
-	| {
-			role: "assistant";
-			content: (TextContent | ThinkingContent | ToolCall)[];
-		}
+	| { role: "assistant"; content: unknown[] }
 	| {
 			role: "toolResult";
 			toolCallId: string;
 			toolName: string;
 			content: (TextContent | ImageContent)[];
 			isError?: boolean;
-		}
-	| { role: string; [k: string]: unknown };
+		};
 
 export default function lapdog(pi: ExtensionAPI): void {
 	let sessionId = "";
@@ -77,11 +73,12 @@ export default function lapdog(pi: ExtensionAPI): void {
 	// the system message as part of its input.
 	let currentSystemPrompt = "";
 
-	// Most recent message list seen in `context`. The `context` event fires
-	// right before each LLM call and gives us the full conversation that's
-	// about to be sent to the model — exactly what we want to attach as
-	// `input.messages` on the LLM span.
-	let pendingContextMessages: PiMessage[] = [];
+	// Most recent LLM-shaped message list captured from the `context` event.
+	// `context` fires right before each LLM call with the full AgentMessage[]
+	// (including extended types like bashExecution / branchSummary /
+	// compactionSummary). We feed it through pi's own `convertToLlm()` so the
+	// snapshot matches what the provider actually receives.
+	let pendingContextMessages: LlmMessage[] = [];
 
 	// ------------------------------------------------------------------
 	// Session lifecycle
@@ -181,10 +178,17 @@ export default function lapdog(pi: ExtensionAPI): void {
 	// ------------------------------------------------------------------
 
 	pi.on("context", (event) => {
-		// `event.messages` is a safe-to-modify deep copy of the conversation
-		// about to be sent to the LLM. Stash it so the next assistant
-		// message_start can include it as the LLM span's input.
-		pendingContextMessages = (event.messages as PiMessage[]) ?? [];
+		// `event.messages` is a deep copy of the AgentMessage[] about to be
+		// sent to the LLM. Run it through pi's own `convertToLlm()` so we
+		// capture the same list the provider sees — bashExecution becomes a
+		// formatted user message, custom/branchSummary/compactionSummary are
+		// inlined as user text, and `excludeFromContext` bash entries are
+		// dropped.
+		try {
+			pendingContextMessages = convertToLlm(event.messages) as LlmMessage[];
+		} catch {
+			pendingContextMessages = [];
+		}
 	});
 
 	// ------------------------------------------------------------------

--- a/ddapm_test_agent/pi_lapdog_extension.ts
+++ b/ddapm_test_agent/pi_lapdog_extension.ts
@@ -41,6 +41,28 @@ function post(event: string, sessionId: string, data: Record<string, unknown>): 
 // Extension
 // ---------------------------------------------------------------------------
 
+// Pi message types — copied from pi-coding-agent docs/session.md so we can
+// inspect them in the `context` hook without depending on the SDK's exports.
+type TextContent = { type: "text"; text: string };
+type ImageContent = { type: "image"; data: string; mimeType: string };
+type ThinkingContent = { type: "thinking"; thinking: string };
+type ToolCall = { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> };
+
+type PiMessage =
+	| { role: "user"; content: string | (TextContent | ImageContent)[] }
+	| {
+			role: "assistant";
+			content: (TextContent | ThinkingContent | ToolCall)[];
+		}
+	| {
+			role: "toolResult";
+			toolCallId: string;
+			toolName: string;
+			content: (TextContent | ImageContent)[];
+			isError?: boolean;
+		}
+	| { role: string; [k: string]: unknown };
+
 export default function lapdog(pi: ExtensionAPI): void {
 	let sessionId = "";
 	let currentModel = "";
@@ -49,6 +71,17 @@ export default function lapdog(pi: ExtensionAPI): void {
 	// Track the user prompt that started the current agent run so we can
 	// attach it to the agent_start event (input event fires before agent_start).
 	let pendingUserPrompt = "";
+
+	// System prompt for the current turn, captured in before_agent_start.
+	// Reused for every LLM call inside the turn so each LLM span can record
+	// the system message as part of its input.
+	let currentSystemPrompt = "";
+
+	// Most recent message list seen in `context`. The `context` event fires
+	// right before each LLM call and gives us the full conversation that's
+	// about to be sent to the model — exactly what we want to attach as
+	// `input.messages` on the LLM span.
+	let pendingContextMessages: PiMessage[] = [];
 
 	// ------------------------------------------------------------------
 	// Session lifecycle
@@ -97,12 +130,25 @@ export default function lapdog(pi: ExtensionAPI): void {
 		pendingUserPrompt = event.text;
 	});
 
+	pi.on("before_agent_start", (_event, ctx) => {
+		// Capture the resolved system prompt for this turn so we can attach
+		// it to every LLM span in the turn. `event.systemPrompt` reflects the
+		// chained prompt as of this handler; ctx.getSystemPrompt() is the
+		// same value and works as a fallback.
+		try {
+			currentSystemPrompt = _event?.systemPrompt ?? ctx.getSystemPrompt() ?? "";
+		} catch {
+			currentSystemPrompt = "";
+		}
+	});
+
 	pi.on("agent_start", () => {
 		post("agent_start", sessionId, {
 			user_prompt: pendingUserPrompt,
 			model: `${currentProvider}/${currentModel}`,
 			model_provider: currentProvider,
 			model_id: currentModel,
+			system_prompt: currentSystemPrompt,
 		});
 		pendingUserPrompt = "";
 	});
@@ -131,6 +177,17 @@ export default function lapdog(pi: ExtensionAPI): void {
 	});
 
 	// ------------------------------------------------------------------
+	// Pre-LLM context (fires before each LLM call)
+	// ------------------------------------------------------------------
+
+	pi.on("context", (event) => {
+		// `event.messages` is a safe-to-modify deep copy of the conversation
+		// about to be sent to the LLM. Stash it so the next assistant
+		// message_start can include it as the LLM span's input.
+		pendingContextMessages = (event.messages as PiMessage[]) ?? [];
+	});
+
+	// ------------------------------------------------------------------
 	// LLM message lifecycle (creates LLM spans)
 	// ------------------------------------------------------------------
 
@@ -138,6 +195,10 @@ export default function lapdog(pi: ExtensionAPI): void {
 		if (event.message.role !== "assistant") return;
 		post("message_start", sessionId, {
 			message_role: "assistant",
+			system_prompt: currentSystemPrompt,
+			// Snapshot of the conversation that will be sent to the model for
+			// this LLM call. Used to populate input.messages on the LLM span.
+			messages: pendingContextMessages,
 		});
 	});
 

--- a/releasenotes/notes/pi-llm-input-messages-1bf8e5a0e7aba7b6.yaml
+++ b/releasenotes/notes/pi-llm-input-messages-1bf8e5a0e7aba7b6.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Pi hooks LLM spans now include ``input.messages`` with the system prompt
+    and full conversation (user, assistant, and toolResult messages) sent to
+    the model. The pi lapdog extension captures the system prompt from
+    ``before_agent_start`` and snapshots the messages array from each
+    ``context`` event, forwarding both with ``message_start``.

--- a/releasenotes/notes/pi-llm-input-messages-1bf8e5a0e7aba7b6.yaml
+++ b/releasenotes/notes/pi-llm-input-messages-1bf8e5a0e7aba7b6.yaml
@@ -1,8 +1,10 @@
 ---
-features:
+fixes:
   - |
-    Pi hooks LLM spans now include ``input.messages`` with the system prompt
-    and full conversation (user, assistant, and toolResult messages) sent to
-    the model. The pi lapdog extension captures the system prompt from
+    Pi hooks LLM spans previously had an empty ``input.messages`` list,
+    losing the user prompt and never recording the system prompt. The pi
+    lapdog extension now captures the system prompt from
     ``before_agent_start`` and snapshots the messages array from each
-    ``context`` event, forwarding both with ``message_start``.
+    ``context`` event, forwarding both with ``message_start`` so each LLM
+    span records the system, user, assistant, and toolResult messages
+    sent to the model.

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -62,8 +62,14 @@ def _turn_end(session_id=SESSION, turn_index=0):
     return {"session_id": session_id, "hook_event_name": "turn_end", "turn_index": turn_index}
 
 
-def _message_start(session_id=SESSION):
-    return {"session_id": session_id, "hook_event_name": "message_start", "message_role": "assistant"}
+def _message_start(session_id=SESSION, system_prompt="", messages=None):
+    return {
+        "session_id": session_id,
+        "hook_event_name": "message_start",
+        "message_role": "assistant",
+        "system_prompt": system_prompt,
+        "messages": messages or [],
+    }
 
 
 def _message_end(session_id=SESSION, content=None, usage=None, stop_reason="end_turn"):
@@ -460,6 +466,143 @@ async def test_second_agent_cycle_resets_step_index(agent):
     # Both cycles should have inference-0
     assert len(steps) == 2
     assert all(s["name"] == "inference-0" for s in steps)
+
+
+async def test_llm_input_messages_include_system_and_user(agent):
+    """LLM span input.messages includes the system prompt and user messages."""
+    sid = "pi-llm-input"
+    system_prompt = "You are a helpful assistant."
+    convo = [
+        {"role": "user", "content": "What is 2 + 2?"},
+    ]
+
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid, turn_index=0))
+    await _post(agent, _message_start(sid, system_prompt=system_prompt, messages=convo))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid, turn_index=0))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    llms = _by_kind(session_spans, "llm")
+    assert len(llms) == 1
+    input_messages = llms[0]["meta"]["input"]["messages"]
+
+    assert input_messages[0] == {"role": "system", "content": system_prompt}
+    assert input_messages[1] == {"role": "user", "content": "What is 2 + 2?"}
+
+
+async def test_llm_input_messages_handle_user_content_blocks(agent):
+    """User messages with TextContent[] are flattened to a single string."""
+    sid = "pi-llm-input-blocks"
+    convo = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Look at this:"},
+                {"type": "image", "data": "...", "mimeType": "image/png"},
+                {"type": "text", "text": "What do you see?"},
+            ],
+        },
+    ]
+
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid, system_prompt="sys", messages=convo))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    llm = _by_kind(session_spans, "llm")[0]
+    user_msg = llm["meta"]["input"]["messages"][1]
+    assert user_msg["role"] == "user"
+    assert "Look at this:" in user_msg["content"]
+    assert "[image]" in user_msg["content"]
+    assert "What do you see?" in user_msg["content"]
+
+
+async def test_llm_input_messages_include_assistant_and_tool_results(agent):
+    """Assistant tool_calls and toolResult messages are mapped to LLMObs format."""
+    sid = "pi-llm-input-tools"
+    # Second LLM call in a turn — conversation now contains the previous
+    # assistant tool call and its toolResult.
+    convo = [
+        {"role": "user", "content": "read foo.py"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Reading..."},
+                {"type": "toolCall", "id": "tc-1", "name": "read", "arguments": {"path": "foo.py"}},
+            ],
+        },
+        {
+            "role": "toolResult",
+            "toolCallId": "tc-1",
+            "toolName": "read",
+            "content": [{"type": "text", "text": "print('hi')"}],
+            "isError": False,
+        },
+    ]
+
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid, system_prompt="sys", messages=convo))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    llm = _by_kind(session_spans, "llm")[0]
+    msgs = llm["meta"]["input"]["messages"]
+    # [system, user, assistant, tool]
+    assert [m["role"] for m in msgs] == ["system", "user", "assistant", "tool"]
+    assistant_msg = msgs[2]
+    assert assistant_msg["content"] == "Reading..."
+    assert assistant_msg["tool_calls"] == [
+        {
+            "name": "read",
+            "arguments": {"path": "foo.py"},
+            "tool_id": "tc-1",
+            "type": "tool_use",
+        }
+    ]
+    tool_msg = msgs[3]
+    assert tool_msg == {"role": "tool", "content": "print('hi')", "tool_id": "tc-1"}
+
+
+async def test_llm_input_messages_omit_system_when_empty(agent):
+    """No system message is emitted when system_prompt is empty."""
+    sid = "pi-llm-no-sys"
+    convo = [{"role": "user", "content": "hi"}]
+
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid, system_prompt="", messages=convo))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    llm = _by_kind(session_spans, "llm")[0]
+    msgs = llm["meta"]["input"]["messages"]
+    assert [m["role"] for m in msgs] == ["user"]
 
 
 async def test_thinking_block_sets_has_thinking(agent):


### PR DESCRIPTION
## Problem

Pi LLM spans were emitted with a hardcoded empty `input.messages` list, which meant:
- the user prompt for each LLM call was lost
- the system prompt was never recorded at all

## Fix

### Extension (`pi_lapdog_extension.ts`)
- New `before_agent_start` listener — captures the resolved system prompt for the turn (`event.systemPrompt` / `ctx.getSystemPrompt()`).
- New `context` listener — snapshots the deep-copy `messages` array. `context` fires before every LLM call and gives us the exact conversation about to be sent to the model.
- `message_start` (assistant) now forwards `system_prompt` and `messages` alongside the existing fields.
- `agent_start` also forwards `system_prompt` for completeness.

### Python handler (`pi_hooks.py`)
- New `_pi_messages_to_llmobs_input(system_prompt, messages)` converts pi's message format to LLMObs `input.messages`:
  - prepends `{role: "system"}` when the system prompt is non-empty
  - `user` → `{role: "user", content}`
  - `assistant` → `{role: "assistant", content, tool_calls: [...]}` (matches the shape used by `claude_proxy.py`)
  - `toolResult` → `{role: "tool", content, tool_id}`
  - extended pi message types (`bashExecution`, `custom`, `branchSummary`, `compactionSummary`) are skipped — they aren't sent to the LLM as standalone messages
- New `_pi_content_to_text` helper flattens `(TextContent | ImageContent | ThinkingContent)[]` to a string with `[image]` / `[thinking]` placeholders so nothing is silently dropped.
- `PendingLLMSpan` now carries `input_messages`; populated in `_handle_message_start`, written to `meta.input.messages` in `_handle_message_end`. Fallback path (no preceding `message_start`) reads from the `message_end` body.

## Tests

4 new cases in `tests/test_pi_hooks.py`:
- `test_llm_input_messages_include_system_and_user` — system + user round-trip
- `test_llm_input_messages_handle_user_content_blocks` — user `TextContent[]` with an embedded image flattens correctly
- `test_llm_input_messages_include_assistant_and_tool_results` — assistant `tool_calls` + `toolResult` mapped to LLMObs format
- `test_llm_input_messages_omit_system_when_empty` — empty `system_prompt` omits the system message

All 16 pi hook tests pass; `black` + `flake8` clean.

## Release note

`releasenotes/notes/pi-llm-input-messages-1bf8e5a0e7aba7b6.yaml`