### PR TITLE
feat(lapdog): add `uninstall` subcommand for clean teardown

### DIFF
--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -179,66 +179,22 @@ No other state is created. There is no daemon installed at the OS level
 
 ## Uninstallation
 
-### 1. Stop the running agent
+> Package managers (Homebrew, pip, pipx) only remove their own files. They
+> do **not** clean up `~/.lapdog/`, the Claude Code hook entries in
+> `~/.claude/settings.json`, or `~/.pi/agent/extensions/lapdog.ts`. Run
+> `lapdog uninstall` first.
+
+### 1. Run `lapdog uninstall`
 
 ```bash
-lapdog stop
+lapdog uninstall
 ```
 
-If `lapdog stop` reports no PID file but you still see something on port 8126,
-find and kill it manually:
+This stops the background agent, removes `~/.lapdog/`, strips lapdog's hook
+entries from `~/.claude/settings.json` (leaving any other hooks you've
+configured untouched), and deletes `~/.pi/agent/extensions/lapdog.ts`.
 
-```bash
-lsof -ti tcp:8126 | xargs kill
-```
-
-### 2. Remove the Claude Code hooks
-
-`lapdog claude` adds hook entries to `~/.claude/settings.json` so Claude Code
-posts events to `localhost:8126/claude/hooks`. They look like:
-
-```json
-{
-  "type": "command",
-  "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
-  "async": true
-}
-```
-
-You can either delete just the entries that POST to
-`localhost:8126/claude/hooks` (leaving any other hooks you've configured
-alone), or `jq` them out:
-
-```bash
-jq '
-  .hooks |= with_entries(
-    .value |= map(
-      .hooks |= map(select(
-        (.command // "") | contains("localhost:8126/claude/hooks") | not
-      ))
-    )
-  )
-' ~/.claude/settings.json > ~/.claude/settings.json.tmp \
-  && mv ~/.claude/settings.json.tmp ~/.claude/settings.json
-```
-
-The hooks are harmless when the agent is not running (the `curl` returns
-non-zero and the `|| true` swallows it), so removing them is optional unless
-you want a fully clean Claude Code config.
-
-### 3. Remove the Pi extension (only if you used `lapdog pi`)
-
-```bash
-rm -f ~/.pi/agent/extensions/lapdog.ts
-```
-
-### 4. Remove lapdog's working directory
-
-```bash
-rm -rf ~/.lapdog
-```
-
-### 5. Uninstall the package
+### 2. Uninstall the package
 
 Match the install method you used:
 
