### PR TITLE
feat(lapdog): add Gemini CLI hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ The test agent can receive [Claude Code hook](https://docs.claude.com/en/docs/cl
 See [`.claude/setup-hooks.md`](.claude/setup-hooks.md) for full setup instructions (also usable as a Claude Code prompt to automate the setup).
 
 
+### Gemini CLI Hooks
+
+The test agent can receive Gemini CLI command-hook events and assemble them into LLM Observability traces.
+
+Run `lapdog gemini` to start the local agent, install/update the bundled Gemini extension, and launch `gemini`. The extension posts Gemini hook payloads to `/gemini/hooks/{EventType}` and uses fail-open `curl ... || true` commands so Gemini is not blocked if the local agent is unavailable.
+
+
 ### Snapshot testing
 
 The test agent provides a form of [characterization testing](https://en.wikipedia.org/wiki/Characterization_test) which

--- a/ddapm_test_agent/_clock.py
+++ b/ddapm_test_agent/_clock.py
@@ -29,3 +29,8 @@ def monotonic_wall_ns() -> int:
             t = _last_ns + 1
         _last_ns = t
         return t
+
+
+def finalized_duration_ns(start_ns: int, end_ns: int) -> int:
+    """Return a positive duration for spans that have left the live/running state."""
+    return max(1, end_ns - start_ns)

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -60,6 +60,7 @@ from .checks import start_trace
 from .claude_hooks import ClaudeHooksAPI
 from .claude_link_tracker import ClaudeLinkTracker
 from .claude_proxy import ClaudeProxyAPI
+from .gemini_hooks import GeminiHooksAPI
 from .pi_hooks import PiHooksAPI
 from .integration import Integration
 from .llmobs_event_platform import LLMObsEventPlatformAPI
@@ -2035,6 +2036,9 @@ def make_app(
 
     pi_hooks_api = PiHooksAPI(hooks_api=claude_hooks_api)
     app.add_routes(pi_hooks_api.get_routes())
+
+    gemini_hooks_api = GeminiHooksAPI(hooks_api=claude_hooks_api)
+    app.add_routes(gemini_hooks_api.get_routes())
 
     async def _cleanup_claude_proxy(app: web.Application) -> None:
         await claude_proxy_api.close()

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -26,6 +26,7 @@ from aiohttp import web
 from aiohttp.web import Request
 import msgpack
 
+from ._clock import finalized_duration_ns
 from ._clock import monotonic_wall_ns
 from .claude_cost_tracker import COST_METRIC_KEYS
 from .claude_link_tracker import ClaudeLinkTracker
@@ -526,7 +527,7 @@ class ClaudeHooksAPI:
         error_message: str = "",
     ) -> None:
         """Populate the step span's duration, output, metadata, and status."""
-        duration = max(0, end_ns - active.start_ns)
+        duration = finalized_duration_ns(active.start_ns, end_ns)
         span = active.span_ref
         span["duration"] = duration
         span["status"] = status
@@ -615,7 +616,7 @@ class ClaudeHooksAPI:
         current duration so the trace is complete.
         """
         now_ns = monotonic_wall_ns()
-        duration = now_ns - session.start_ns
+        duration = finalized_duration_ns(session.start_ns, now_ns)
 
         # Discard any pending permission wait — the turn was interrupted so we don't
         # want it bleeding into the next turn's accumulated total.
@@ -636,7 +637,7 @@ class ClaudeHooksAPI:
             agent_info = session.agent_span_stack.pop()
             span_ref = agent_info.get("_span_ref")
             if span_ref:
-                span_ref["duration"] = now_ns - agent_info["start_ns"]
+                span_ref["duration"] = finalized_duration_ns(agent_info["start_ns"], now_ns)
                 span_ref["status"] = "error"
                 span_ref["meta"]["error"] = {"message": "interrupted"}
 
@@ -879,7 +880,7 @@ class ClaudeHooksAPI:
             return
 
         # Normal tool span
-        duration = now_ns - start_ns
+        duration = finalized_duration_ns(start_ns, now_ns)
 
         span_links = []
         if self._link_tracker:
@@ -1046,7 +1047,7 @@ class ClaudeHooksAPI:
         agent_info = session.agent_span_stack.pop()
         # Remove from active_agents map
         session.active_agents.pop(str(agent_info["span_id"]), None)
-        duration = now_ns - agent_info["start_ns"]
+        duration = finalized_duration_ns(agent_info["start_ns"], now_ns)
 
         task_tool_use_id = agent_info.get("task_tool_use_id", "")
         task_tool_input = agent_info.get("task_tool_input")
@@ -1258,7 +1259,7 @@ class ClaudeHooksAPI:
             return
 
         now_ns = monotonic_wall_ns()
-        duration = now_ns - session.start_ns
+        duration = finalized_duration_ns(session.start_ns, now_ns)
 
         # Finalize any still-open step on the root agent before aggregating the turn.
         self._finalize_all_steps_for_agent(session, session.root_span_id, now_ns)
@@ -1432,7 +1433,7 @@ class ClaudeHooksAPI:
             tool_input_dict = {}
 
         intent = _extract_intent(actual_tool_name, tool_input_dict)
-        duration = now_ns - start_ns
+        duration = finalized_duration_ns(start_ns, now_ns)
 
         # Consume any pending permission wait
         estimated_permission_wait_ms: Optional[int] = None

--- a/ddapm_test_agent/gemini_hooks.py
+++ b/ddapm_test_agent/gemini_hooks.py
@@ -13,6 +13,7 @@ from typing import Tuple
 from aiohttp import web
 from aiohttp.web import Request
 
+from ._clock import finalized_duration_ns
 from ._clock import monotonic_wall_ns
 from .claude_cost_tracker import compute_cost_metrics
 from .claude_hooks import ClaudeHooksAPI
@@ -373,7 +374,7 @@ class GeminiHooksAPI:
             end_ns = monotonic_wall_ns()
 
         ref = active.span_ref
-        ref["duration"] = end_ns - active.start_ns
+        ref["duration"] = finalized_duration_ns(active.start_ns, end_ns)
         ref["meta"]["output"]["value"] = active.output_text
         metadata = ref["meta"].setdefault("metadata", {})
         metadata["message_index"] = active.message_index
@@ -403,7 +404,7 @@ class GeminiHooksAPI:
         if len(output_value) > _MAX_RESPONSE_LEN:
             output_value = output_value[:_MAX_RESPONSE_LEN]
 
-        root_span["duration"] = now_ns - session.start_ns
+        root_span["duration"] = finalized_duration_ns(session.start_ns, now_ns)
         root_span["status"] = status
         root_span["meta"]["input"]["value"] = "\n\n".join(session.user_prompts)
         root_span["meta"]["output"]["value"] = output_value
@@ -581,7 +582,7 @@ class GeminiHooksAPI:
             "name": actual_tool_name,
             "status": "error" if is_error else "ok",
             "start_ns": start_ns,
-            "duration": now_ns - start_ns,
+            "duration": finalized_duration_ns(start_ns, now_ns),
             "ml_app": _ML_APP,
             "service": _ML_APP,
             "env": "local",

--- a/ddapm_test_agent/gemini_hooks.py
+++ b/ddapm_test_agent/gemini_hooks.py
@@ -2,7 +2,9 @@
 
 import logging
 import os
+from collections import defaultdict
 from typing import Any
+from typing import DefaultDict
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -69,7 +71,9 @@ class GeminiHooksAPI:
         self._raw_events: List[Dict[str, Any]] = []
         self._active_steps: Dict[str, ActiveGeminiStep] = {}
         self._step_indexes: Dict[str, int] = {}
-        self._last_tool_use_ids: Dict[str, str] = {}
+        self._synthetic_tool_use_ids_by_name: DefaultDict[str, DefaultDict[str, List[str]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
 
     # ------------------------------------------------------------------
     # Shared-state helpers
@@ -185,7 +189,7 @@ class GeminiHooksAPI:
 
         contents = llm_request.get("contents", [])
         if not isinstance(contents, list):
-            return messages
+            contents = []
 
         for content in contents:
             if not isinstance(content, dict):
@@ -198,6 +202,24 @@ class GeminiHooksAPI:
             if tool_calls:
                 entry["tool_calls"] = tool_calls
             messages.append(entry)
+
+        legacy_messages = llm_request.get("messages", [])
+        if isinstance(legacy_messages, list):
+            for message in legacy_messages:
+                if not isinstance(message, dict):
+                    continue
+                role = _gemini_role(message.get("role"))
+                content = message.get("content", "")
+                if isinstance(content, list):
+                    text, tool_calls, tool_id = _gemini_parts_to_text_and_tools(content)
+                else:
+                    text, tool_calls, tool_id = _to_json_str(content), [], ""
+                entry = {"role": role, "content": text}
+                if tool_id and role == "tool":
+                    entry["tool_id"] = tool_id
+                if tool_calls:
+                    entry["tool_calls"] = tool_calls
+                messages.append(entry)
         return messages
 
     def _llm_output(self, body: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]], List[str], str]:
@@ -240,7 +262,7 @@ class GeminiHooksAPI:
     def _clear_turn_state(self, session_id: str) -> None:
         self._active_steps.pop(session_id, None)
         self._step_indexes[session_id] = 0
-        self._last_tool_use_ids.pop(session_id, None)
+        self._synthetic_tool_use_ids_by_name.pop(session_id, None)
 
     def _start_root(self, session: SessionState, prompt: str) -> None:
         if session.root_span_emitted:
@@ -494,7 +516,7 @@ class GeminiHooksAPI:
         tool_use_id = _extract_tool_use_id(body)
         if not tool_use_id:
             tool_use_id = _synthetic_tool_use_id(session_id, tool_name, len(session.pending_tools))
-            self._last_tool_use_ids[session_id] = tool_use_id
+            self._synthetic_tool_use_ids_by_name[session_id][tool_name].append(tool_use_id)
 
         tool_input = body.get("tool_input")
         if tool_input is None:
@@ -517,7 +539,9 @@ class GeminiHooksAPI:
 
         active = self._ensure_step(session)
         tool_name = str(body.get("tool_name", "unknown_tool") or "unknown_tool")
-        tool_use_id = _extract_tool_use_id(body) or self._last_tool_use_ids.pop(session_id, "")
+        tool_use_id = _extract_tool_use_id(body)
+        if not tool_use_id:
+            tool_use_id = self._pop_synthetic_tool_use_id(session_id, tool_name)
         if not tool_use_id:
             tool_use_id = _synthetic_tool_use_id(session_id, tool_name, len(session.pending_tools))
 
@@ -583,6 +607,26 @@ class GeminiHooksAPI:
             self._hooks_api._set_permission_wait_critical_evaluation(span, wait_ms)
 
         self._append_span(span)
+
+    def _pop_synthetic_tool_use_id(self, session_id: str, tool_name: str) -> str:
+        by_name = self._synthetic_tool_use_ids_by_name.get(session_id)
+        if not by_name:
+            return ""
+
+        pending_for_name = by_name.get(tool_name)
+        if pending_for_name:
+            tool_use_id = pending_for_name.pop(0)
+            if not pending_for_name:
+                by_name.pop(tool_name, None)
+            return tool_use_id
+
+        for name, pending_ids in list(by_name.items()):
+            if pending_ids:
+                tool_use_id = pending_ids.pop(0)
+                if not pending_ids:
+                    by_name.pop(name, None)
+                return tool_use_id
+        return ""
 
     def _handle_after_agent(self, session_id: str, body: Dict[str, Any]) -> None:
         session = self._hooks_api._sessions.get(session_id)
@@ -756,6 +800,10 @@ def _gemini_parts_to_text_and_tools(parts: Any) -> Tuple[str, List[Dict[str, Any
     tool_id = ""
 
     for part in parts:
+        if isinstance(part, str):
+            if part:
+                text_parts.append(part)
+            continue
         if not isinstance(part, dict):
             continue
         text = part.get("text")

--- a/ddapm_test_agent/gemini_hooks.py
+++ b/ddapm_test_agent/gemini_hooks.py
@@ -1,0 +1,803 @@
+"""Gemini CLI hook events -> LLM Observability spans."""
+
+import logging
+import os
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from aiohttp import web
+from aiohttp.web import Request
+
+from ._clock import monotonic_wall_ns
+from .claude_cost_tracker import compute_cost_metrics
+from .claude_hooks import ClaudeHooksAPI
+from .claude_hooks import PendingToolSpan
+from .claude_hooks import SessionState
+from .claude_hooks import _HOSTNAME
+from .claude_hooks import _USER_HANDLE
+from .claude_hooks import _format_span_id
+from .claude_hooks import _format_trace_id
+from .claude_hooks import _to_json_str
+from .llmobs_event_platform import with_cors
+
+log = logging.getLogger(__name__)
+
+_ML_APP = os.environ.get("DD_GEMINI_ML_APP", "gemini-cli")
+_MODEL_PROVIDER = "google"
+_MAX_PROMPT_LEN = 8192
+_MAX_RESPONSE_LEN = 4096
+_MAX_OUTPUT_SUMMARY_LEN = 2048
+
+
+class ActiveGeminiStep:
+    """Tracks one Gemini inference cycle and any tools it requested."""
+
+    def __init__(
+        self,
+        span_id: str,
+        parent_id: str,
+        start_ns: int,
+        message_index: int,
+        span_ref: Dict[str, Any],
+    ) -> None:
+        self.span_id = span_id
+        self.parent_id = parent_id
+        self.start_ns = start_ns
+        self.message_index = message_index
+        self.span_ref = span_ref
+        self.output_text = ""
+        self.tool_use_ids: List[str] = []
+        self.has_thinking = False
+        self.stop_reason = ""
+        self.llm_count = 0
+        self.tool_count = 0
+
+
+class GeminiHooksAPI:
+    """Handler for Gemini CLI command-hook events.
+
+    Gemini CLI sends command hooks directly over HTTP.  Unlike Codex, there is
+    no live JSONL file to tail for the normal capture path; unlike Claude, the
+    model request/response and token usage are available in the hook payloads.
+    """
+
+    def __init__(self, hooks_api: ClaudeHooksAPI) -> None:
+        self._hooks_api = hooks_api
+        self._raw_events: List[Dict[str, Any]] = []
+        self._active_steps: Dict[str, ActiveGeminiStep] = {}
+        self._step_indexes: Dict[str, int] = {}
+        self._last_tool_use_ids: Dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Shared-state helpers
+    # ------------------------------------------------------------------
+
+    def _get_or_create_session(self, session_id: str) -> SessionState:
+        return self._hooks_api._get_or_create_session(session_id)
+
+    def _append_span(self, span: Dict[str, Any]) -> None:
+        self._hooks_api._assembled_spans.append(span)
+
+    def _root_ref(self, session: SessionState) -> Optional[Dict[str, Any]]:
+        return getattr(session, "_root_span_ref", None)
+
+    def _current_parent_id(self, session: SessionState) -> str:
+        active = self._active_steps.get(session.session_id)
+        if active:
+            return active.span_id
+        return str(session.root_span_id)
+
+    def _append_model(self, session: SessionState, model: str) -> None:
+        if not model:
+            return
+        session.model = model
+        if not session.models or session.models[-1] != model:
+            session.models.append(model)
+
+    def _append_common_tags(self, session: SessionState, source_tag: str) -> List[str]:
+        tags = [
+            f"ml_app:{_ML_APP}",
+            f"session_id:{session.session_id}",
+            f"service:{_ML_APP}",
+            "env:local",
+            source_tag,
+            "language:python",
+            f"hostname:{_HOSTNAME}",
+        ]
+        if _USER_HANDLE:
+            tags.append(f"user_handle:{_USER_HANDLE}")
+        return tags
+
+    # ------------------------------------------------------------------
+    # Gemini payload parsing
+    # ------------------------------------------------------------------
+
+    def _extract_model(self, body: Dict[str, Any]) -> str:
+        for key in ("model", "model_id"):
+            val = body.get(key)
+            if isinstance(val, str) and val:
+                return val
+        llm_request = body.get("llm_request")
+        if isinstance(llm_request, dict):
+            model = llm_request.get("model")
+            if isinstance(model, str):
+                return model
+        return ""
+
+    def _usage_metrics(self, body: Dict[str, Any]) -> Tuple[Dict[str, int], bool]:
+        llm_response = body.get("llm_response")
+        usage = llm_response.get("usageMetadata") if isinstance(llm_response, dict) else None
+        if not isinstance(usage, dict):
+            usage = body.get("usageMetadata")
+        if not isinstance(usage, dict):
+            usage = body.get("usage")
+        if not isinstance(usage, dict):
+            return {}, False
+
+        input_tokens = _int_value(usage.get("promptTokenCount", usage.get("input", 0)))
+        output_tokens = _int_value(usage.get("candidatesTokenCount", usage.get("output", 0)))
+        thought_tokens = _int_value(usage.get("thoughtsTokenCount", usage.get("thoughts", 0)))
+        cache_read = _int_value(usage.get("cachedContentTokenCount", usage.get("cacheRead", 0)))
+        cache_write = _int_value(usage.get("cacheWrite", 0))
+        total_tokens = _int_value(usage.get("totalTokenCount", usage.get("totalTokens", 0)))
+        if not total_tokens:
+            total_tokens = input_tokens + output_tokens + thought_tokens
+
+        non_cached_input = max(input_tokens - cache_read - cache_write, 0)
+        metrics = {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens,
+            "cache_read_input_tokens": cache_read,
+            "cache_write_input_tokens": cache_write,
+            "non_cached_input_tokens": non_cached_input,
+        }
+        if thought_tokens:
+            metrics["reasoning_tokens"] = thought_tokens
+            metrics["gemini_thoughts_tokens"] = thought_tokens
+
+        model = self._extract_model(body)
+        cost_metrics = compute_cost_metrics(
+            model_id=model,
+            non_cached_input_tokens=non_cached_input,
+            cache_write_tokens=cache_write,
+            cache_read_tokens=cache_read,
+            output_tokens=output_tokens,
+        )
+        if cost_metrics:
+            metrics.update(cost_metrics)
+
+        return metrics, thought_tokens > 0
+
+    def _llm_input_messages(self, body: Dict[str, Any]) -> List[Dict[str, Any]]:
+        llm_request = body.get("llm_request")
+        if not isinstance(llm_request, dict):
+            return []
+
+        messages: List[Dict[str, Any]] = []
+        system_instruction = llm_request.get("systemInstruction")
+        system_text = _gemini_content_to_text(system_instruction)
+        if system_text:
+            messages.append({"role": "system", "content": system_text})
+
+        contents = llm_request.get("contents", [])
+        if not isinstance(contents, list):
+            return messages
+
+        for content in contents:
+            if not isinstance(content, dict):
+                continue
+            role = _gemini_role(content.get("role"))
+            text, tool_calls, tool_id = _gemini_parts_to_text_and_tools(content.get("parts", []))
+            entry: Dict[str, Any] = {"role": role, "content": text}
+            if tool_id and role == "tool":
+                entry["tool_id"] = tool_id
+            if tool_calls:
+                entry["tool_calls"] = tool_calls
+            messages.append(entry)
+        return messages
+
+    def _llm_output(self, body: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]], List[str], str]:
+        llm_response = body.get("llm_response")
+        if not isinstance(llm_response, dict):
+            return "", [], [], ""
+
+        candidates = llm_response.get("candidates", [])
+        if not isinstance(candidates, list):
+            return "", [], [], ""
+
+        text_parts: List[str] = []
+        tool_calls: List[Dict[str, Any]] = []
+        tool_use_ids: List[str] = []
+        stop_reason = ""
+
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            if not stop_reason and isinstance(candidate.get("finishReason"), str):
+                stop_reason = candidate["finishReason"]
+            content = candidate.get("content")
+            if not isinstance(content, dict):
+                continue
+            text, calls, _tool_id = _gemini_parts_to_text_and_tools(content.get("parts", []))
+            if text:
+                text_parts.append(text)
+            for call in calls:
+                tool_calls.append(call)
+                tool_id = str(call.get("tool_id", ""))
+                if tool_id:
+                    tool_use_ids.append(tool_id)
+
+        return "\n".join(text_parts), tool_calls, tool_use_ids, stop_reason
+
+    # ------------------------------------------------------------------
+    # Span lifecycle
+    # ------------------------------------------------------------------
+
+    def _clear_turn_state(self, session_id: str) -> None:
+        self._active_steps.pop(session_id, None)
+        self._step_indexes[session_id] = 0
+        self._last_tool_use_ids.pop(session_id, None)
+
+    def _start_root(self, session: SessionState, prompt: str) -> None:
+        if session.root_span_emitted:
+            now_ns = monotonic_wall_ns()
+            session.trace_id = _format_trace_id()
+            session.root_span_id = _format_span_id()
+            session.start_ns = now_ns
+            session.user_prompts = []
+            session.tools_used = set()
+            session.pending_tools = {}
+            session.agent_span_stack = []
+            session.deferred_agent_spans = {}
+            session.claimed_task_tools = set()
+            session.active_agents = {}
+            session.root_span_emitted = False
+            session.models = [session.model] if session.model else []
+        elif self._root_ref(session) is not None:
+            self._finalize_root(session, {"prompt_response": ""}, status="error", error_message="interrupted")
+
+        self._clear_turn_state(session.session_id)
+
+        if prompt:
+            session.user_prompts.append(prompt)
+
+        root_span: Dict[str, Any] = {
+            "span_id": session.root_span_id,
+            "trace_id": session.trace_id,
+            "parent_id": "undefined",
+            "name": "gemini-request",
+            "status": "ok",
+            "start_ns": session.start_ns,
+            "duration": 0,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": self._append_common_tags(session, "source:gemini-hooks") + ["trajectory.semantic_type:turn"],
+            "meta": {
+                "span": {"kind": "agent"},
+                "input": {"value": prompt},
+                "output": {"value": ""},
+                "model_name": session.model,
+                "model_provider": session.model_provider or _MODEL_PROVIDER,
+                "metadata": {"models_used": session.models[:]},
+            },
+            "metrics": {},
+        }
+        self._append_span(root_span)
+        session._root_span_ref = root_span  # type: ignore[attr-defined]
+
+    def _start_step(self, session: SessionState) -> ActiveGeminiStep:
+        self._finalize_active_step(session.session_id)
+
+        idx = self._step_indexes.get(session.session_id, 0)
+        self._step_indexes[session.session_id] = idx + 1
+        now_ns = monotonic_wall_ns()
+        span_id = _format_span_id()
+        parent_id = session.root_span_id
+
+        step_span: Dict[str, Any] = {
+            "span_id": span_id,
+            "trace_id": session.trace_id,
+            "parent_id": parent_id,
+            "name": f"inference-{idx}",
+            "status": "ok",
+            "start_ns": now_ns,
+            "duration": 0,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": self._append_common_tags(session, "source:gemini-hooks")
+            + ["trajectory.semantic_type:agent_message"],
+            "meta": {
+                "span": {"kind": "step"},
+                "input": {},
+                "output": {"value": ""},
+                "metadata": {"message_index": idx},
+            },
+            "metrics": {},
+        }
+        self._append_span(step_span)
+
+        active = ActiveGeminiStep(
+            span_id=span_id,
+            parent_id=parent_id,
+            start_ns=now_ns,
+            message_index=idx,
+            span_ref=step_span,
+        )
+        self._active_steps[session.session_id] = active
+        return active
+
+    def _ensure_step(self, session: SessionState, *, new_after_existing_llm: bool = False) -> ActiveGeminiStep:
+        active = self._active_steps.get(session.session_id)
+        if active is None:
+            return self._start_step(session)
+        if new_after_existing_llm and active.llm_count > 0:
+            return self._start_step(session)
+        return active
+
+    def _finalize_active_step(self, session_id: str, end_ns: Optional[int] = None) -> None:
+        active = self._active_steps.pop(session_id, None)
+        if not active:
+            return
+
+        if end_ns is None:
+            end_ns = monotonic_wall_ns()
+
+        ref = active.span_ref
+        ref["duration"] = end_ns - active.start_ns
+        ref["meta"]["output"]["value"] = active.output_text
+        metadata = ref["meta"].setdefault("metadata", {})
+        metadata["message_index"] = active.message_index
+        if active.tool_use_ids:
+            metadata["tool_use_ids"] = active.tool_use_ids
+        if active.has_thinking:
+            metadata["has_thinking"] = True
+        if active.stop_reason:
+            metadata["stop_reason"] = active.stop_reason
+
+    def _finalize_root(
+        self,
+        session: SessionState,
+        body: Dict[str, Any],
+        *,
+        status: str = "ok",
+        error_message: str = "",
+    ) -> None:
+        self._finalize_active_step(session.session_id)
+
+        root_span = self._root_ref(session)
+        if not root_span:
+            return
+
+        now_ns = monotonic_wall_ns()
+        output_value = str(body.get("prompt_response", body.get("output", "")) or "")
+        if len(output_value) > _MAX_RESPONSE_LEN:
+            output_value = output_value[:_MAX_RESPONSE_LEN]
+
+        root_span["duration"] = now_ns - session.start_ns
+        root_span["status"] = status
+        root_span["meta"]["input"]["value"] = "\n\n".join(session.user_prompts)
+        root_span["meta"]["output"]["value"] = output_value
+        root_span["meta"]["model_name"] = session.model
+        root_span["meta"]["model_provider"] = session.model_provider or _MODEL_PROVIDER
+        root_span["meta"].setdefault("metadata", {})["models_used"] = session.models[:]
+        if error_message:
+            root_span["meta"]["error"] = {"message": error_message}
+
+        tool_usage = self._hooks_api._aggregate_tool_usage(session.trace_id)
+        dd_fields: Dict[str, Any] = {
+            "agent_manifest": {
+                "name": _ML_APP,
+                "model": session.model,
+                "model_provider": session.model_provider or _MODEL_PROVIDER,
+                "models": session.models[:],
+                "tools": [{"name": name} for name in sorted(session.tools_used)],
+            }
+        }
+        if tool_usage:
+            dd_fields["tool_usage"] = tool_usage
+        self._hooks_api._set_hidden_metadata(root_span, **dd_fields)
+
+        session.root_span_emitted = True
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _handle_session_start(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._get_or_create_session(session_id)
+        session.model_provider = _MODEL_PROVIDER
+        self._append_model(session, self._extract_model(body))
+        log.info("Gemini session started: %s (model=%s)", session_id, session.model)
+
+    def _handle_before_agent(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._get_or_create_session(session_id)
+        session.model_provider = _MODEL_PROVIDER
+        self._append_model(session, self._extract_model(body))
+
+        prompt = str(body.get("prompt", body.get("user_prompt", "")) or "")
+        if len(prompt) > _MAX_PROMPT_LEN:
+            prompt = prompt[:_MAX_PROMPT_LEN]
+        self._start_root(session, prompt)
+
+    def _handle_after_model(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._hooks_api._sessions.get(session_id)
+        if not session or not self._root_ref(session):
+            return
+
+        model = self._extract_model(body)
+        self._append_model(session, model)
+        session.model_provider = _MODEL_PROVIDER
+
+        active = self._ensure_step(session, new_after_existing_llm=True)
+        input_messages = self._llm_input_messages(body)
+        output_text, tool_calls, tool_use_ids, stop_reason = self._llm_output(body)
+        metrics, has_thinking = self._usage_metrics(body)
+
+        if output_text:
+            active.output_text = output_text
+        if tool_use_ids:
+            active.tool_use_ids = tool_use_ids
+        if has_thinking:
+            active.has_thinking = True
+        if stop_reason:
+            active.stop_reason = stop_reason
+
+        output_messages: List[Dict[str, Any]] = []
+        if output_text or tool_calls:
+            message: Dict[str, Any] = {"role": "assistant", "content": output_text}
+            if tool_calls:
+                message["tool_calls"] = tool_calls
+            output_messages.append(message)
+
+        now_ns = monotonic_wall_ns()
+        span = {
+            "span_id": _format_span_id(),
+            "trace_id": session.trace_id,
+            "parent_id": active.span_id,
+            "name": model or session.model or "gemini",
+            "status": "ok",
+            "start_ns": now_ns,
+            "duration": 1,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": self._append_common_tags(session, "source:gemini-hooks"),
+            "meta": {
+                "span": {"kind": "llm"},
+                "model_name": model or session.model,
+                "model_provider": _MODEL_PROVIDER,
+                "input": {"messages": input_messages},
+                "output": {"messages": output_messages},
+                "metadata": {"stop_reason": stop_reason},
+            },
+            "metrics": metrics,
+        }
+        self._append_span(span)
+        active.llm_count += 1
+
+    def _handle_before_tool(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._hooks_api._sessions.get(session_id)
+        if not session or not self._root_ref(session):
+            return
+
+        active = self._ensure_step(session)
+        tool_name = str(body.get("tool_name", "unknown_tool") or "unknown_tool")
+        tool_use_id = _extract_tool_use_id(body)
+        if not tool_use_id:
+            tool_use_id = _synthetic_tool_use_id(session_id, tool_name, len(session.pending_tools))
+            self._last_tool_use_ids[session_id] = tool_use_id
+
+        tool_input = body.get("tool_input")
+        if tool_input is None:
+            tool_input = {}
+
+        session.tools_used.add(tool_name)
+        span_id = _format_span_id()
+        session.pending_tools[tool_use_id] = PendingToolSpan(
+            span_id=span_id,
+            tool_name=tool_name,
+            tool_input=tool_input,
+            parent_id=active.span_id,
+            start_ns=monotonic_wall_ns(),
+        )
+
+    def _handle_after_tool(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._hooks_api._sessions.get(session_id)
+        if not session or not self._root_ref(session):
+            return
+
+        active = self._ensure_step(session)
+        tool_name = str(body.get("tool_name", "unknown_tool") or "unknown_tool")
+        tool_use_id = _extract_tool_use_id(body) or self._last_tool_use_ids.pop(session_id, "")
+        if not tool_use_id:
+            tool_use_id = _synthetic_tool_use_id(session_id, tool_name, len(session.pending_tools))
+
+        now_ns = monotonic_wall_ns()
+        pending = session.pending_tools.pop(tool_use_id, None)
+        if pending:
+            span_id = pending.span_id
+            parent_id = pending.parent_id
+            start_ns = pending.start_ns
+            input_value = _to_json_str(pending.tool_input) if pending.tool_input else ""
+            actual_tool_name = pending.tool_name
+        else:
+            span_id = _format_span_id()
+            parent_id = active.span_id
+            start_ns = now_ns
+            input_value = ""
+            actual_tool_name = tool_name
+
+        session.tools_used.add(actual_tool_name)
+        active.tool_count += 1
+        if tool_use_id not in active.tool_use_ids:
+            active.tool_use_ids.append(tool_use_id)
+
+        tool_error = str(body.get("tool_error", "") or "")
+        is_error = bool(tool_error)
+        output = body.get("tool_response", "")
+        output_value = _to_json_str(output) if output != "" else ""
+        if len(output_value) > _MAX_OUTPUT_SUMMARY_LEN:
+            output_value = output_value[:_MAX_OUTPUT_SUMMARY_LEN]
+        if is_error and len(tool_error) > _MAX_OUTPUT_SUMMARY_LEN:
+            tool_error = tool_error[:_MAX_OUTPUT_SUMMARY_LEN]
+
+        span: Dict[str, Any] = {
+            "span_id": span_id,
+            "trace_id": session.trace_id,
+            "parent_id": parent_id,
+            "name": actual_tool_name,
+            "status": "error" if is_error else "ok",
+            "start_ns": start_ns,
+            "duration": now_ns - start_ns,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": self._append_common_tags(session, "source:gemini-hooks") + [f"tool_name:{actual_tool_name}"],
+            "meta": {
+                "span": {"kind": "tool"},
+                "input": {"value": input_value},
+                "output": {"value": output_value},
+                "model_name": session.model,
+                "model_provider": _MODEL_PROVIDER,
+                "metadata": {"tool_id": tool_use_id},
+            },
+            "metrics": {},
+        }
+        if is_error:
+            span["meta"]["error"] = {"message": tool_error or output_value}
+
+        if session.pending_permission_at_ns is not None:
+            wait_ms = (now_ns - session.pending_permission_at_ns) // 1_000_000
+            session.pending_permission_at_ns = None
+            self._hooks_api._set_hidden_metadata(span, estimated_permission_wait_ms=wait_ms)
+            self._hooks_api._set_permission_wait_critical_evaluation(span, wait_ms)
+
+        self._append_span(span)
+
+    def _handle_after_agent(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            return
+        self._finalize_root(session, body)
+
+    def _handle_session_end(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            return
+        if not session.root_span_emitted and self._root_ref(session):
+            self._finalize_root(session, body, status="error", error_message=str(body.get("reason", "session ended")))
+        self._clear_turn_state(session_id)
+
+    def _handle_pre_compress(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            return
+        active = self._active_steps.get(session_id)
+        span_ref = active.span_ref if active else self._root_ref(session)
+        if span_ref is None:
+            return
+        dd = span_ref.setdefault("meta", {}).setdefault("metadata", {}).setdefault("_dd", {})
+        dd.setdefault("compactions", []).append(
+            {
+                "trigger": body.get("trigger", ""),
+                "transcript_path": body.get("transcript_path", ""),
+            }
+        )
+
+    def _handle_notification(self, session_id: str, body: Dict[str, Any]) -> None:
+        session = self._hooks_api._sessions.get(session_id)
+        if not session:
+            return
+        notification_type = str(body.get("notification_type", "") or "").lower()
+        if "permission" in notification_type or "tool" in notification_type:
+            session.pending_permission_at_ns = monotonic_wall_ns()
+
+    _HANDLERS: Dict[str, str] = {
+        "SessionStart": "_handle_session_start",
+        "SessionEnd": "_handle_session_end",
+        "BeforeAgent": "_handle_before_agent",
+        "AfterAgent": "_handle_after_agent",
+        "AfterModel": "_handle_after_model",
+        "BeforeTool": "_handle_before_tool",
+        "AfterTool": "_handle_after_tool",
+        "PreCompress": "_handle_pre_compress",
+        "Notification": "_handle_notification",
+    }
+
+    def _dispatch(self, event_type: str, body: Dict[str, Any]) -> None:
+        session_id = str(body.get("session_id", "") or "")
+        handler_name = self._HANDLERS.get(event_type)
+        if handler_name:
+            handler = getattr(self, handler_name)
+            handler(session_id, body)
+        else:
+            log.debug("Unhandled Gemini hook event: %s", event_type)
+
+    # ------------------------------------------------------------------
+    # HTTP handlers
+    # ------------------------------------------------------------------
+
+    async def handle_hook(self, request: Request) -> web.Response:
+        """Handle Gemini hook payloads.
+
+        Supports both ``POST /gemini/hooks/{event_type}`` and
+        ``POST /gemini/hooks`` with ``hook_event_name`` in the JSON body.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+
+        event_type = request.match_info.get("event_type") or body.get("hook_event_name") or body.get("event_type")
+        if not isinstance(event_type, str) or not event_type:
+            return web.json_response({"error": "missing event_type"}, status=400)
+        if event_type not in self._HANDLERS:
+            return web.json_response({"error": f"unknown event_type: {event_type}"}, status=400)
+
+        session_id = body.get("session_id", "")
+        if not session_id:
+            return web.json_response({"error": "missing session_id"}, status=400)
+
+        body["hook_event_name"] = event_type
+        self._raw_events.append(body)
+        self._dispatch(event_type, body)
+
+        if event_type in ("AfterAgent", "SessionEnd"):
+            await self._hooks_api._forward_trace_to_backend(str(session_id))
+            await self._hooks_api._forward_eval_metrics_to_backend(str(session_id))
+
+        return web.json_response({"status": "ok"})
+
+    async def handle_raw_events(self, request: Request) -> web.Response:
+        """Handle GET /gemini/hooks/raw."""
+        return web.json_response({"events": self._raw_events})
+
+    async def handle_sessions(self, request: Request) -> web.Response:
+        """Handle GET /gemini/hooks/sessions."""
+        sessions = []
+        for sid, state in self._hooks_api._sessions.items():
+            sessions.append(
+                {
+                    "session_id": sid,
+                    "trace_id": state.trace_id,
+                    "root_span_id": state.root_span_id,
+                    "num_prompts": len(state.user_prompts),
+                    "pending_tools": len(state.pending_tools),
+                    "active_step": sid in self._active_steps,
+                    "models": state.models,
+                }
+            )
+        return web.json_response({"sessions": sessions})
+
+    async def handle_spans(self, request: Request) -> web.Response:
+        """Handle GET /gemini/hooks/spans."""
+        return web.json_response({"spans": self._hooks_api._assembled_spans})
+
+    def get_routes(self) -> List[web.RouteDef]:
+        """Return Gemini hook routes."""
+        return [
+            web.post("/gemini/hooks", with_cors(self.handle_hook)),
+            web.post("/gemini/hooks/{event_type}", with_cors(self.handle_hook)),
+            web.post("/capture/gemini/{event_type}", with_cors(self.handle_hook)),
+            web.route("*", "/gemini/hooks/raw", with_cors(self.handle_raw_events)),
+            web.route("*", "/gemini/hooks/sessions", with_cors(self.handle_sessions)),
+            web.route("*", "/gemini/hooks/spans", with_cors(self.handle_spans)),
+        ]
+
+
+def _int_value(value: Any) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value))
+        except ValueError:
+            return 0
+    return 0
+
+
+def _gemini_role(role: Any) -> str:
+    if role == "model":
+        return "assistant"
+    if role == "function":
+        return "tool"
+    if isinstance(role, str) and role:
+        return role
+    return "user"
+
+
+def _gemini_content_to_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        text, _tool_calls, _tool_id = _gemini_parts_to_text_and_tools(value.get("parts", []))
+        return text
+    return ""
+
+
+def _gemini_parts_to_text_and_tools(parts: Any) -> Tuple[str, List[Dict[str, Any]], str]:
+    if not isinstance(parts, list):
+        return "", [], ""
+
+    text_parts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
+    tool_id = ""
+
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            text_parts.append(text)
+            continue
+
+        function_call = part.get("functionCall")
+        if isinstance(function_call, dict):
+            name = str(function_call.get("name", "") or "")
+            args = function_call.get("args")
+            if not isinstance(args, dict):
+                args = {}
+            call_id = str(function_call.get("id", "") or "")
+            if not call_id:
+                call_id = _synthetic_tool_use_id("gemini", name, len(tool_calls))
+            tool_calls.append({"name": name, "arguments": args, "tool_id": call_id, "type": "tool_use"})
+            continue
+
+        function_response = part.get("functionResponse")
+        if isinstance(function_response, dict):
+            tool_id = str(function_response.get("id", "") or "")
+            response = function_response.get("response")
+            if response is not None:
+                text_parts.append(_to_json_str(response))
+
+    return "\n".join(text_parts), tool_calls, tool_id
+
+
+def _extract_tool_use_id(body: Dict[str, Any]) -> str:
+    for key in ("tool_use_id", "tool_call_id", "id"):
+        value = body.get(key)
+        if isinstance(value, str) and value:
+            return value
+    mcp_context = body.get("mcp_context")
+    if isinstance(mcp_context, dict):
+        value = mcp_context.get("tool_use_id")
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _synthetic_tool_use_id(session_id: str, tool_name: str, index: int) -> str:
+    safe_tool = tool_name.replace(" ", "_") or "tool"
+    return f"gemini-{session_id}-{safe_tool}-{index}"

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -1,16 +1,14 @@
 """CLI for lapdog subcommands"""
 
 import argparse
