### PR TITLE
fix(lapdog): properly prioritize which `ddtrace` dependency to use for instrumenting any app with `lapdog`

### DIFF
--- a/lapdog/bootstrap/sitecustomize.py
+++ b/lapdog/bootstrap/sitecustomize.py
@@ -1,0 +1,37 @@
+"""
+Lapdog bootstrap: loaded via PYTHONPATH to instrument Python processes with ddtrace.
+Runs as sitecustomize before any user code. Exits cleanly if ddtrace is unavailable.
+"""
+import os
+import sys
+
+try:
+    import ddtrace  # noqa: F401
+except ImportError:
+    # Fall back to lapdog's own ddtrace if one was provided and is ABI-compatible.
+    _lapdog_sp = os.environ.get("_LAPDOG_DDTRACE_SITE_PACKAGES")
+    if _lapdog_sp:
+        sys.path.insert(0, _lapdog_sp)
+        try:
+            import ddtrace  # noqa: F401
+        except ImportError:
+            _lapdog_ver = os.environ.get("_LAPDOG_PYTHON_VERSION", "unknown")
+            _target_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
+            print(
+                f"[lapdog] Python version mismatch: lapdog uses Python {_lapdog_ver} "
+                f"but this process is Python {_target_ver}.\n"
+                "[lapdog] Install ddtrace in your app's Python environment:\n"
+                "[lapdog]   pip install ddtrace",
+                file=sys.stderr,
+            )
+            os._exit(1)
+    else:
+        print(
+            "[lapdog] ddtrace is not installed.\n"
+            "[lapdog] Install it in your app's Python environment:\n"
+            "[lapdog]   pip install ddtrace",
+            file=sys.stderr,
+        )
+        os._exit(1)
+
+import ddtrace.auto  # noqa: F401

--- a/lapdog/bootstrap/sitecustomize.py
+++ b/lapdog/bootstrap/sitecustomize.py
@@ -17,21 +17,19 @@ except ImportError:
         except ImportError:
             _lapdog_ver = os.environ.get("_LAPDOG_PYTHON_VERSION", "unknown")
             _target_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
-            print(
+            os.write(2, (
                 f"[lapdog] Python version mismatch: lapdog uses Python {_lapdog_ver} "
                 f"but this process is Python {_target_ver}.\n"
                 "[lapdog] Install ddtrace in your app's Python environment:\n"
-                "[lapdog]   pip install ddtrace",
-                file=sys.stderr,
-            )
+                "[lapdog]   pip install ddtrace\n"
+            ).encode())
             os._exit(1)
     else:
-        print(
+        os.write(2, (
             "[lapdog] ddtrace is not installed.\n"
             "[lapdog] Install it in your app's Python environment:\n"
-            "[lapdog]   pip install ddtrace",
-            file=sys.stderr,
-        )
+            "[lapdog]   pip install ddtrace\n"
+        ).encode())
         os._exit(1)
 
 import ddtrace.auto  # noqa: F401

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -297,6 +297,11 @@ def _start_lapdog_detached(port: int, forward_data: bool) -> None:
 
 def cmd_exec(app_cmd: List[str], forward_data: bool, disable_hooks: bool = False) -> None:
     """Auto-start lapdog if needed, inject tracer env vars, then exec the app command. Never returns."""
+    resolved = shutil.which(app_cmd[0])
+    if not resolved:
+        print(f"[lapdog] Command not found: {app_cmd[0]}", file=sys.stderr)
+        sys.exit(1)
+
     _ensure_lapdog_running(forward_data)
     print(build_running_banner(data_type="application"))
 
