### PR TITLE
feat(lapdog): add support for cost tracking `opus-4-7` with Claude Code

### DIFF
--- a/ddapm_test_agent/claude_cost_tracker.py
+++ b/ddapm_test_agent/claude_cost_tracker.py
@@ -11,8 +11,18 @@ and the metric keys expected by the web-ui LLM observability span detail view:
     estimated_cache_write_input_cost
     estimated_cache_read_input_cost
 
-Pricing data last updated 2025-10 based on Anthropic public pricing and
-dd-go/domains/ml-observability/libs/costtracker/model_prices.go.
+Pricing data last updated 2025-11 based on:
+  * Anthropic public pricing: https://www.anthropic.com/pricing#api
+  * pi-ai models.generated.js (the data Claude Code itself uses to compute
+    the self-reported per-turn cost shown in its UI):
+    @mariozechner/pi-ai/dist/models.generated.js
+  * dd-go/domains/ml-observability/libs/costtracker/model_prices.go
+
+Note: Anthropic significantly reduced Opus prices starting with Opus 4.5
+(Nov 2025).  Opus 4.5 / 4.6 / 4.7 cost $5 / $25 / $0.50 / $6.25 per Mtok,
+whereas Opus 4 / 4.1 / 3 still cost $15 / $75 / $1.50 / $18.75 per Mtok.
+Using the old Opus rates for 4.5+ overcharges by exactly 3x.
+
 Only the popular models used with Claude Code are included.
 """
 
@@ -44,8 +54,14 @@ class _PriceTier:
 # "claude-opus-4-6-20250514", are matched by iterating these prefixes in
 # order from most- to least-specific.
 #
-# Pricing source: dd-go costtracker model_prices.go (updated 2025-10-21) and
-# Anthropic public pricing pages.  All costs are nanodollars / token.
+# Pricing sources (see module docstring):
+#   * Anthropic public pricing: https://www.anthropic.com/pricing#api
+#   * pi-ai @mariozechner/pi-ai models.generated.js (matches what Claude Code
+#     reports as its own per-turn cost)
+#   * dd-go costtracker model_prices.go
+# All costs are nanodollars / token (1 nanodollar = 1e-9 USD).
+# Per-Mtok USD pricing translates directly: $1/Mtok = 1_000 nano/token,
+# $5/Mtok = 5_000 nano/token, $15/Mtok = 15_000 nano/token, etc.
 # ---------------------------------------------------------------------------
 
 # Keys added by the local cost tracker that must be stripped before forwarding
@@ -65,13 +81,35 @@ COST_METRIC_KEYS: FrozenSet[str] = frozenset(
 _ONE_TIER = 0  # sentinel: no upper bound on a single tier
 
 _PRICING: List[Tuple[str, List[_PriceTier]]] = [
-    # ---- Opus ---------------------------------------------------------------
-    # claude-opus-4-6 / claude-opus-4.6  (latest)
+    # ---- Opus 4.5+ (reduced pricing, Nov 2025) ------------------------------
+    # $5 / $25 / $0.50 cache-read / $6.25 cache-write per Mtok.
+    # Source: Anthropic pricing page; pi-ai models.generated.js entries
+    # "anthropic.claude-opus-4-5-...", "...claude-opus-4-6-v1", "...claude-opus-4-7".
+    #
+    # claude-opus-4-7 / claude-opus-4.7  (latest)
+    (
+        "claude-opus-4-7",
+        [_PriceTier(0, _ONE_TIER, 5_000, 6_250, 500, 25_000)],
+    ),
+    # claude-opus-4-6 / claude-opus-4.6
     (
         "claude-opus-4-6",
+        [_PriceTier(0, _ONE_TIER, 5_000, 6_250, 500, 25_000)],
+    ),
+    # claude-opus-4-5 / claude-opus-4.5
+    (
+        "claude-opus-4-5",
+        [_PriceTier(0, _ONE_TIER, 5_000, 6_250, 500, 25_000)],
+    ),
+    # ---- Opus 4 / 4.1 / 3 (legacy higher pricing) ---------------------------
+    # $15 / $75 / $1.50 cache-read / $18.75 cache-write per Mtok.
+    #
+    # claude-opus-4-1 / claude-opus-4.1  (must come before "claude-opus-4")
+    (
+        "claude-opus-4-1",
         [_PriceTier(0, _ONE_TIER, 15_000, 18_750, 1_500, 75_000)],
     ),
-    # claude-opus-4 / claude-opus-4.5  (same unit prices as 4-6)
+    # claude-opus-4  (base 4.0)
     (
         "claude-opus-4",
         [_PriceTier(0, _ONE_TIER, 15_000, 18_750, 1_500, 75_000)],

--- a/releasenotes/notes/fix-opus-4-5-plus-pricing-21702ad058972846.yaml
+++ b/releasenotes/notes/fix-opus-4-5-plus-pricing-21702ad058972846.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fix Claude Code cost tracking to use the reduced Anthropic
+    pricing for Claude Opus 4.5 / 4.6 / 4.7 ($5 / $25 / $0.50 cache-read /
+    $6.25 cache-write per Mtok).  Previously these models were priced at the
+    legacy Opus 4 rates, overestimating cost by exactly 3x.  Opus 4 / 4.1 / 3
+    continue to use the legacy higher rates, and an explicit ``claude-opus-4-5``
+    entry has been added so it no longer falls through to the ``claude-opus-4``
+    prefix.
+features:
+  - |
+    Add ``claude-opus-4-7`` and ``claude-opus-4-1`` to the cost tracking table.

--- a/tests/test_claude_cost_tracker.py
+++ b/tests/test_claude_cost_tracker.py
@@ -33,33 +33,34 @@ class TestModelLookup:
 class TestCostCalculation:
     """Correctness of the nanodollar arithmetic for each cost type."""
 
-    # claude-opus-4-6: input=15000, cache_write=18750, cache_read=1500, output=75000
+    # Opus 4.5+ (4-5 / 4-6 / 4-7): input=5000, cache_write=6250, cache_read=500, output=25000
+    # Opus 4 / 4.1 / 3: input=15000, cache_write=18750, cache_read=1500, output=75000
 
     def test_non_cached_input_cost(self) -> None:
         result = compute_cost_metrics("claude-opus-4-6", non_cached_input_tokens=100, cache_write_tokens=0, cache_read_tokens=0, output_tokens=0)
         assert result is not None
-        assert result["estimated_non_cached_input_cost"] == 100 * 15_000
+        assert result["estimated_non_cached_input_cost"] == 100 * 5_000
         assert result["estimated_cache_write_input_cost"] == 0
         assert result["estimated_cache_read_input_cost"] == 0
         assert result["estimated_output_cost"] == 0
-        assert result["estimated_input_cost"] == 100 * 15_000
-        assert result["estimated_total_cost"] == 100 * 15_000
+        assert result["estimated_input_cost"] == 100 * 5_000
+        assert result["estimated_total_cost"] == 100 * 5_000
 
     def test_cache_write_cost(self) -> None:
         result = compute_cost_metrics("claude-opus-4-6", non_cached_input_tokens=0, cache_write_tokens=200, cache_read_tokens=0, output_tokens=0)
         assert result is not None
-        assert result["estimated_cache_write_input_cost"] == 200 * 18_750
+        assert result["estimated_cache_write_input_cost"] == 200 * 6_250
         assert result["estimated_non_cached_input_cost"] == 0
 
     def test_cache_read_cost(self) -> None:
         result = compute_cost_metrics("claude-opus-4-6", non_cached_input_tokens=0, cache_write_tokens=0, cache_read_tokens=500, output_tokens=0)
         assert result is not None
-        assert result["estimated_cache_read_input_cost"] == 500 * 1_500
+        assert result["estimated_cache_read_input_cost"] == 500 * 500
 
     def test_output_cost(self) -> None:
         result = compute_cost_metrics("claude-opus-4-6", non_cached_input_tokens=0, cache_write_tokens=0, cache_read_tokens=0, output_tokens=50)
         assert result is not None
-        assert result["estimated_output_cost"] == 50 * 75_000
+        assert result["estimated_output_cost"] == 50 * 25_000
 
     def test_all_token_types_combined(self) -> None:
         result = compute_cost_metrics(
@@ -70,11 +71,31 @@ class TestCostCalculation:
             output_tokens=50,
         )
         assert result is not None
-        expected_input = 100 * 15_000 + 200 * 18_750 + 500 * 1_500
-        expected_output = 50 * 75_000
+        expected_input = 100 * 5_000 + 200 * 6_250 + 500 * 500
+        expected_output = 50 * 25_000
         assert result["estimated_input_cost"] == expected_input
         assert result["estimated_output_cost"] == expected_output
         assert result["estimated_total_cost"] == expected_input + expected_output
+
+    def test_legacy_opus_4_pricing(self) -> None:
+        # claude-opus-4 (base 4.0) and claude-opus-4-1 keep the older higher rates.
+        for model in ("claude-opus-4", "claude-opus-4-20250514", "claude-opus-4-1", "claude-opus-4-1-20250805"):
+            result = compute_cost_metrics(model, 100, 200, 500, 50)
+            assert result is not None, model
+            assert result["estimated_non_cached_input_cost"] == 100 * 15_000, model
+            assert result["estimated_cache_write_input_cost"] == 200 * 18_750, model
+            assert result["estimated_cache_read_input_cost"] == 500 * 1_500, model
+            assert result["estimated_output_cost"] == 50 * 75_000, model
+
+    def test_opus_share_reduced_pricing(self) -> None:
+        # Opus 4.5 / 4.6 / 4.7 all use the post-Nov-2025 reduced rates.
+        for model in ("claude-opus-4-5", "claude-opus-4-6", "claude-opus-4-7"):
+            result = compute_cost_metrics(model, 100, 200, 500, 50)
+            assert result is not None, model
+            assert result["estimated_non_cached_input_cost"] == 100 * 5_000, model
+            assert result["estimated_cache_write_input_cost"] == 200 * 6_250, model
+            assert result["estimated_cache_read_input_cost"] == 500 * 500, model
+            assert result["estimated_output_cost"] == 50 * 25_000, model
 
     def test_zero_tokens_returns_all_zeros(self) -> None:
         result = compute_cost_metrics("claude-sonnet-4-6", 0, 0, 0, 0)


### PR DESCRIPTION
Adds support for properly cost tracking `ops-4-7` via Claude Code, and addresses a bug in the local cost tracking logic.