-import json
 import os
+import pkgutil
 from pathlib import Path
 import shutil
 import signal
 import subprocess
 import sys
 import time
-from typing import Any
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -397,65 +395,31 @@ def cmd_pi(sub_cmd_args: List[str], forward_data: bool) -> None:
 # Gemini extension management
 # ---------------------------------------------------------------------------
 
-_GEMINI_EVENTS = [
-    ("SessionStart", ""),
-    ("BeforeAgent", ""),
-    ("AfterModel", ""),
-    ("BeforeTool", "*"),
-    ("AfterTool", "*"),
-    ("AfterAgent", ""),
-    ("SessionEnd", ""),
-    ("PreCompress", ""),
-    ("Notification", ""),
-]
 _GEMINI_EXTENSION_DIR = os.path.expanduser("~/.lapdog/gemini-extension")
+_GEMINI_EXTENSION_TEMPLATE_FILES = {
+    "gemini_extension/gemini-extension.json": "gemini-extension.json",
+    "gemini_extension/hooks/hooks.json.template": "hooks/hooks.json",
+    "gemini_extension/plugin/lapdog-gemini/GEMINI.md": "plugin/lapdog-gemini/GEMINI.md",
+}
+_GEMINI_URL_PLACEHOLDER = "{{LAPDOG_URL}}"
 
 
-def _gemini_hook_command(port: int, event: str) -> str:
-    return (
-        "curl -sS -X POST -H 'Content-Type: application/json' "
-        f"-d @- http://localhost:{port}/gemini/hooks/{event} >/dev/null 2>&1 || true"
-    )
+def _gemini_extension_resource_text(resource_path: str) -> str:
+    data = pkgutil.get_data("lapdog", resource_path)
+    if data is None:
+        print(f"[lapdog] Gemini extension resource not found: {resource_path}", file=sys.stderr)
+        sys.exit(1)
+    return data.decode("utf-8")
 
 
 def _write_gemini_extension(extension_dir: str, port: int) -> None:
