### PR TITLE
docs(lapdog): point dashboard URLs at lapdog.datadoghq.com

### DIFF
--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -96,7 +96,7 @@ docker run --rm \
 ```
 
 Then point your application at the host: `DD_TRACE_AGENT_URL=http://localhost:8126`.
-Open the dashboard at <http://localhost:8126/leash/>.
+Open the dashboard at <https://lapdog.datadoghq.com>.
 
 To persist sessions across container restarts, mount a host directory at
 `/snapshots`:
@@ -194,8 +194,10 @@ lapdog status
 lapdog stop
 ```
 
-Open <http://localhost:8126/leash/> while a session is running to see traces,
-sessions, costs, and permission friction in real time.
+Open <https://lapdog.datadoghq.com> while a session is running to see traces,
+sessions, costs, and permission friction in real time. The page reads directly
+from your local agent on `localhost:8126` — no Datadog account or login
+required.
 
 Important: `lapdog claude` and `lapdog codex` are proxy-backed workflows.
 They put the local Lapdog agent in the live model-request path. Keep Lapdog

--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -33,8 +33,8 @@ want to know what `lapdog start` actually does).
 - Python **3.11+** when installing via `pip` or from source. The Homebrew tap
   bundles its own interpreter, so the system Python version does not matter.
 - Port **8126** free on `localhost`. If the port is taken, set `PORT=<other>`
-  before running `lapdog start` and open the dashboard at
-  `http://localhost:<port>/leash/`.
+  before running `lapdog start` and override the port from the dashboard's
+  agent-status popover ("Collecting sessions" → port input).
 - For `lapdog claude` / `lapdog pi`: the `claude` / `pi` binary already on
   `PATH`.
 
@@ -95,7 +95,7 @@ docker run --rm \
 ```
 
 Then point your application at the host: `DD_TRACE_AGENT_URL=http://localhost:8126`.
-Open the dashboard at <http://localhost:8126/leash/>.
+Open the dashboard at <https://lapdog.datadoghq.com>.
 
 To persist sessions across container restarts, mount a host directory at
 `/snapshots`:
@@ -150,8 +150,10 @@ lapdog status
 lapdog stop
 ```
 
-Open <http://localhost:8126/leash/> while a session is running to see traces,
-sessions, costs, and permission friction in real time.
+Open <https://lapdog.datadoghq.com> while a session is running to see traces,
+sessions, costs, and permission friction in real time. The page reads directly
+from your local agent on `localhost:8126` — no Datadog account or login
+required.
 
 Useful flags:
 


### PR DESCRIPTION
## Summary
Follow-up to #351. The README referenced `http://localhost:8126/leash/` in three places, but the test agent does not serve a UI at `/leash/` — that URL is fictional. The real dashboard is hosted at https://lapdog.datadoghq.com and reads directly from the local agent on `localhost:8126`.

## Changes
- Quickstart and Docker sections: swap `http://localhost:8126/leash/` for https://lapdog.datadoghq.com. Quickstart now also notes that the page reads from the local agent and needs no Datadog account.
- Requirements: drop the bogus `http://localhost:<port>/leash/` URL from the port-override note. Direct users instead to the agent-status popover in the dashboard, which is the actual UI for overriding the port.

## Preview
Rendered README: https://github.com/DataDog/dd-apm-test-agent/blob/kyle/lapdog-readme-dashboard-url/lapdog/README.md

Claude session: `1e26db38-e2e5-41d5-b214-b4a8c11b8ddb`
Resume: `claude --resume 1e26db38-e2e5-41d5-b214-b4a8c11b8ddb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)