@@ -306,12 +311,6 @@ def cmd_exec(app_cmd: List[str], forward_data: bool, disable_hooks: bool = False
         sys.exit(1)
 
     env = tracer_inject.build_instrumented_env(port=port)
-
-    resolved = shutil.which(app_cmd[0])
-    if not resolved:
-        print(f"[lapdog] Command not found: {app_cmd[0]}", file=sys.stderr)
-        sys.exit(1)
-
     os.execvpe(resolved, app_cmd, env)
 
 

--- a/lapdog/tracer_inject.py
+++ b/lapdog/tracer_inject.py
@@ -6,24 +6,22 @@ from typing import Dict
 from typing import Optional
 
 
-def _ddtrace_bootstrap_path() -> Optional[str]:
-    """Return the ddtrace sitecustomize bootstrap directory, or None if ddtrace is not installed."""
+def _lapdog_bootstrap_dir() -> str:
+    return os.path.join(os.path.dirname(__file__), "bootstrap")
+
+
+def _lapdog_ddtrace_site_packages() -> Optional[str]:
+    """Return the site-packages dir containing lapdog's own ddtrace, or None if not installed."""
     spec = importlib.util.find_spec("ddtrace")
     if spec is None or spec.origin is None:
         return None
-    bootstrap = os.path.join(os.path.dirname(spec.origin), "bootstrap")
-    return bootstrap if os.path.isdir(bootstrap) else None
+    return os.path.dirname(os.path.dirname(spec.origin))
 
 
-def _ddtrace_install_command() -> str:
-    """Return the right pip install command for the current install method."""
-    # check for homebrew install
-    if "/Cellar/lapdog/" in sys.executable:
-        return "/opt/homebrew/opt/lapdog/libexec/bin/python -m pip install ddtrace"
-    return "pip install 'ddapm-test-agent[ddtrace]'"
-
-
-def build_instrumented_env(port: int, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+def build_instrumented_env(
+    port: int,
+    base_env: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
     """Return a copy of base_env with tracer env vars injected for Python processes."""
     env = dict(base_env if base_env is not None else os.environ)
 
@@ -33,15 +31,13 @@ def build_instrumented_env(port: int, base_env: Optional[Dict[str, str]] = None)
     env["DD_LLMOBS_ENABLED"] = "true"
     env["DD_LLMOBS_AGENTLESS_ENABLED"] = "false"
 
-    bootstrap = _ddtrace_bootstrap_path()
-    if bootstrap:
-        existing = env.get("PYTHONPATH", "")
-        env["PYTHONPATH"] = f"{bootstrap}{os.pathsep}{existing}" if existing else bootstrap
-    else:
-        print(
-            "[lapdog] ddtrace not installed; Python processes will not be traced. "
-            f"Install with: {_ddtrace_install_command()}",
-            file=sys.stderr,
-        )
+    bootstrap = _lapdog_bootstrap_dir()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{bootstrap}{os.pathsep}{existing}" if existing else bootstrap
+
+    lapdog_sp = _lapdog_ddtrace_site_packages()
+    if lapdog_sp:
+        env["_LAPDOG_DDTRACE_SITE_PACKAGES"] = lapdog_sp
+        env["_LAPDOG_PYTHON_VERSION"] = f"{sys.version_info.major}.{sys.version_info.minor}"
 
     return env

--- a/releasenotes/notes/lapdog-can-instrument-app-python-fix-a88e62e6ee46b41e.yaml
+++ b/releasenotes/notes/lapdog-can-instrument-app-python-fix-a88e62e6ee46b41e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ``lapdog`` properly prioritizes using a user's ``ddtrace`` dependency before trying its own, and on any issues, logs an instruction to install ``ddtrace``, when using ``lapdog`` to instrument Python applications or processes.

--- a/tests/test_tracer_inject.py
+++ b/tests/test_tracer_inject.py
@@ -87,7 +87,7 @@ class TestSitecustomize:
             [sys.executable, "-c", "print('should not reach')"],
             capture_output=True,
             text=True,
-            env={"PYTHONPATH": f"{BOOTSTRAP_DIR}{os.pathsep}{fake_broken_ddtrace}"},
+            env={**os.environ, "PYTHONPATH": f"{BOOTSTRAP_DIR}{os.pathsep}{fake_broken_ddtrace}"},
         )
         assert result.returncode == 1
         assert "ddtrace is not installed" in result.stderr
@@ -98,6 +98,7 @@ class TestSitecustomize:
             capture_output=True,
             text=True,
             env={
+                **os.environ,
                 "PYTHONPATH": f"{BOOTSTRAP_DIR}{os.pathsep}{fake_broken_ddtrace}",
                 "_LAPDOG_DDTRACE_SITE_PACKAGES": "/nonexistent/site-packages",
                 "_LAPDOG_PYTHON_VERSION": "3.99",

--- a/tests/test_tracer_inject.py
+++ b/tests/test_tracer_inject.py
@@ -1,0 +1,106 @@
+"""Tests for lapdog.tracer_inject and lapdog/bootstrap/sitecustomize.py."""
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from lapdog import tracer_inject
+
+
+BOOTSTRAP_DIR = str(Path(tracer_inject.__file__).parent / "bootstrap")
+
+
+class TestBuildInstrumentedEnv:
+    def test_sets_dd_vars(self) -> None:
+        env = tracer_inject.build_instrumented_env(port=8126, base_env={})
+        assert env["DD_TRACE_AGENT_URL"] == "http://127.0.0.1:8126"
+        assert env["DD_TRACE_AGENT_HOST"] == "127.0.0.1"
+        assert env["DD_TRACE_AGENT_PORT"] == "8126"
+        assert env["DD_LLMOBS_ENABLED"] == "true"
+        assert env["DD_LLMOBS_AGENTLESS_ENABLED"] == "false"
+
+    def test_injects_bootstrap_pythonpath(self) -> None:
+        env = tracer_inject.build_instrumented_env(port=8126, base_env={})
+        assert env["PYTHONPATH"].startswith(BOOTSTRAP_DIR)
+
+    def test_prepends_to_existing_pythonpath(self) -> None:
+        env = tracer_inject.build_instrumented_env(port=8126, base_env={"PYTHONPATH": "/existing"})
+        parts = env["PYTHONPATH"].split(os.pathsep)
+        assert parts[0] == BOOTSTRAP_DIR
+        assert "/existing" in parts
+
+    def test_sets_lapdog_site_packages_when_ddtrace_installed(self) -> None:
+        fake_sp = "/fake/site-packages"
+        with mock.patch("lapdog.tracer_inject._lapdog_ddtrace_site_packages", return_value=fake_sp):
+            env = tracer_inject.build_instrumented_env(port=8126, base_env={})
+        assert env["_LAPDOG_DDTRACE_SITE_PACKAGES"] == fake_sp
+
+    def test_sets_lapdog_python_version_when_ddtrace_installed(self) -> None:
+        expected = f"{sys.version_info.major}.{sys.version_info.minor}"
+        with mock.patch("lapdog.tracer_inject._lapdog_ddtrace_site_packages", return_value="/fake/sp"):
+            env = tracer_inject.build_instrumented_env(port=8126, base_env={})
+        assert env["_LAPDOG_PYTHON_VERSION"] == expected
+
+    def test_no_lapdog_vars_when_ddtrace_not_installed(self) -> None:
+        with mock.patch("lapdog.tracer_inject._lapdog_ddtrace_site_packages", return_value=None):
+            env = tracer_inject.build_instrumented_env(port=8126, base_env={})
+        assert "_LAPDOG_DDTRACE_SITE_PACKAGES" not in env
+        assert "_LAPDOG_PYTHON_VERSION" not in env
+
+    def test_uses_os_environ_as_base_by_default(self) -> None:
+        with mock.patch.dict(os.environ, {"MY_VAR": "hello"}):
+            env = tracer_inject.build_instrumented_env(port=8126)
+        assert env["MY_VAR"] == "hello"
+
+
+class TestSitecustomize:
+    @pytest.fixture()
+    def fake_broken_ddtrace(self, tmp_path: Path) -> str:
+        """Create a directory containing a ddtrace package that raises ImportError on import.
+
+        Placing this directory early in PYTHONPATH shadows the real ddtrace from the
+        venv's site-packages, letting us test the "ddtrace not importable" paths without
+        needing a Python install that lacks ddtrace.
+        """
+        ddtrace_dir = tmp_path / "ddtrace"
+        ddtrace_dir.mkdir()
+        (ddtrace_dir / "__init__.py").write_text("raise ImportError(\"No module named 'ddtrace'\")")
+        return str(tmp_path)
+
+    def test_loads_ddtrace_when_installed(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", "import ddtrace; print('ok')"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONPATH": BOOTSTRAP_DIR},
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ok" in result.stdout
+
+    def test_exits_with_message_when_ddtrace_missing(self, fake_broken_ddtrace: str) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", "print('should not reach')"],
+            capture_output=True,
+            text=True,
+            env={"PYTHONPATH": f"{BOOTSTRAP_DIR}{os.pathsep}{fake_broken_ddtrace}"},
+        )
+        assert result.returncode == 1
+        assert "ddtrace is not installed" in result.stderr
+
+    def test_exits_with_version_mismatch_message_on_abi_error(self, fake_broken_ddtrace: str) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", "print('should not reach')"],
+            capture_output=True,
+            text=True,
+            env={
+                "PYTHONPATH": f"{BOOTSTRAP_DIR}{os.pathsep}{fake_broken_ddtrace}",
+                "_LAPDOG_DDTRACE_SITE_PACKAGES": "/nonexistent/site-packages",
+                "_LAPDOG_PYTHON_VERSION": "3.99",
+            },
+        )
+        assert result.returncode == 1
+        assert "version mismatch" in result.stderr
+        assert "3.99" in result.stderr

--- a/tests/test_tracer_inject.py
+++ b/tests/test_tracer_inject.py
@@ -71,11 +71,13 @@ class TestSitecustomize:
         return str(tmp_path)
 
     def test_loads_ddtrace_when_installed(self) -> None:
+        existing = os.environ.get("PYTHONPATH", "")
+        pythonpath = f"{BOOTSTRAP_DIR}{os.pathsep}{existing}" if existing else BOOTSTRAP_DIR
         result = subprocess.run(
             [sys.executable, "-c", "import ddtrace; print('ok')"],
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": BOOTSTRAP_DIR},
+            env={**os.environ, "PYTHONPATH": pythonpath},
         )
         assert result.returncode == 0, result.stderr
         assert "ok" in result.stdout


### PR DESCRIPTION
Now looks for `ddtrace` in

1. The existing environment (from whatever environment the Python process is run from) dependencies
2. Global lapdog if lapdog was installed from `"ddapm-test-agent[ddtrace]"` and Python versions match

If it is not found or there is a Python version mismatch between the spawned Python process and the global version that installed `lapdog`, we log and gracefully exit.

```
[lapdog] Python version mismatch: lapdog uses Python 3.14 but this process is Python 3.13.
[lapdog] Install ddtrace in your app's Python environment:
[lapdog]   pip install ddtrace
```