### PR TITLE
include sitecustomize

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=["tests*", "releasenotes", "scripts"]),
     package_data={
         "ddapm_test_agent": ["py.typed", "templates/*", "static/*",],
-        "lapdog": ["py.typed", "claude_intercept.mjs", "pi_lapdog_extension.ts"],
+        "lapdog": ["py.typed", "claude_intercept.mjs", "pi_lapdog_extension.ts", "bootstrap/*"],
     },
     python_requires=">=3.8",
     install_requires=[


### PR DESCRIPTION
the sitecustomize file is not included in the most recent version: https://inspector.pypi.io/project/ddapm-test-agent/1.54.0/packages/9b/5f/d6e3ddb1bb0ef9db01b10fd66d13f74a0157b7f1b16051172f64400ee836/ddapm_test_agent-1.54.0-py3-none-any.whl/