-    os.makedirs(os.path.join(extension_dir, "hooks"), exist_ok=True)
-    os.makedirs(os.path.join(extension_dir, "plugin", "lapdog-gemini"), exist_ok=True)
-
-    extension = {
-        "name": "lapdog",
-        "version": "1.0.0",
-        "contextFileName": "plugin/lapdog-gemini/GEMINI.md",
-        "settings": [],
-    }
-    with open(os.path.join(extension_dir, "gemini-extension.json"), "w") as f:
-        json.dump(extension, f, indent=2)
-        f.write("\n")
-
-    hooks: Dict[str, Any] = {"hooks": {}}
-    for event, matcher in _GEMINI_EVENTS:
-        hooks["hooks"][event] = [
-            {
-                "matcher": matcher,
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": _gemini_hook_command(port, event),
-                        "timeout": 15000 if event == "SessionEnd" else 5000,
-                    }
-                ],
-            }
-        ]
-    with open(os.path.join(extension_dir, "hooks", "hooks.json"), "w") as f:
-        json.dump(hooks, f, indent=2)
-        f.write("\n")
-
-    with open(os.path.join(extension_dir, "plugin", "lapdog-gemini", "GEMINI.md"), "w") as f:
-        f.write(
-            "# Lapdog\n\n"
-            "Lapdog is capturing this Gemini CLI session for local Datadog LLM Observability.\n"
-            "Use `lapdog status` to check whether the local capture agent is running.\n"
-        )
+    lapdog_url = f"http://localhost:{port}"
+    for resource_path, output_path in _GEMINI_EXTENSION_TEMPLATE_FILES.items():
+        content = _gemini_extension_resource_text(resource_path).replace(_GEMINI_URL_PLACEHOLDER, lapdog_url)
+        destination = os.path.join(extension_dir, output_path)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination, "w") as f:
+            f.write(content)
 
 
 def _install_gemini_extension(port: int) -> None:

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -1,6 +1,7 @@
 """CLI for lapdog subcommands"""
 
 import argparse
