### PR TITLE
context breakdown fixes

### DIFF
--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -44,6 +44,7 @@ _ML_APP = os.environ.get("DD_CLAUDE_CODE_ML_APP", "claude-code")
 # All other models default to 200k.
 _1M_CONTEXT_MODELS = {
     "claude-opus-4-6",
+    "claude-opus-4-7",
     "claude-sonnet-4-6",
 }
 

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -1250,18 +1250,29 @@ class ClaudeHooksAPI:
     ) -> Optional[Dict[str, Any]]:
         """Return context delta for an agent span.
 
-        parent_span_id: only consider LLM spans whose parent is this span.
+        parent_span_id: agent span_id. Considers LLM spans parented directly
+        under this agent, and LLM spans parented under a step span whose
+        parent is this agent (instrumented sessions interpose step spans
+        between agent and LLM).
         first_input_tokens: context size at the beginning of this span.
         - Root agent: session.last_known_input_tokens (persists across turns)
         - Subagent:   0 (each subagent has its own fresh context window)
         """
+        step_span_ids = {
+            s.get("span_id")
+            for s in self._assembled_spans
+            if s.get("trace_id") == trace_id
+            and s.get("meta", {}).get("span", {}).get("kind") == "step"
+            and s.get("parent_id") == parent_span_id
+        }
+        llm_parent_ids = step_span_ids | {parent_span_id}
         llm_spans = sorted(
             [
                 s
                 for s in self._assembled_spans
                 if s.get("trace_id") == trace_id
                 and s.get("meta", {}).get("span", {}).get("kind") == "llm"
-                and s.get("parent_id") == parent_span_id
+                and s.get("parent_id") in llm_parent_ids
             ],
             key=lambda s: s.get("start_ns", 0),
         )

--- a/releasenotes/notes/claude-opus-4-7-1m-context-and-context-delta-fix-fd7068123a681c62.yaml
+++ b/releasenotes/notes/claude-opus-4-7-1m-context-and-context-delta-fix-fd7068123a681c62.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Add ``claude-opus-4-7`` to the set of models recognized as having a 1M
+    token context window.
+fixes:
+  - |
+    claude hooks: ``context_delta`` is now correctly reported on agent spans
+    in instrumented Claude Code sessions that nest llm spans within step spans.

--- a/tests/test_claude_steps.py
+++ b/tests/test_claude_steps.py
@@ -718,3 +718,32 @@ def test_subagent_posttool_race_reparents_under_step():
             f"{tool['name']} parented to {tool['parent_id']!r}, "
             f"expected sub-agent step {sub_step['span_id']!r}"
         )
+
+
+def test_context_delta_attached_to_root_agent_through_step():
+    """Root agent span carries ``context_delta`` aggregated from LLM spans
+    that sit under its step children. Instrumented sessions interpose a
+    ``step`` span between agent and llm, so the lookup must traverse it."""
+    sid = "sess-context-delta-step"
+    hooks_api, proxy_api, _ = _make_apis()
+
+    hooks_api._dispatch_hook(_session_start(sid))
+    hooks_api._dispatch_hook(_user_prompt(sid))
+
+    llm_span = _simulate_llm_call(
+        proxy_api,
+        sid,
+        _response(text="Hello!", stop_reason="end_turn"),
+    )
+    hooks_api._dispatch_hook(_stop(sid))
+
+    spans = _spans_for_session(hooks_api, sid)
+    root = _find_root(spans)
+    step = _by_kind(spans, "step")[0]
+
+    assert llm_span["parent_id"] == step["span_id"]
+    assert step["parent_id"] == root["span_id"]
+
+    context_delta = root.get("meta", {}).get("metadata", {}).get("_dd", {}).get("context_delta")
+    assert context_delta is not None, "context_delta missing on root agent span"
+    assert context_delta["last_input_tokens"] == 100

--- a/tests/test_claude_steps.py
+++ b/tests/test_claude_steps.py
@@ -723,7 +723,8 @@ def test_subagent_posttool_race_reparents_under_step():
 def test_context_delta_attached_to_root_agent_through_step():
     """Root agent span carries ``context_delta`` aggregated from LLM spans
     that sit under its step children. Instrumented sessions interpose a
-    ``step`` span between agent and llm, so the lookup must traverse it."""
+    ``step`` span between agent and llm, so the lookup must traverse it.
+    """
     sid = "sess-context-delta-step"
     hooks_api, proxy_api, _ = _make_apis()
 


### PR DESCRIPTION
This PR:
- Adds opus 4.7 to list of models with 1m token context window
- Updates the logic for finding llm spans belonging to an agent turn (this broke when we started nesting llm spans within step spans)