@@ -258,3 +214,36 @@ docker rmi ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
 ```
 
 After this nothing lapdog wrote remains on the system.
+
+### Manual cleanup (if `lapdog uninstall` isn't available)
+
+If you're on a lapdog build that pre-dates the `uninstall` subcommand, or
+you've already removed the package without running it, do the cleanup by
+hand:
+
+```bash
+# 1. Stop the agent (or kill anything still on port 8126).
+lapdog stop 2>/dev/null || lsof -ti tcp:8126 | xargs -r kill
+
+# 2. Remove ~/.lapdog/.
+rm -rf ~/.lapdog
+
+# 3. Remove the pi extension (only if you used `lapdog pi`).
+rm -f ~/.pi/agent/extensions/lapdog.ts
+
+# 4. Strip the lapdog hook entries from ~/.claude/settings.json.
+jq '
+  .hooks |= with_entries(
+    .value |= map(
+      .hooks |= map(select(
+        (.command // "") | contains("localhost:8126/claude/hooks") | not
+      ))
+    )
+  )
+' ~/.claude/settings.json > ~/.claude/settings.json.tmp \
+  && mv ~/.claude/settings.json.tmp ~/.claude/settings.json
+```
+
+The hook entries are harmless when the agent is not running (the `curl`
+returns non-zero and the `|| true` swallows it), so removing them is
+optional unless you want a fully clean Claude Code config.

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -16,19 +16,21 @@ from lapdog.lapdog_ascii_art import build_running_banner
 
 import requests
 
+from lapdog.hooks import remove_claude_code_hooks
 from lapdog.hooks import write_claude_code_hooks
-from lapdog.paths import LOG_FILE, PID_FILE
+from lapdog.paths import LAPDOG_DIR, LOG_FILE, PID_FILE
 from lapdog import tracer_inject
 
-LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi"]
+LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "uninstall"]
 LAPDOG_USAGE = (
     "Usage: lapdog [OPTIONS] <command> [command-args...]\n"
     "Options must appear before <command>. Arguments after <command> are forwarded.\n"
-    "  start   Start lapdog (background)\n"
-    "  stop    Stop lapdog (started by 'lapdog start' or 'lapdog claude')\n"
-    "  status  Show lapdog status (from /info)\n"
-    "  claude  Start lapdog in background if needed, then launch Claude with intercept\n"
-    "  pi      Start lapdog in background if needed, install extension, then launch pi\n"
+    "  start      Start lapdog (background)\n"
+    "  stop       Stop lapdog (started by 'lapdog start' or 'lapdog claude')\n"
+    "  status     Show lapdog status (from /info)\n"
+    "  claude     Start lapdog in background if needed, then launch Claude with intercept\n"
+    "  pi         Start lapdog in background if needed, install extension, then launch pi\n"
+    "  uninstall  Stop lapdog and remove all state it wrote (~/.lapdog, Claude hooks, pi extension)\n"
     "\n"
     "Any other command is treated as an app to run with tracing instrumentation:\n"
     "  lapdog python app.py\n"
@@ -143,7 +145,9 @@ def _maybe_write_claude_hooks(disable: bool) -> None:
     write_claude_code_hooks(claude_settings_path)
 
 
-def _start_lapdog(port: int, extra_args: Optional[List[str]] = None, forward_data: bool = False) -> Tuple[int, int, str]:
+def _start_lapdog(
+    port: int, extra_args: Optional[List[str]] = None, forward_data: bool = False
+) -> Tuple[int, int, str]:
     """Start lapdog in background with logs to the log file; wait until ready or exit on timeout. Return (process, log_path)."""
     log_path = _log_file_path()
     os.makedirs(os.path.dirname(log_path), exist_ok=True)
@@ -389,11 +393,56 @@ def cmd_pi(sub_cmd_args: List[str], forward_data: bool) -> None:
     _run_pi(args=sub_cmd_args, port=port)
 
 
+def cmd_uninstall() -> None:
+    """Tear down everything lapdog has written outside the package install dir.
+
+    Run this *before* `brew uninstall lapdog` / `pip uninstall ddapm-test-agent`;
+    package managers only remove their own files and have no record of the
+    runtime state lapdog creates in the user's home directory.
+    """
+    # 1. Stop the background agent if it's running.
+    pid, _ = _read_pid_file()
+    if pid is not None:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            print(f"[lapdog] Stopped background agent (pid {pid}).")
+        except ProcessLookupError:
+            pass
+        except OSError as e:
+            print(f"[lapdog] Failed to stop background agent (pid {pid}): {e}", file=sys.stderr)
+    _remove_pid_file()
+
+    # 2. Remove the ~/.lapdog working directory.
+    if os.path.isdir(LAPDOG_DIR):
+        shutil.rmtree(LAPDOG_DIR, ignore_errors=True)
+        print(f"[lapdog] Removed {LAPDOG_DIR}/")
+
+    # 3. Strip lapdog's hook entries from Claude Code settings.
+    claude_settings_path = Path.home() / ".claude" / "settings.json"
+    if claude_settings_path.exists() and remove_claude_code_hooks(claude_settings_path):
+        print(f"[lapdog] Removed lapdog hook entries from {claude_settings_path}.")
+
+    # 4. Remove the pi extension.
+    if os.path.isfile(_PI_EXT_DEST):
+        try:
+            os.remove(_PI_EXT_DEST)
+            print(f"[lapdog] Removed {_PI_EXT_DEST}.")
+        except OSError as e:
+            print(f"[lapdog] Failed to remove {_PI_EXT_DEST}: {e}", file=sys.stderr)
+
+    print(
+        "[lapdog] Cleanup complete. Now uninstall the package:\n"
+        "[lapdog]   brew uninstall lapdog\n"
+        "[lapdog]   pipx uninstall ddapm-test-agent\n"
+        "[lapdog]   pip uninstall ddapm-test-agent"
+    )
+
+
 def _parse_command(cmd_args: List[str]) -> Tuple[List[str], List[str]]:
     lapdog_args: List[str] = []
 
     for arg_idx, arg in enumerate(cmd_args):
-        if not arg.startswith('--'):
+        if not arg.startswith("--"):
             return lapdog_args, cmd_args[arg_idx:]
 
         lapdog_args.append(arg)
@@ -461,3 +510,5 @@ def main() -> None:
         )
     elif sub_cmd == "pi":
         cmd_pi(sub_cmd_args=sub_cmd_args, forward_data=lapdog_parsed_args.forward)
+    elif sub_cmd == "uninstall":
+        cmd_uninstall()

--- a/lapdog/hooks.py
+++ b/lapdog/hooks.py
@@ -61,3 +61,59 @@ def write_claude_code_hooks(claude_settings_path: Path) -> None:
     claude_code_settings["hooks"] = hooks
     with open(claude_settings_path, "w") as claude_settings:
         json.dump(claude_code_settings, claude_settings, indent=2)
+
+
+def remove_claude_code_hooks(claude_settings_path: Path) -> bool:
+    """Inverse of ``write_claude_code_hooks``: strip lapdog's hook entries.
+
+    The canonical ``_CLAUDE_CODE_HOOK`` is removed from every event. If
+    removing it leaves a default ``matcher: ""`` entry with no remaining
+    hooks, that entry is dropped too so the file stays tidy. Any
+    non-lapdog hooks the user has configured are left untouched.
+
+    Returns True if the file was modified (and rewritten), False otherwise
+    (file missing, unparseable, or contained no lapdog hooks).
+    """
+    try:
+        with open(claude_settings_path, "r") as f:
+            settings = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return False
+
+    hooks = settings.get("hooks", None)
+    if not isinstance(hooks, dict):
+        return False
+
+    changed = False
+    for event in _CLAUDE_CODE_EVENTS:
+        matchers = hooks.get(event)
+        if not isinstance(matchers, list):
+            continue
+        new_matchers: List[Dict[str, Any]] = []
+        for matcher in matchers:
+            if not isinstance(matcher, dict):
+                new_matchers.append(matcher)
+                continue
+            matcher_hooks = cast(List[Dict[str, Any]], matcher.get("hooks", []))
+            if not isinstance(matcher_hooks, list):
+                new_matchers.append(matcher)
+                continue
+            filtered = [h for h in matcher_hooks if h != _CLAUDE_CODE_HOOK]
+            if len(filtered) == len(matcher_hooks):
+                new_matchers.append(matcher)
+                continue
+            changed = True
+            if not filtered and matcher.get("matcher", "") == "":
+                # Drop the now-empty default-matcher entry lapdog wrote.
+                continue
+            matcher["hooks"] = filtered
+            new_matchers.append(matcher)
+        hooks[event] = new_matchers
+
+    if not changed:
+        return False
+
+    settings["hooks"] = hooks
+    with open(claude_settings_path, "w") as f:
+        json.dump(settings, f, indent=2)
+    return True

--- a/releasenotes/notes/lapdog-uninstall-subcommand-7c4f3a9c2b8d1e63.yaml
+++ b/releasenotes/notes/lapdog-uninstall-subcommand-7c4f3a9c2b8d1e63.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Add ``lapdog uninstall`` subcommand. Stops the background agent,
+    removes ``~/.lapdog/``, strips lapdog's hook entries from Claude Code
+    settings (leaving any other hooks the user has configured untouched),
+    and deletes the pi extension. Intended to be run before uninstalling
+    the package via ``brew uninstall lapdog`` / ``pip uninstall
+    ddapm-test-agent``, since package managers cannot clean up state
+    lapdog writes to the user's home directory.

--- a/tests/test_lapdog_claude_hooks.py
+++ b/tests/test_lapdog_claude_hooks.py
@@ -8,6 +8,7 @@ from lapdog.hooks import (
     _CLAUDE_CODE_DEFAULT_MATCHER as CLAUDE_CODE_DEFAULT_MATCHER,
     _CLAUDE_CODE_HOOK as CLAUDE_CODE_HOOK,
     _CLAUDE_CODE_EVENTS as CLAUDE_CODE_EVENTS,
+    remove_claude_code_hooks,
     write_claude_code_hooks,
 )
 
@@ -109,3 +110,65 @@ class TestClaudeCodeHooksWriting:
             },
         }
         assert _read_settings(settings_path) == expected
+
+
+class TestClaudeCodeHooksRemoval:
+    """Tests for ``remove_claude_code_hooks`` (inverse of write)."""
+
+    def test_round_trip_clears_lapdog_hooks(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text("{}")
+        write_claude_code_hooks(settings_path)
+        changed = remove_claude_code_hooks(settings_path)
+        assert changed is True
+        # Every event's matcher list should be empty after removal — the
+        # default-matcher entries lapdog wrote contained only its own hook.
+        expected = {"hooks": {event: [] for event in CLAUDE_CODE_EVENTS}}
+        assert _read_settings(settings_path) == expected
+
+    def test_preserves_unrelated_user_hooks(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        user_hook = {"type": "command", "command": "echo bash"}
+        starting = {
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Bash", "hooks": [user_hook]},
+                    {"matcher": "", "hooks": [CLAUDE_CODE_HOOK]},
+                ],
+                "Stop": [{"matcher": "", "hooks": [CLAUDE_CODE_HOOK, user_hook]}],
+            },
+            "other": "kept",
+        }
+        settings_path.write_text(json.dumps(starting, indent=2))
+        changed = remove_claude_code_hooks(settings_path)
+        assert changed is True
+        # PreToolUse: the Bash matcher survives untouched; the default-matcher
+        # entry that held only lapdog's hook is dropped entirely.
+        # Stop: the default matcher keeps user_hook, just minus lapdog's.
+        expected = {
+            "hooks": {
+                "PreToolUse": [{"matcher": "Bash", "hooks": [user_hook]}],
+                "Stop": [{"matcher": "", "hooks": [user_hook]}],
+            },
+            "other": "kept",
+        }
+        assert _read_settings(settings_path) == expected
+
+    def test_noop_when_file_missing(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        assert remove_claude_code_hooks(settings_path) is False
+        assert not settings_path.exists()
+
+    def test_noop_when_no_lapdog_hooks(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        other = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "x"}]}]}}
+        settings_path.write_text(json.dumps(other, indent=2))
+        assert remove_claude_code_hooks(settings_path) is False
+        assert _read_settings(settings_path) == other
+
+    def test_noop_when_unparseable(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text("not json {{")
+        assert remove_claude_code_hooks(settings_path) is False
+        # File contents unchanged.
+        assert settings_path.read_text() == "not json {{"


### PR DESCRIPTION
## Summary
Adds `lapdog uninstall`. Stops the background agent, removes `~/.lapdog/`, strips lapdog's hook entries from `~/.claude/settings.json` (leaves the user's other hooks alone), and deletes `~/.pi/agent/extensions/lapdog.ts`. Intended to be run *before* `brew uninstall lapdog` / `pip uninstall ddapm-test-agent` — package managers can't reach the state lapdog writes under `$HOME`.

Also amends `lapdog/README.md` (added in #351) to recommend `lapdog uninstall` as the primary uninstall path, with the existing manual `jq`/`rm` recipe kept as a fallback for users on older builds.

## Tests
Adds 5 tests for `remove_claude_code_hooks` covering:
- round-trip after `write_claude_code_hooks` cleans every event
- preservation of non-lapdog hooks the user has configured (both within a default matcher and in named matchers)
- no-op when the settings file is missing
- no-op when the file has no lapdog hooks
- no-op when the file is unparseable

All 12 tests in `tests/test_lapdog_claude_hooks.py` pass.

## Stacking
This PR is **stacked on top of [#351](https://github.com/DataDog/dd-apm-test-agent/pull/351)** (base branch = `kyle/lapdog-readme`). The diff shown here is just the subcommand + tests + release note + README amendment. Merge #351 first; GitHub will auto-retarget this PR to `master`.

## Companion PR
- homebrew-lapdog: [DataDog/homebrew-lapdog#20](https://github.com/DataDog/homebrew-lapdog/pull/20) — caveats reference `lapdog uninstall`. Draft until this feature ships in a `ddapm-test-agent` release + bottle.

Claude session: `1e26db38-e2e5-41d5-b214-b4a8c11b8ddb`
Resume: `claude --resume 1e26db38-e2e5-41d5-b214-b4a8c11b8ddb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)