+import json
 import os
 from pathlib import Path
 import shutil
@@ -8,6 +9,8 @@ import signal
 import subprocess
 import sys
 import time
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -20,7 +23,7 @@ from lapdog.hooks import write_claude_code_hooks
 from lapdog.paths import LOG_FILE, PID_FILE
 from lapdog import tracer_inject
 
-LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi"]
+LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "gemini"]
 LAPDOG_USAGE = (
     "Usage: lapdog [OPTIONS] <command> [command-args...]\n"
     "Options must appear before <command>. Arguments after <command> are forwarded.\n"
@@ -29,6 +32,7 @@ LAPDOG_USAGE = (
     "  status  Show lapdog status (from /info)\n"
     "  claude  Start lapdog in background if needed, then launch Claude with intercept\n"
     "  pi      Start lapdog in background if needed, install extension, then launch pi\n"
+    "  gemini  Start lapdog in background if needed, install extension, then launch Gemini\n"
     "\n"
     "Any other command is treated as an app to run with tracing instrumentation:\n"
     "  lapdog python app.py\n"
@@ -52,11 +56,11 @@ def _resolved_port(cli_args: Optional[List[str]] = None) -> int:
 
 
 def _pid_file_path() -> str:
-    return os.environ.get("LAPDOG_PID_FILE", PID_FILE)
+    return str(os.environ.get("LAPDOG_PID_FILE", PID_FILE))
 
 
 def _log_file_path() -> str:
-    return os.environ.get("LAPDOG_LOG_FILE", LOG_FILE)
+    return str(os.environ.get("LAPDOG_LOG_FILE", LOG_FILE))
 
 
 def _url_for_port(port: int) -> str:
@@ -389,6 +393,115 @@ def cmd_pi(sub_cmd_args: List[str], forward_data: bool) -> None:
     _run_pi(args=sub_cmd_args, port=port)
 
 
+# ---------------------------------------------------------------------------
+# Gemini extension management
+# ---------------------------------------------------------------------------
+
+_GEMINI_EVENTS = [
+    ("SessionStart", ""),
+    ("BeforeAgent", ""),
+    ("AfterModel", ""),
+    ("BeforeTool", "*"),
+    ("AfterTool", "*"),
+    ("AfterAgent", ""),
+    ("SessionEnd", ""),
+    ("PreCompress", ""),
+    ("Notification", ""),
+]
+_GEMINI_EXTENSION_DIR = os.path.expanduser("~/.lapdog/gemini-extension")
+
+
+def _gemini_hook_command(port: int, event: str) -> str:
+    return (
+        "curl -sS -X POST -H 'Content-Type: application/json' "
+        f"-d @- http://localhost:{port}/gemini/hooks/{event} >/dev/null 2>&1 || true"
+    )
+
+
+def _write_gemini_extension(extension_dir: str, port: int) -> None:
+    os.makedirs(os.path.join(extension_dir, "hooks"), exist_ok=True)
+    os.makedirs(os.path.join(extension_dir, "plugin", "lapdog-gemini"), exist_ok=True)
+
+    extension = {
+        "name": "lapdog",
+        "version": "1.0.0",
+        "contextFileName": "plugin/lapdog-gemini/GEMINI.md",
+        "settings": [],
+    }
+    with open(os.path.join(extension_dir, "gemini-extension.json"), "w") as f:
+        json.dump(extension, f, indent=2)
+        f.write("\n")
+
+    hooks: Dict[str, Any] = {"hooks": {}}
+    for event, matcher in _GEMINI_EVENTS:
+        hooks["hooks"][event] = [
+            {
+                "matcher": matcher,
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": _gemini_hook_command(port, event),
+                        "timeout": 15000 if event == "SessionEnd" else 5000,
+                    }
+                ],
+            }
+        ]
+    with open(os.path.join(extension_dir, "hooks", "hooks.json"), "w") as f:
+        json.dump(hooks, f, indent=2)
+        f.write("\n")
+
+    with open(os.path.join(extension_dir, "plugin", "lapdog-gemini", "GEMINI.md"), "w") as f:
+        f.write(
+            "# Lapdog\n\n"
+            "Lapdog is capturing this Gemini CLI session for local Datadog LLM Observability.\n"
+            "Use `lapdog status` to check whether the local capture agent is running.\n"
+        )
+
+
+def _install_gemini_extension(port: int) -> None:
+    gemini_bin = shutil.which("gemini")
+    if not gemini_bin:
+        print("[lapdog] 'gemini' not found in PATH", file=sys.stderr)
+        sys.exit(1)
+
+    _write_gemini_extension(_GEMINI_EXTENSION_DIR, port)
+    proc = subprocess.run(
+        [gemini_bin, "extensions", "install", _GEMINI_EXTENSION_DIR, "--consent", "--skip-settings"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        if proc.stdout:
+            print(proc.stdout, file=sys.stderr)
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr)
+        print(f"[lapdog] Failed to install Gemini extension from {_GEMINI_EXTENSION_DIR}", file=sys.stderr)
+        sys.exit(proc.returncode)
+
+
+def _run_gemini(args: Optional[List[str]] = None, port: Optional[int] = 8126) -> None:
+    """Exec the gemini binary, forwarding arguments. Never returns."""
+    if args is None:
+        args = []
+    gemini_bin = shutil.which("gemini")
+    if not gemini_bin:
+        print("[lapdog] 'gemini' not found in PATH", file=sys.stderr)
+        sys.exit(1)
+    env = {**os.environ, "LAPDOG_URL": f"http://localhost:{port}"}
+    os.execve(gemini_bin, [gemini_bin] + args, env)
+
+
+def cmd_gemini(sub_cmd_args: List[str], forward_data: bool) -> None:
+    """Ensure lapdog is running, install the Gemini extension, then launch Gemini."""
+    port = _ensure_lapdog_running(forward_data, detached=True)
+    _install_gemini_extension(port or 8126)
+
+    print(build_running_banner(data_type="coding session"))
+    _run_gemini(args=sub_cmd_args, port=port)
+
+
 def _parse_command(cmd_args: List[str]) -> Tuple[List[str], List[str]]:
     lapdog_args: List[str] = []
 
@@ -466,3 +579,5 @@ def main() -> None:
         )
     elif sub_cmd == "pi":
         cmd_pi(sub_cmd_args=sub_cmd_args, forward_data=lapdog_parsed_args.forward)
