### PR TITLE
feat(agent): add authentication field to info endpoint

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -2026,7 +2026,6 @@ def make_app(
     app["dd_site"] = dd_site
     app["dd_api_key"] = dd_api_key
 
-    # if dd_api_key and dd_site and not disable_llmobs_data_forwarding:
     valid_auth = _is_valid_api_key_and_site_combination(dd_api_key, dd_site) if dd_api_key and dd_site else False
     app["authenticated"] = valid_auth
     if not disable_llmobs_data_forwarding and not valid_auth:

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -2027,12 +2027,12 @@ def make_app(
     app["dd_api_key"] = dd_api_key
 
     # if dd_api_key and dd_site and not disable_llmobs_data_forwarding:
-    valid_auth = _is_valid_api_key_and_site_combination(dd_api_key, dd_site)
+    valid_auth = _is_valid_api_key_and_site_combination(dd_api_key, dd_site) if dd_api_key and dd_site else False
     app["authenticated"] = valid_auth
     if not disable_llmobs_data_forwarding and not valid_auth:
         log.warning("Cannot forward LLM Observability data with an invalid DD_API_KEY and DD_SITE, disabling LLM Observability data forwarding.")
         disable_llmobs_data_forwarding = True
-    
+
     app["disable_llmobs_data_forwarding"] = disable_llmobs_data_forwarding
 
     return app

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -2026,12 +2026,13 @@ def make_app(
     app["dd_site"] = dd_site
     app["dd_api_key"] = dd_api_key
 
-    if dd_api_key and dd_site and not disable_llmobs_data_forwarding:
-        valid_auth = _is_valid_api_key_and_site_combination(dd_api_key, dd_site)
-        app["authenticated"] = valid_auth
-        if not valid_auth:
-            log.warning("Cannot forward LLM Observability data with an invalid DD_API_KEY and DD_SITE, disabling LLM Observability data forwarding.")
-            disable_llmobs_data_forwarding = True
+    # if dd_api_key and dd_site and not disable_llmobs_data_forwarding:
+    valid_auth = _is_valid_api_key_and_site_combination(dd_api_key, dd_site)
+    app["authenticated"] = valid_auth
+    if not disable_llmobs_data_forwarding and not valid_auth:
+        log.warning("Cannot forward LLM Observability data with an invalid DD_API_KEY and DD_SITE, disabling LLM Observability data forwarding.")
+        disable_llmobs_data_forwarding = True
+    
     app["disable_llmobs_data_forwarding"] = disable_llmobs_data_forwarding
 
     return app

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -1104,6 +1104,8 @@ class Agent:
                     text="Incorrect DD API key and site combination to update", headers=headers
                 )
 
+            request.app["authenticated"] = True
+
         # Second pass to apply the config
         for key in data:
             request.app[key] = data[key]
@@ -1148,7 +1150,8 @@ class Agent:
                 # Just a random selection of some peer_tags to aggregate on for testing, not exhaustive
                 "peer_tags": ["db.name", "mongodb.db", "messaging.system"],
                 "span_events": True,  # Advertise support for the top-level Span field for Span Events
-                "llmobs_data_forwarding": not request.app["disable_llmobs_data_forwarding"] and request.app["dd_api_key"] and request.app["dd_site"],  # api key and site not empty strings
+                "llmobs_data_forwarding": not request.app["disable_llmobs_data_forwarding"],
+                "authenticated": request.app.get("authenticated", False),
             },
             headers=headers,
         )
@@ -2025,6 +2028,7 @@ def make_app(
 
     if dd_api_key and dd_site and not disable_llmobs_data_forwarding:
         valid_auth = _is_valid_api_key_and_site_combination(dd_api_key, dd_site)
+        app["authenticated"] = valid_auth
         if not valid_auth:
             log.warning("Cannot forward LLM Observability data with an invalid DD_API_KEY and DD_SITE, disabling LLM Observability data forwarding.")
             disable_llmobs_data_forwarding = True

--- a/releasenotes/notes/test-agent-authenticated-signal-e7509497c9dfc4c2.yaml
+++ b/releasenotes/notes/test-agent-authenticated-signal-e7509497c9dfc4c2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds an ``authenticated`` field to the ``/info`` endpoint that is ``true`` if the test agent is configured with a valid Datadog API key and site.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -151,6 +151,7 @@ async def test_info(agent):
         "client_drop_p0s": True,
         "span_events": True,
         "llmobs_data_forwarding": False,
+        "authenticated": False,
     }
 
 


### PR DESCRIPTION
Adds an `authenticated` field to the `/info` that returns whether or not a valid `dd_api_key` and `dd_site` are present when running the agent. Has no impact on existing usage and just exposes the `_is_valid_api_key_and_site_combination` check we were already doing.