### PR TITLE
feat(lapdog): ship Claude Code plugin via in-repo marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "lapdog",
+  "metadata": {
+    "description": "Claude Code plugins for lapdog (local LLM observability via the dd-apm-test-agent)"
+  },
+  "owner": {
+    "name": "Datadog",
+    "url": "https://github.com/DataDog/dd-apm-test-agent"
+  },
+  "plugins": [
+    {
+      "name": "lapdog",
+      "source": "./plugins/lapdog"
+    }
+  ]
+}

--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -22,6 +22,7 @@ want to know what `lapdog start` actually does).
   - [pip (Linux, macOS, Windows)](#pip-linux-macos-windows)
   - [Docker](#docker)
   - [From source](#from-source)
+- [Claude Code plugin](#claude-code-plugin)
 - [Quickstart](#quickstart)
 - [What lapdog touches on your machine](#what-lapdog-touches-on-your-machine)
 - [Uninstallation](#uninstallation)
@@ -130,6 +131,36 @@ pip install "git+https://github.com/DataDog/dd-apm-test-agent@<branch-or-sha>"
 
 ---
 
+## Claude Code plugin
+
+The recommended way to capture Claude Code sessions is the `lapdog` Claude
+Code plugin, vended from a marketplace inside this same repository. The plugin
+registers a non-blocking `curl` hook for every Claude Code event so the local
+lapdog agent can record traces, prompts, tool calls, and permission requests.
+
+```bash
+# One-time: add this repo as a marketplace and install the plugin.
+claude plugin marketplace add DataDog/dd-apm-test-agent
+claude plugin install lapdog@lapdog
+
+# Then in any session:
+lapdog start                  # run the local agent
+claude                        # plugin-installed hooks POST to localhost:8126
+```
+
+Open <http://localhost:8126/leash/> while a session is running.
+
+The plugin lives entirely under `~/.claude/plugins/...` — it does **not**
+modify `~/.claude/settings.json`. `claude plugin uninstall lapdog@lapdog`
+fully removes it.
+
+If you cannot or do not want to install the plugin, `lapdog claude --hooks`
+writes the equivalent hook entries directly into `~/.claude/settings.json`.
+This is opt-in: by default `lapdog claude` no longer touches your Claude Code
+settings.
+
+---
+
 ## Quickstart
 
 ```bash
@@ -156,7 +187,9 @@ sessions, costs, and permission friction in real time.
 Useful flags:
 
 - `--forward` — also forward LLMObs events to Datadog (requires `DD_API_KEY`).
-- `--disable-claude-code-hooks` — do not modify `~/.claude/settings.json`.
+- `--hooks` — opt-in: write Claude Code hook entries into
+  `~/.claude/settings.json` so Claude Code posts events to the local agent.
+  Prefer installing the [Claude Code plugin](#claude-code-plugin) instead.
 - `-p <port>` / `--port <port>` — bind to a different port (default `8126`).
 
 ---
@@ -169,7 +202,7 @@ Knowing this up front makes the uninstall list below easy to verify.
 | --- | --- | --- |
 | `~/.lapdog/lapdog.pid` | `lapdog start` / `lapdog claude` / `lapdog pi` | PID + port of the background agent |
 | `~/.lapdog/lapdog.log` | same | stdout/stderr of the background agent |
-| `~/.claude/settings.json` | `lapdog claude` (unless `--disable-claude-code-hooks`) | adds a `curl` hook to `localhost:8126/claude/hooks` for each Claude Code event |
+| `~/.claude/settings.json` | only `lapdog claude --hooks` (opt-in) | adds a `curl` hook to `localhost:8126/claude/hooks` for each Claude Code event. The Claude Code plugin path leaves this file alone. |
 | `~/.pi/agent/extensions/lapdog.ts` | `lapdog pi` | Pi extension that reports tool calls to the local agent |
 
 No other state is created. There is no daemon installed at the OS level
@@ -192,10 +225,19 @@ find and kill it manually:
 lsof -ti tcp:8126 | xargs kill
 ```
 
-### 2. Remove the Claude Code hooks
+### 2. Remove the Claude Code plugin (if installed)
 
-`lapdog claude` adds hook entries to `~/.claude/settings.json` so Claude Code
-posts events to `localhost:8126/claude/hooks`. They look like:
+If you installed the plugin from the marketplace:
+
+```bash
+claude plugin uninstall lapdog@lapdog
+claude plugin marketplace remove lapdog
+```
+
+### 3. Remove the Claude Code hooks (only if you used `lapdog claude --hooks`)
+
+`lapdog claude --hooks` adds hook entries to `~/.claude/settings.json` so
+Claude Code posts events to `localhost:8126/claude/hooks`. They look like:
 
 ```json
 {
@@ -226,19 +268,19 @@ The hooks are harmless when the agent is not running (the `curl` returns
 non-zero and the `|| true` swallows it), so removing them is optional unless
 you want a fully clean Claude Code config.
 
-### 3. Remove the Pi extension (only if you used `lapdog pi`)
+### 4. Remove the Pi extension (only if you used `lapdog pi`)
 
 ```bash
 rm -f ~/.pi/agent/extensions/lapdog.ts
 ```
 
-### 4. Remove lapdog's working directory
+### 5. Remove lapdog's working directory
 
 ```bash
 rm -rf ~/.lapdog
 ```
 
-### 5. Uninstall the package
+### 6. Uninstall the package
 
 Match the install method you used:
 

--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -144,15 +144,14 @@ claude plugin marketplace add DataDog/dd-apm-test-agent
 claude plugin install lapdog@lapdog
 
 # Then in any session:
-lapdog start                  # run the local agent
-claude                        # plugin-installed hooks POST to localhost:8126
+lapdog claude                 # starts the agent, instruments LLM calls, launches Claude
 ```
 
 The plugin lives entirely under `~/.claude/plugins/...` — it does **not**
 modify `~/.claude/settings.json`. `claude plugin uninstall lapdog@lapdog`
 fully removes it.
 
-If you cannot or do not want to install the plugin, `lapdog claude --hooks`
+If you cannot or do not want to install the plugin, `lapdog --hooks claude`
 writes the equivalent hook entries directly into `~/.claude/settings.json`.
 This is opt-in: by default `lapdog claude` no longer touches your Claude Code
 settings.
@@ -200,7 +199,7 @@ Knowing this up front makes the uninstall list below easy to verify.
 | --- | --- | --- |
 | `~/.lapdog/lapdog.pid` | `lapdog start` / `lapdog claude` / `lapdog pi` | PID + port of the background agent |
 | `~/.lapdog/lapdog.log` | same | stdout/stderr of the background agent |
-| `~/.claude/settings.json` | only `lapdog claude --hooks` (opt-in) | adds a `curl` hook to `localhost:8126/claude/hooks` for each Claude Code event. The Claude Code plugin path leaves this file alone. |
+| `~/.claude/settings.json` | only `lapdog --hooks claude` (opt-in) | adds a `curl` hook to `localhost:8126/claude/hooks` for each Claude Code event. The Claude Code plugin path leaves this file alone. |
 | `~/.pi/agent/extensions/lapdog.ts` | `lapdog pi` | Pi extension that reports tool calls to the local agent |
 
 No other state is created. There is no daemon installed at the OS level
@@ -232,9 +231,9 @@ claude plugin uninstall lapdog@lapdog
 claude plugin marketplace remove lapdog
 ```
 
-### 3. Remove the Claude Code hooks (only if you used `lapdog claude --hooks`)
+### 3. Remove the Claude Code hooks (only if you used `lapdog --hooks claude`)
 
-`lapdog claude --hooks` adds hook entries to `~/.claude/settings.json` so
+`lapdog --hooks claude` adds hook entries to `~/.claude/settings.json` so
 Claude Code posts events to `localhost:8126/claude/hooks`. They look like:
 
 ```json

--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -148,8 +148,6 @@ lapdog start                  # run the local agent
 claude                        # plugin-installed hooks POST to localhost:8126
 ```
 
-Open <http://localhost:8126/leash/> while a session is running.
-
 The plugin lives entirely under `~/.claude/plugins/...` — it does **not**
 modify `~/.claude/settings.json`. `claude plugin uninstall lapdog@lapdog`
 fully removes it.

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -136,8 +136,8 @@ def _remove_pid_file() -> None:
             pass
 
 
-def _maybe_write_claude_hooks(disable: bool) -> None:
-    if disable:
+def _maybe_write_claude_hooks(enable: bool) -> None:
+    if not enable:
         return
     claude_settings_path = Path.home() / ".claude" / "settings.json"
     write_claude_code_hooks(claude_settings_path)
@@ -295,7 +295,7 @@ def _start_lapdog_detached(port: int, forward_data: bool) -> None:
     # refused that would make a re-check flaky.
 
 
-def cmd_exec(app_cmd: List[str], forward_data: bool, disable_hooks: bool = False) -> None:
+def cmd_exec(app_cmd: List[str], forward_data: bool) -> None:
     """Auto-start lapdog if needed, inject tracer env vars, then exec the app command. Never returns."""
     resolved = shutil.which(app_cmd[0])
     if not resolved:
@@ -314,9 +314,9 @@ def cmd_exec(app_cmd: List[str], forward_data: bool, disable_hooks: bool = False
     os.execvpe(resolved, app_cmd, env)
 
 
-def cmd_claude(sub_cmd_args: List[str], forward_data: bool, disable_hooks: bool) -> None:
+def cmd_claude(sub_cmd_args: List[str], forward_data: bool, enable_hooks: bool) -> None:
     """Ensure lapdog is running in background, then launch Claude with intercept."""
-    _maybe_write_claude_hooks(disable_hooks)
+    _maybe_write_claude_hooks(enable_hooks)
     _ensure_lapdog_running(forward_data, detached=True)
     print(build_running_banner(data_type="coding session"))
 
@@ -418,10 +418,15 @@ def _parse_lapdog_args(lapdog_args: List[str]) -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--disable-claude-code-hooks",
+        "--hooks",
         action="store_true",
         default=False,
-        help="Skip writing Claude Code hooks to ~/.claude/settings.json.",
+        help=(
+            "Write Claude Code hooks to ~/.claude/settings.json so Claude Code posts "
+            "events to the local lapdog agent. Prefer installing the 'lapdog' Claude "
+            "Code plugin (claude plugin marketplace add DataDog/dd-apm-test-agent && "
+            "claude plugin install lapdog@lapdog) instead of this flag."
+        ),
     )
 
     return parser.parse_args(args=lapdog_args)
@@ -457,7 +462,7 @@ def main() -> None:
         cmd_claude(
             sub_cmd_args=sub_cmd_args,
             forward_data=lapdog_parsed_args.forward,
-            disable_hooks=lapdog_parsed_args.disable_claude_code_hooks,
+            enable_hooks=lapdog_parsed_args.hooks,
         )
     elif sub_cmd == "pi":
         cmd_pi(sub_cmd_args=sub_cmd_args, forward_data=lapdog_parsed_args.forward)

--- a/plugins/lapdog/.claude-plugin/plugin.json
+++ b/plugins/lapdog/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "lapdog",
+  "version": "0.1.0",
+  "description": "Forward Claude Code hook events to a locally running lapdog / dd-apm-test-agent on http://localhost:8126 for trace, prompt, tool-call, and cost visibility at http://localhost:8126/leash/."
+}

--- a/plugins/lapdog/.claude-plugin/plugin.json
+++ b/plugins/lapdog/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "lapdog",
   "version": "0.1.0",
-  "description": "Forward Claude Code hook events to a locally running lapdog / dd-apm-test-agent on http://localhost:8126 for trace, prompt, tool-call, and cost visibility at http://localhost:8126/leash/."
+  "description": "Forward Claude Code hook events to a locally running lapdog / dd-apm-test-agent on http://localhost:8126 for trace, prompt, tool-call, and cost visibility."
 }

--- a/plugins/lapdog/README.md
+++ b/plugins/lapdog/README.md
@@ -7,8 +7,9 @@ running [lapdog](https://github.com/DataDog/dd-apm-test-agent) /
 `http://localhost:8126/claude/hooks`.
 
 Pair this plugin with `lapdog start` (or `lapdog claude`) on the same machine.
-While both are running, open <http://localhost:8126/leash/> to inspect traces,
-sessions, costs, and permission friction in real time.
+While both are running, every Claude Code event is recorded by the local
+agent for inspection (e.g. via the test agent's `/test/session/traces` and
+related endpoints, or the optional Web UI started with `--web-ui-port`).
 
 ## Install
 

--- a/plugins/lapdog/README.md
+++ b/plugins/lapdog/README.md
@@ -1,0 +1,28 @@
+# lapdog (Claude Code plugin)
+
+Forwards every Claude Code hook event (`PreToolUse`, `PostToolUse`,
+`UserPromptSubmit`, `SessionStart`, `PermissionRequest`, ...) to a locally
+running [lapdog](https://github.com/DataDog/dd-apm-test-agent) /
+[dd-apm-test-agent](https://github.com/DataDog/dd-apm-test-agent) on
+`http://localhost:8126/claude/hooks`.
+
+Pair this plugin with `lapdog start` (or `lapdog claude`) on the same machine.
+While both are running, open <http://localhost:8126/leash/> to inspect traces,
+sessions, costs, and permission friction in real time.
+
+## Install
+
+```bash
+claude plugin marketplace add DataDog/dd-apm-test-agent
+claude plugin install lapdog@lapdog
+```
+
+## What it does
+
+For each Claude Code hook event the plugin runs a single non-blocking `curl`
+that POSTs the event payload to the local lapdog agent. When the agent is not
+running the `curl` fails silently (`|| true`), so the plugin is harmless to
+leave installed.
+
+The plugin does not write to `~/.claude/settings.json` and does not require
+any further configuration.

--- a/plugins/lapdog/hooks/hooks.json
+++ b/plugins/lapdog/hooks/hooks.json
@@ -1,0 +1,148 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' -d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/releasenotes/notes/lapdog-claude-code-plugin-d4f4601cb1b61a41.yaml
+++ b/releasenotes/notes/lapdog-claude-code-plugin-d4f4601cb1b61a41.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    Ship a `lapdog` Claude Code plugin from a marketplace homed in this
+    repository. After `claude plugin marketplace add DataDog/dd-apm-test-agent`
+    and `claude plugin install lapdog@lapdog`, Claude Code POSTs every hook
+    event (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart, ...) to
+    `http://localhost:8126/claude/hooks` without `lapdog claude` having to
+    mutate `~/.claude/settings.json`.
+upgrade:
+  - |
+    `lapdog claude` no longer writes Claude Code hook entries to
+    `~/.claude/settings.json` by default. The previous
+    `--disable-claude-code-hooks` flag is replaced by an opt-in `--hooks`
+    flag for users who cannot install the plugin. The recommended path is
+    `claude plugin install lapdog@lapdog`.


### PR DESCRIPTION
## Summary

- Add a one-plugin Claude Code marketplace at the repo root (`.claude-plugin/marketplace.json`, name `lapdog`) and a `lapdog` plugin under `plugins/lapdog/` whose `hooks/hooks.json` registers the same non-blocking `curl` hook for every Claude Code event that `lapdog/hooks.py` writes today.
- Flip `lapdog claude` hook-writing from default-on (`--disable-claude-code-hooks` opt-out) to default-off (`--hooks` opt-in). The plugin is now the recommended integration path; `lapdog claude` no longer mutates `~/.claude/settings.json` unless explicitly asked.
- Update `lapdog/README.md` with a "Claude Code plugin" install section, the new flag semantics, and a `claude plugin uninstall` step in the uninstall flow.
- Add release note covering both the feature and the flag rename (upgrade impact).

Install once the PR merges:

```bash
claude plugin marketplace add DataDog/dd-apm-test-agent
claude plugin install lapdog@lapdog
```

## Test plan

- [x] `claude plugin validate <repo>` — marketplace passes.
- [x] `claude plugin validate plugins/lapdog` — plugin passes (one expected `author` warning, intentionally suppressed).
- [x] Plugin `hooks.json` event list and command equal `_CLAUDE_CODE_EVENTS` / `_CLAUDE_CODE_HOOK` from `lapdog/hooks.py` (verified by script).
- [x] `lapdog claude --hooks` writes settings; bare `lapdog claude` does not (verified via `_maybe_write_claude_hooks` smoke test).
- [x] Removed `--disable-claude-code-hooks` flag is rejected by the parser.
- [x] Existing `tests/test_lapdog_claude_hooks.py` still aligns — it tests `write_claude_code_hooks` directly, which is unchanged.
- [ ] Reviewer: run `claude plugin marketplace add DataDog/dd-apm-test-agent` against this branch and confirm `claude plugin install lapdog@lapdog` works end-to-end against a running `lapdog start`.