+    elif sub_cmd == "gemini":
+        cmd_gemini(sub_cmd_args=sub_cmd_args, forward_data=lapdog_parsed_args.forward)

--- a/lapdog/gemini_extension/gemini-extension.json
+++ b/lapdog/gemini_extension/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "lapdog",
+  "version": "1.0.0",
+  "contextFileName": "plugin/lapdog-gemini/GEMINI.md",
+  "settings": []
+}

--- a/lapdog/gemini_extension/hooks/hooks.json.template
+++ b/lapdog/gemini_extension/hooks/hooks.json.template
@@ -1,0 +1,112 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/SessionStart >/dev/null 2>&1 || true",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/BeforeAgent >/dev/null 2>&1 || true",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "AfterModel": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/AfterModel >/dev/null 2>&1 || true",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "BeforeTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/BeforeTool >/dev/null 2>&1 || true",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/AfterTool >/dev/null 2>&1 || true",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/AfterAgent >/dev/null 2>&1 || true",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/SessionEnd >/dev/null 2>&1 || true",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
+    "PreCompress": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/PreCompress >/dev/null 2>&1 || true",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sS -X POST -H 'Content-Type: application/json' -d @- {{LAPDOG_URL}}/gemini/hooks/Notification >/dev/null 2>&1 || true",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/lapdog/gemini_extension/plugin/lapdog-gemini/GEMINI.md
+++ b/lapdog/gemini_extension/plugin/lapdog-gemini/GEMINI.md
@@ -1,0 +1,4 @@
+# Lapdog
+
+Lapdog is capturing this Gemini CLI session for local Datadog LLM Observability.
+Use `lapdog status` to check whether the local capture agent is running.

--- a/releasenotes/notes/gemini-cli-hooks-b83774b9f772707a.yaml
+++ b/releasenotes/notes/gemini-cli-hooks-b83774b9f772707a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add Gemini CLI hook support for lapdog. Gemini command hooks can now be
+    received by the test agent and assembled into LLM Observability traces.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,15 @@ setup(
     packages=find_packages(exclude=["tests*", "releasenotes", "scripts"]),
     package_data={
         "ddapm_test_agent": ["py.typed", "templates/*", "static/*",],
-        "lapdog": ["py.typed", "claude_intercept.mjs", "pi_lapdog_extension.ts", "bootstrap/*"],
+        "lapdog": [
+            "py.typed",
+            "claude_intercept.mjs",
+            "pi_lapdog_extension.ts",
+            "bootstrap/*",
+            "gemini_extension/*",
+            "gemini_extension/hooks/*",
+            "gemini_extension/plugin/lapdog-gemini/*",
+        ],
     },
     python_requires=">=3.8",
     install_requires=[

--- a/tests/fixtures/claude_minimal_tool_session.json
+++ b/tests/fixtures/claude_minimal_tool_session.json
@@ -1,0 +1,45 @@
+{
+  "metadata": {
+    "source": "trajectory/trajectory/serve/testdata/harness-profiles/claude-code/minimal-tool-session/raw-events.jsonl",
+    "notes": "Claude Code hook fixture used as the semantic baseline for a minimal read-tool session."
+  },
+  "events": [
+    {
+      "hook_event_name": "SessionStart",
+      "session_id": "claude-code-fixture-minimal-tool-session",
+      "source": "startup",
+      "cwd": "/workspace/fixture-repo",
+      "model": "claude-sonnet-4-5",
+      "version": "2.0.0-fixture"
+    },
+    {
+      "hook_event_name": "UserPromptSubmit",
+      "session_id": "claude-code-fixture-minimal-tool-session",
+      "prompt": "Inspect README.md and summarize the test fixture.",
+      "model": "claude-sonnet-4-5"
+    },
+    {
+      "hook_event_name": "PreToolUse",
+      "session_id": "claude-code-fixture-minimal-tool-session",
+      "tool_use_id": "toolu_fixture_read_1",
+      "tool_name": "Read",
+      "tool_input": {
+        "file_path": "README.md"
+      }
+    },
+    {
+      "hook_event_name": "PostToolUse",
+      "session_id": "claude-code-fixture-minimal-tool-session",
+      "tool_use_id": "toolu_fixture_read_1",
+      "tool_name": "Read",
+      "tool_response": {
+        "content": "# Fixture Repo\nHarness profile example.\n"
+      }
+    },
+    {
+      "hook_event_name": "SessionEnd",
+      "session_id": "claude-code-fixture-minimal-tool-session",
+      "exit_reason": "normal"
+    }
+  ]
+}

--- a/tests/fixtures/gemini_real_tool_session.json
+++ b/tests/fixtures/gemini_real_tool_session.json
@@ -1,0 +1,430 @@
+{
+  "metadata": {
+    "captured_with": "gemini-cli 0.38.2",
+    "captured_at": "2026-05-15T19:59:00-04:00",
+    "capture_command": "gemini --approval-mode yolo --allowed-tools run_shell_command,read_file -p <prompt>",
+    "sanitized_fields": ["session_id", "timestamp", "transcript_path"],
+    "notes": "Captured from a real headless Gemini CLI run. Long repeated context text was shortened, but event names, field names, tool names, and payload shapes match the captured events."
+  },
+  "events": [
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "SessionStart",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "source": "startup"
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "BeforeAgent",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "prompt": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done"
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "PreCompress",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "trigger": "auto"
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterModel",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "llm_request": {
+        "model": "gemini-3-flash-preview",
+        "messages": [
+          {
+            "role": "user",
+            "content": "<session_context>Workspace /private/tmp/lapdog-gemini-real-fixture contains README.md.</session_context>"
+          },
+          {
+            "role": "user",
+            "content": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done"
+          }
+        ],
+        "config": {
+          "temperature": 1,
+          "topP": 0.95,
+          "topK": 64
+        }
+      },
+      "llm_response": {
+        "text": "I will now execute `pwd` and read the `README.md` file",
+        "candidates": [
+          {
+            "content": {
+              "role": "model",
+              "parts": ["I will now execute `pwd` and read the `README.md` file"]
+            }
+          }
+        ],
+        "usageMetadata": {}
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterModel",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "llm_request": {
+        "model": "gemini-3-flash-preview",
+        "messages": [
+          {
+            "role": "user",
+            "content": "<session_context>Workspace /private/tmp/lapdog-gemini-real-fixture contains README.md.</session_context>"
+          },
+          {
+            "role": "user",
+            "content": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done"
+          }
+        ],
+        "config": {
+          "temperature": 1,
+          "topP": 0.95,
+          "topK": 64
+        }
+      },
+      "llm_response": {
+        "text": ".\n",
+        "candidates": [
+          {
+            "content": {
+              "role": "model",
+              "parts": [".\n"]
+            }
+          }
+        ],
+        "usageMetadata": {}
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterModel",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "llm_request": {
+        "model": "gemini-3-flash-preview",
+        "messages": [
+          {
+            "role": "user",
+            "content": "<session_context>Workspace /private/tmp/lapdog-gemini-real-fixture contains README.md.</session_context>"
+          },
+          {
+            "role": "user",
+            "content": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done"
+          }
+        ],
+        "config": {
+          "temperature": 1,
+          "topP": 0.95,
+          "topK": 64
+        }
+      },
+      "llm_response": {
+        "text": "",
+        "candidates": [
+          {
+            "content": {
+              "role": "model",
+              "parts": []
+            }
+          }
+        ],
+        "usageMetadata": {}
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterModel",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "llm_request": {
+        "model": "gemini-3-flash-preview",
+        "messages": [
+          {
+            "role": "user",
+            "content": "<session_context>Workspace /private/tmp/lapdog-gemini-real-fixture contains README.md.</session_context>"
+          },
+          {
+            "role": "user",
+            "content": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done"
+          }
+        ],
+        "config": {
+          "temperature": 1,
+          "topP": 0.95,
+          "topK": 64
+        }
+      },
+      "llm_response": {
+        "text": "",
+        "candidates": [
+          {
+            "content": {
+              "role": "model",
+              "parts": []
+            }
+          }
+        ],
+        "usageMetadata": {}
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterModel",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "llm_request": {
+        "model": "gemini-3-flash-preview",
+        "messages": [
+          {
+            "role": "user",
+            "content": "<session_context>Workspace /private/tmp/lapdog-gemini-real-fixture contains README.md.</session_context>"
+          },
+          {
+            "role": "user",
+            "content": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done"
+          }
+        ],
+        "config": {
+          "temperature": 1,
+          "topP": 0.95,
+          "topK": 64
+        }
+      },
+      "llm_response": {
+        "text": "",
+        "candidates": [
+          {
+            "content": {
+              "role": "model",
+              "parts": [""]
+            },
+            "finishReason": "STOP"
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 17167,
+          "candidatesTokenCount": 67,
+          "totalTokenCount": 17234
+        }
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "BeforeTool",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "tool_name": "read_file",
+      "tool_input": {
+        "file_path": "README.md"
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "BeforeTool",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "tool_name": "run_shell_command",
+      "tool_input": {
+        "command": "pwd",
+        "description": "Getting the current working directory."
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterTool",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "tool_name": "read_file",
+      "tool_input": {
+        "file_path": "README.md"
+      },
+      "tool_response": {
+        "llmContent": "# Fixture Repo\nLapdog Gemini real tool fixture.\n",
+        "returnDisplay": ""
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterTool",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "tool_name": "run_shell_command",
+      "tool_input": {
+        "command": "pwd",
+        "description": "Getting the current working directory."
+      },
+      "tool_response": {
+        "llmContent": "Output: /private/tmp/lapdog-gemini-real-fixture\nProcess Group PGID: 93841",
+        "returnDisplay": [
+          [
+            {
+              "text": "/private/tmp/lapdog-gemini-real-fixture                                         ",
+              "bold": false,
+              "italic": false,
+              "underline": false,
+              "dim": false,
+              "inverse": false,
+              "isUninitialized": true,
+              "fg": "",
+              "bg": ""
+            }
+          ],
+          [
+            {
+              "text": " ",
+              "bold": false,
+              "italic": false,
+              "underline": false,
+              "dim": false,
+              "inverse": true,
+              "isUninitialized": true,
+              "fg": "",
+              "bg": ""
+            },
+            {
+              "text": "                                                                               ",
+              "bold": false,
+              "italic": false,
+              "underline": false,
+              "dim": false,
+              "inverse": false,
+              "isUninitialized": true,
+              "fg": "",
+              "bg": ""
+            }
+          ]
+        ]
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "PreCompress",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "trigger": "auto"
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterModel",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "llm_request": {
+        "model": "gemini-3-flash-preview",
+        "messages": [
+          {
+            "role": "user",
+            "content": "<session_context>Workspace /private/tmp/lapdog-gemini-real-fixture contains README.md.</session_context>"
+          },
+          {
+            "role": "user",
+            "content": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done"
+          },
+          {
+            "role": "model",
+            "content": "I will now execute `pwd` and read the `README.md` file.\n"
+          }
+        ],
+        "config": {
+          "temperature": 1,
+          "topP": 0.95,
+          "topK": 64
+        }
+      },
+      "llm_response": {
+        "text": "real-fixture-done",
+        "candidates": [
+          {
+            "content": {
+              "role": "model",
+              "parts": ["real-fixture-done"]
+            }
+          }
+        ],
+        "usageMetadata": {}
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterModel",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "llm_request": {
+        "model": "gemini-3-flash-preview",
+        "messages": [
+          {
+            "role": "user",
+            "content": "<session_context>Workspace /private/tmp/lapdog-gemini-real-fixture contains README.md.</session_context>"
+          },
+          {
+            "role": "user",
+            "content": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done"
+          },
+          {
+            "role": "model",
+            "content": "I will now execute `pwd` and read the `README.md` file.\n"
+          }
+        ],
+        "config": {
+          "temperature": 1,
+          "topP": 0.95,
+          "topK": 64
+        }
+      },
+      "llm_response": {
+        "text": "",
+        "candidates": [
+          {
+            "content": {
+              "role": "model",
+              "parts": [""]
+            },
+            "finishReason": "STOP"
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 17275,
+          "candidatesTokenCount": 5,
+          "totalTokenCount": 17280
+        }
+      }
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "AfterAgent",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "prompt": "You must call the run_shell_command tool with command 'pwd'. Then call the read_file tool on README.md. Do not answer until both tool results return. After both tools answer exactly: real-fixture-done",
+      "prompt_response": "I will now execute `pwd` and read the `README.md` file.\n .\n   \nreal-fixture-done ",
+      "stop_hook_active": false
+    },
+    {
+      "session_id": "gemini-real-tool-session",
+      "transcript_path": "/tmp/gemini/chats/session.json",
+      "cwd": "/private/tmp/lapdog-gemini-real-fixture",
+      "hook_event_name": "SessionEnd",
+      "timestamp": "2026-05-15T19:59:00.000Z",
+      "reason": "exit"
+    }
+  ]
+}

--- a/tests/test_gemini_hooks.py
+++ b/tests/test_gemini_hooks.py
@@ -229,6 +229,42 @@ async def test_gemini_active_turn_keeps_root_duration_zero_for_live_badge(agent,
     assert data["result"]["events"][0]["event"]["custom"]["duration"] == 4_000_000_000
 
 
+async def test_gemini_same_tick_finalization_exits_live_badge(agent, monkeypatch):
+    now = {"ns": 1_000_000_000}
+    monkeypatch.setattr("ddapm_test_agent.claude_hooks.monotonic_wall_ns", lambda: now["ns"])
+    monkeypatch.setattr("ddapm_test_agent.gemini_hooks.monotonic_wall_ns", lambda: now["ns"])
+
+    sid = "gemini-same-tick-finalized"
+    await _post(agent, "SessionStart", _session_start(sid))
+    await _post(agent, "BeforeAgent", _before_agent(sid, "finish immediately"))
+    await _post(agent, "AfterModel", _after_model(sid, output_text="done"))
+
+    resp = await agent.get("/gemini/hooks/spans")
+    assert resp.status == 200
+    spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+    root = [s for s in spans if s["parent_id"] == "undefined"][0]
+    assert root["duration"] == 0
+    trace_id = root["trace_id"]
+
+    await _post(agent, "AfterAgent", _after_agent(sid, "done"))
+
+    resp = await agent.get("/gemini/hooks/spans")
+    assert resp.status == 200
+    spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+    root = [s for s in spans if s["parent_id"] == "undefined"][0]
+    step = _by_kind(spans, "step")[0]
+    assert root["duration"] == 1
+    assert step["duration"] == 1
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": f"@trace_id:{trace_id} @parent_id:undefined"}, "limit": 50}},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["result"]["events"][0]["event"]["custom"]["duration"] == 1
+
+
 def test_gemini_real_tool_fixture_matches_current_cli_shape():
     fixture = _load_fixture("gemini_real_tool_session.json")
     events = fixture["events"]

--- a/tests/test_gemini_hooks.py
+++ b/tests/test_gemini_hooks.py
@@ -187,6 +187,48 @@ async def test_gemini_full_turn_with_tool(agent):
     assert tool["meta"]["metadata"]["_dd"]["estimated_permission_wait_ms"] >= 0
 
 
+async def test_gemini_active_turn_keeps_root_duration_zero_for_live_badge(agent, monkeypatch):
+    now = {"ns": 1_000_000_000}
+    monkeypatch.setattr("ddapm_test_agent.claude_hooks.monotonic_wall_ns", lambda: now["ns"])
+    monkeypatch.setattr("ddapm_test_agent.gemini_hooks.monotonic_wall_ns", lambda: now["ns"])
+
+    sid = "gemini-live-root-duration"
+    await _post(agent, "SessionStart", _session_start(sid))
+    await _post(agent, "BeforeAgent", _before_agent(sid, "Keep the trace live"))
+
+    resp = await agent.get("/gemini/hooks/spans")
+    assert resp.status == 200
+    spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+    root = [s for s in spans if s["parent_id"] == "undefined"][0]
+    assert root["duration"] == 0
+    trace_id = root["trace_id"]
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": f"@trace_id:{trace_id} @parent_id:undefined"}, "limit": 50}},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["result"]["events"][0]["event"]["custom"]["duration"] == 0
+
+    resp = await agent.get(f"/api/ui/llm-obs/v1/trace/{trace_id}")
+    assert resp.status == 200
+    data = await resp.json()
+    attrs = data["data"]["attributes"]
+    assert attrs["spans"][attrs["root_id"]]["duration"] == 0
+
+    now["ns"] = 5_000_000_000
+    await _post(agent, "AfterAgent", _after_agent(sid, "done"))
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": f"@trace_id:{trace_id} @parent_id:undefined"}, "limit": 50}},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["result"]["events"][0]["event"]["custom"]["duration"] == 4_000_000_000
+
+
 def test_gemini_real_tool_fixture_matches_current_cli_shape():
     fixture = _load_fixture("gemini_real_tool_session.json")
     events = fixture["events"]

--- a/tests/test_gemini_hooks.py
+++ b/tests/test_gemini_hooks.py
@@ -1,0 +1,235 @@
+"""Tests for Gemini CLI hook ingestion."""
+
+import json
+
+
+async def _post(agent, event_type, payload):
+    return await agent.post(
+        f"/gemini/hooks/{event_type}",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps(payload),
+    )
+
+
+def _spans(body):
+    return body["spans"]
+
+
+def _by_kind(spans, kind):
+    return [s for s in spans if s.get("meta", {}).get("span", {}).get("kind") == kind]
+
+
+def _session_start(session_id):
+    return {"session_id": session_id, "source": "startup", "cwd": "/tmp/project"}
+
+
+def _before_agent(session_id, prompt="Explain the repo"):
+    return {"session_id": session_id, "prompt": prompt}
+
+
+def _after_model(
+    session_id,
+    *,
+    model="gemini-2.5-pro",
+    output_text="",
+    tool_call=None,
+    prompt_tokens=150,
+    output_tokens=75,
+    thought_tokens=25,
+    finish_reason="STOP",
+):
+    parts = []
+    if output_text:
+        parts.append({"text": output_text})
+    if tool_call:
+        parts.append({"functionCall": tool_call})
+    return {
+        "session_id": session_id,
+        "llm_request": {
+            "model": model,
+            "contents": [{"role": "user", "parts": [{"text": "Explain the repo"}]}],
+        },
+        "llm_response": {
+            "candidates": [
+                {
+                    "finishReason": finish_reason,
+                    "content": {"role": "model", "parts": parts},
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": prompt_tokens,
+                "candidatesTokenCount": output_tokens,
+                "thoughtsTokenCount": thought_tokens,
+                "cachedContentTokenCount": 10,
+            },
+        },
+    }
+
+
+def _before_tool(session_id, tool_use_id="tool-1", tool_name="read_file"):
+    return {
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "tool_input": {"file_path": "README.md"},
+        "mcp_context": {"tool_use_id": tool_use_id},
+    }
+
+
+def _after_tool(session_id, tool_use_id="tool-1", tool_name="read_file", response="contents", error=""):
+    body = {
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "tool_response": response,
+        "mcp_context": {"tool_use_id": tool_use_id},
+    }
+    if error:
+        body["tool_error"] = error
+    return body
+
+
+def _after_agent(session_id, response="Done"):
+    return {"session_id": session_id, "prompt_response": response}
+
+
+async def test_gemini_full_turn_with_tool(agent):
+    sid = "gemini-full-turn"
+    await _post(agent, "SessionStart", _session_start(sid))
+    await _post(agent, "BeforeAgent", _before_agent(sid))
+    await _post(
+        agent,
+        "AfterModel",
+        _after_model(
+            sid,
+            tool_call={"id": "tool-1", "name": "read_file", "args": {"file_path": "README.md"}},
+            finish_reason="TOOL_CALL",
+        ),
+    )
+    await _post(agent, "BeforeTool", _before_tool(sid))
+    await _post(
+        agent,
+        "Notification",
+        {"session_id": sid, "notification_type": "tool_permission_requested", "message": "Allow read_file?"},
+    )
+    await _post(agent, "AfterTool", _after_tool(sid))
+    await _post(agent, "AfterAgent", _after_agent(sid, "The repo is a test agent."))
+
+    resp = await agent.get("/gemini/hooks/spans")
+    assert resp.status == 200
+    spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+
+    roots = [s for s in spans if s["parent_id"] == "undefined"]
+    steps = _by_kind(spans, "step")
+    llms = _by_kind(spans, "llm")
+    tools = _by_kind(spans, "tool")
+
+    assert len(roots) == 1
+    assert len(steps) == 1
+    assert len(llms) == 1
+    assert len(tools) == 1
+
+    root = roots[0]
+    step = steps[0]
+    llm = llms[0]
+    tool = tools[0]
+
+    assert root["name"] == "gemini-request"
+    assert "source:gemini-hooks" in root["tags"]
+    assert "trajectory.semantic_type:turn" in root["tags"]
+    assert root["meta"]["input"]["value"] == "Explain the repo"
+    assert root["meta"]["output"]["value"] == "The repo is a test agent."
+    assert root["meta"]["model_provider"] == "google"
+
+    assert step["parent_id"] == root["span_id"]
+    assert llm["parent_id"] == step["span_id"]
+    assert tool["parent_id"] == step["span_id"]
+    assert step["meta"]["metadata"]["tool_use_ids"] == ["tool-1"]
+    assert step["meta"]["metadata"]["has_thinking"] is True
+
+    assert llm["name"] == "gemini-2.5-pro"
+    assert llm["meta"]["model_provider"] == "google"
+    assert llm["metrics"]["input_tokens"] == 150
+    assert llm["metrics"]["output_tokens"] == 75
+    assert llm["metrics"]["reasoning_tokens"] == 25
+    assert llm["metrics"]["cache_read_input_tokens"] == 10
+    assert llm["meta"]["output"]["messages"][0]["tool_calls"][0]["tool_id"] == "tool-1"
+
+    assert tool["name"] == "read_file"
+    assert tool["status"] == "ok"
+    assert tool["meta"]["metadata"]["tool_id"] == "tool-1"
+    assert tool["meta"]["metadata"]["_dd"]["estimated_permission_wait_ms"] >= 0
+
+
+async def test_gemini_multiple_after_model_calls_create_steps(agent):
+    sid = "gemini-multi-step"
+    await _post(agent, "SessionStart", _session_start(sid))
+    await _post(agent, "BeforeAgent", _before_agent(sid))
+    await _post(
+        agent,
+        "AfterModel",
+        _after_model(
+            sid,
+            tool_call={"id": "tool-1", "name": "read_file", "args": {"file_path": "README.md"}},
+            finish_reason="TOOL_CALL",
+        ),
+    )
+    await _post(agent, "BeforeTool", _before_tool(sid))
+    await _post(agent, "AfterTool", _after_tool(sid))
+    await _post(agent, "AfterModel", _after_model(sid, output_text="README contents summarized."))
+    await _post(agent, "AfterAgent", _after_agent(sid, "README contents summarized."))
+
+    resp = await agent.get("/gemini/hooks/spans")
+    spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+
+    root = [s for s in spans if s["parent_id"] == "undefined"][0]
+    steps = sorted(_by_kind(spans, "step"), key=lambda s: s["name"])
+    llms = _by_kind(spans, "llm")
+    tools = _by_kind(spans, "tool")
+
+    assert [s["name"] for s in steps] == ["inference-0", "inference-1"]
+    assert all(step["parent_id"] == root["span_id"] for step in steps)
+    assert {llm["parent_id"] for llm in llms} == {step["span_id"] for step in steps}
+    assert tools[0]["parent_id"] == steps[0]["span_id"]
+    assert steps[1]["meta"]["output"]["value"] == "README contents summarized."
+
+
+async def test_gemini_endpoint_alias_and_raw_events(agent):
+    sid = "gemini-alias"
+    resp = await agent.post("/capture/gemini/SessionStart", json=_session_start(sid))
+    assert resp.status == 200
+
+    raw = await agent.get("/gemini/hooks/raw")
+    assert raw.status == 200
+    events = (await raw.json())["events"]
+    assert any(event["session_id"] == sid and event["hook_event_name"] == "SessionStart" for event in events)
+
+
+async def test_gemini_rejects_bad_payloads(agent):
+    resp = await agent.post("/gemini/hooks/SessionStart", data="{")
+    assert resp.status == 400
+
+    resp = await agent.post("/gemini/hooks/SessionStart", json={"source": "startup"})
+    assert resp.status == 400
+
+    resp = await agent.post("/gemini/hooks/NoSuchEvent", json={"session_id": "gemini-bad"})
+    assert resp.status == 400
+
+
+async def test_gemini_tool_error_span(agent):
+    sid = "gemini-tool-error"
+    await _post(agent, "SessionStart", _session_start(sid))
+    await _post(agent, "BeforeAgent", _before_agent(sid))
+    await _post(agent, "BeforeTool", _before_tool(sid, tool_use_id="bad-tool", tool_name="run_shell_command"))
+    await _post(
+        agent,
+        "AfterTool",
+        _after_tool(sid, tool_use_id="bad-tool", tool_name="run_shell_command", response="", error="permission denied"),
+    )
+    await _post(agent, "AfterAgent", _after_agent(sid, "Could not run it."))
+
+    resp = await agent.get("/gemini/hooks/spans")
+    spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+    tools = _by_kind(spans, "tool")
+
+    assert len(tools) == 1
+    assert tools[0]["status"] == "error"
+    assert tools[0]["meta"]["error"]["message"] == "permission denied"

--- a/tests/test_gemini_hooks.py
+++ b/tests/test_gemini_hooks.py
@@ -1,6 +1,10 @@
 """Tests for Gemini CLI hook ingestion."""
 
 import json
+from pathlib import Path
+
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 async def _post(agent, event_type, payload):
@@ -17,6 +21,30 @@ def _spans(body):
 
 def _by_kind(spans, kind):
     return [s for s in spans if s.get("meta", {}).get("span", {}).get("kind") == kind]
+
+
+def _load_fixture(name):
+    return json.loads((_FIXTURES_DIR / name).read_text())
+
+
+def _read_tool_semantics(events, before_name, after_name, tool_names):
+    before = next(
+        event
+        for event in events
+        if event["hook_event_name"] == before_name and event.get("tool_name") in tool_names
+    )
+    after = next(
+        event
+        for event in events
+        if event["hook_event_name"] == after_name and event.get("tool_name") in tool_names
+    )
+    return {
+        "phase_before": "pre_tool_use",
+        "phase_after": "post_tool_use",
+        "tool_family": "read_file",
+        "path": before["tool_input"]["file_path"],
+        "has_output": bool(after.get("tool_response")),
+    }
 
 
 def _session_start(session_id):
@@ -157,6 +185,81 @@ async def test_gemini_full_turn_with_tool(agent):
     assert tool["status"] == "ok"
     assert tool["meta"]["metadata"]["tool_id"] == "tool-1"
     assert tool["meta"]["metadata"]["_dd"]["estimated_permission_wait_ms"] >= 0
+
+
+def test_gemini_real_tool_fixture_matches_current_cli_shape():
+    fixture = _load_fixture("gemini_real_tool_session.json")
+    events = fixture["events"]
+
+    assert [event["hook_event_name"] for event in events] == [
+        "SessionStart",
+        "BeforeAgent",
+        "PreCompress",
+        "AfterModel",
+        "AfterModel",
+        "AfterModel",
+        "AfterModel",
+        "AfterModel",
+        "BeforeTool",
+        "BeforeTool",
+        "AfterTool",
+        "AfterTool",
+        "PreCompress",
+        "AfterModel",
+        "AfterModel",
+        "AfterAgent",
+        "SessionEnd",
+    ]
+
+    tool_events = [event for event in events if event["hook_event_name"] in ("BeforeTool", "AfterTool")]
+    assert [event["tool_name"] for event in tool_events] == [
+        "read_file",
+        "run_shell_command",
+        "read_file",
+        "run_shell_command",
+    ]
+    assert all("tool_use_id" not in event and "mcp_context" not in event for event in tool_events)
+
+    after_model = next(event for event in events if event["hook_event_name"] == "AfterModel")
+    assert "messages" in after_model["llm_request"]
+    assert isinstance(after_model["llm_response"]["candidates"][0]["content"]["parts"][0], str)
+
+
+async def test_gemini_real_tool_fixture_pairs_tools_and_matches_claude_read_semantics(agent):
+    gemini_fixture = _load_fixture("gemini_real_tool_session.json")
+    claude_fixture = _load_fixture("claude_minimal_tool_session.json")
+    gemini_events = gemini_fixture["events"]
+
+    for event in gemini_events:
+        await _post(agent, event["hook_event_name"], event)
+
+    resp = await agent.get("/gemini/hooks/spans")
+    assert resp.status == 200
+    spans = [s for s in _spans(await resp.json()) if s.get("session_id") == "gemini-real-tool-session"]
+
+    llms = _by_kind(spans, "llm")
+    tools = _by_kind(spans, "tool")
+    tools_by_name = {tool["name"]: tool for tool in tools}
+
+    assert {"read_file", "run_shell_command"} <= set(tools_by_name)
+    read_tool = tools_by_name["read_file"]
+    shell_tool = tools_by_name["run_shell_command"]
+
+    assert "README.md" in read_tool["meta"]["input"]["value"]
+    assert "Lapdog Gemini real tool fixture" in read_tool["meta"]["output"]["value"]
+    assert "pwd" in shell_tool["meta"]["input"]["value"]
+    assert "/private/tmp/lapdog-gemini-real-fixture" in shell_tool["meta"]["output"]["value"]
+
+    assert any(llm["meta"]["input"]["messages"] for llm in llms)
+    assert any(
+        message.get("content") == "real-fixture-done"
+        for llm in llms
+        for message in llm["meta"]["output"]["messages"]
+    )
+
+    assert _read_tool_semantics(gemini_events, "BeforeTool", "AfterTool", {"read_file"}) == _read_tool_semantics(
+        claude_fixture["events"], "PreToolUse", "PostToolUse", {"Read"}
+    )
 
 
 async def test_gemini_multiple_after_model_calls_create_steps(agent):

--- a/tests/test_lapdog_gemini_extension.py
+++ b/tests/test_lapdog_gemini_extension.py
@@ -1,7 +1,31 @@
 import json
+import pkgutil
 
-from lapdog.cli import _GEMINI_EVENTS
+from lapdog.cli import _GEMINI_EXTENSION_TEMPLATE_FILES
 from lapdog.cli import _write_gemini_extension
+
+_GEMINI_EVENTS = [
+    ("SessionStart", ""),
+    ("BeforeAgent", ""),
+    ("AfterModel", ""),
+    ("BeforeTool", "*"),
+    ("AfterTool", "*"),
+    ("AfterAgent", ""),
+    ("SessionEnd", ""),
+    ("PreCompress", ""),
+    ("Notification", ""),
+]
+
+
+def test_gemini_extension_templates_are_packaged():
+    for resource_path in _GEMINI_EXTENSION_TEMPLATE_FILES:
+        data = pkgutil.get_data("lapdog", resource_path)
+        assert data is not None
+        assert data
+
+    hooks_template = pkgutil.get_data("lapdog", "gemini_extension/hooks/hooks.json.template")
+    assert hooks_template is not None
+    assert b"{{LAPDOG_URL}}" in hooks_template
 
 
 def test_write_gemini_extension_generates_command_hooks(tmp_path):
@@ -21,6 +45,7 @@ def test_write_gemini_extension_generates_command_hooks(tmp_path):
         assert hook_group["matcher"] == matcher
         assert hook["type"] == "command"
         assert f"http://localhost:9123/gemini/hooks/{event}" in hook["command"]
+        assert "{{LAPDOG_URL}}" not in hook["command"]
         assert hook["command"].endswith(">/dev/null 2>&1 || true")
 
     assert hooks["hooks"]["SessionEnd"][0]["hooks"][0]["timeout"] == 15000

--- a/tests/test_lapdog_gemini_extension.py
+++ b/tests/test_lapdog_gemini_extension.py
@@ -1,0 +1,27 @@
+import json
+
+from lapdog.cli import _GEMINI_EVENTS
+from lapdog.cli import _write_gemini_extension
+
+
+def test_write_gemini_extension_generates_command_hooks(tmp_path):
+    _write_gemini_extension(str(tmp_path), port=9123)
+
+    extension = json.loads((tmp_path / "gemini-extension.json").read_text())
+    hooks = json.loads((tmp_path / "hooks" / "hooks.json").read_text())
+    context = (tmp_path / "plugin" / "lapdog-gemini" / "GEMINI.md").read_text()
+
+    assert extension["name"] == "lapdog"
+    assert extension["contextFileName"] == "plugin/lapdog-gemini/GEMINI.md"
+    assert "Lapdog" in context
+
+    for event, matcher in _GEMINI_EVENTS:
+        hook_group = hooks["hooks"][event][0]
+        hook = hook_group["hooks"][0]
+        assert hook_group["matcher"] == matcher
+        assert hook["type"] == "command"
+        assert f"http://localhost:9123/gemini/hooks/{event}" in hook["command"]
+        assert hook["command"].endswith(">/dev/null 2>&1 || true")
+
+    assert hooks["hooks"]["SessionEnd"][0]["hooks"][0]["timeout"] == 15000
+    assert hooks["hooks"]["BeforeAgent"][0]["hooks"][0]["timeout"] == 5000


### PR DESCRIPTION
## Summary
- add Gemini CLI command-hook ingestion and LLMObs span assembly
- register Gemini hook routes, including trajectory-compatible /capture/gemini/{EventType}
- add lapdog gemini launcher support that generates and installs a Gemini extension for the selected local port
- document Gemini hook usage

## Validation
- pytest tests/test_gemini_hooks.py tests/test_lapdog_gemini_extension.py tests/test_pi_hooks.py tests/test_lapdog_claude_hooks.py -q
- pytest tests/test_gemini_hooks.py tests/test_pi_hooks.py tests/test_claude_hooks.py tests/test_claude_steps.py tests/test_lapdog_claude_hooks.py -q
- python -m flake8 ddapm_test_agent/gemini_hooks.py lapdog/cli.py tests/test_gemini_hooks.py tests/test_lapdog_gemini_extension.py
- git diff --check