### PR TITLE
Add trajectory marker support to LLMObs test agent

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -290,9 +290,7 @@ def default_value_trace_results_summary():
 def _is_valid_api_key_and_site_combination(dd_api_key: str, dd_site: str) -> bool:
     """Check if the api key + site is a valid DD auth combo"""
     url = f"https://api.{dd_site}/api/v1/validate"
-    headers = {
-        "DD-API-KEY": dd_api_key
-    }
+    headers = {"DD-API-KEY": dd_api_key}
 
     response = requests.get(url=url, headers=headers)
     result = cast(Dict[str, bool], response.json())
@@ -388,6 +386,7 @@ class Agent:
             "/evp_proxy/v2/api/v2/llmobs",
             "/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric",
             "/evp_proxy/v2/api/intake/llm-obs/v2/eval-metric",
+            "/v2/eval-metric",
             "/evp_proxy/v2/api/v2/exposures",
             "/evp_proxy/v4/api/v2/errorsintake",
             "/evp_proxy/v4/api/v2/llmobs",
@@ -978,6 +977,14 @@ class Agent:
         return web.HTTPOk()
 
     async def handle_evp_proxy_v2_llmobs_eval_metric(self, request: Request) -> web.Response:
+        try:
+            payload = json.loads((await request.read()).decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return web.HTTPOk()
+
+        llmobs_api = request.app.get("llmobs_event_platform_api")
+        if llmobs_api:
+            llmobs_api.ingest_eval_metric_payload(payload)
         return web.HTTPOk()
 
     async def handle_evp_proxy_v2_api_v2_exposures(self, request: Request) -> web.Response:
@@ -1141,10 +1148,7 @@ class Agent:
             dd_api_key = data.get("dd_api_key", request.app["dd_api_key"])
             dd_site = data.get("dd_site", request.app["dd_site"])
 
-            is_valid = _is_valid_api_key_and_site_combination(
-                dd_api_key=dd_api_key,
-                dd_site=dd_site
-            )
+            is_valid = _is_valid_api_key_and_site_combination(dd_api_key=dd_api_key, dd_site=dd_site)
 
             if not is_valid:
                 return web.HTTPUnprocessableEntity(
@@ -1758,6 +1762,7 @@ class Agent:
                 "/evp_proxy/v2/api/v2/llmobs": self.handle_evp_proxy_v2_api_v2_llmobs,
                 "/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric": self.handle_evp_proxy_v2_llmobs_eval_metric,
                 "/evp_proxy/v2/api/intake/llm-obs/v2/eval-metric": self.handle_evp_proxy_v2_llmobs_eval_metric,
+                "/v2/eval-metric": self.handle_evp_proxy_v2_llmobs_eval_metric,
                 "/evp_proxy/v2/api/v2/exposures": self.handle_evp_proxy_v2_api_v2_exposures,
                 "/evp_proxy/v4/api/v2/errorsintake": self.handle_evp_proxy_v4_api_v2_errorsintake,
                 "/evp_proxy/v4/api/v2/llmobs": self.handle_evp_proxy_v4_api_v2_llmobs,
@@ -1984,6 +1989,7 @@ def make_app(
             web.post("/evp_proxy/v2/api/v2/llmobs/update", agent.handle_evp_proxy_v2_api_v2_llmobs_update),
             web.post("/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric", agent.handle_evp_proxy_v2_llmobs_eval_metric),
             web.post("/evp_proxy/v2/api/intake/llm-obs/v2/eval-metric", agent.handle_evp_proxy_v2_llmobs_eval_metric),
+            web.post("/v2/eval-metric", agent.handle_evp_proxy_v2_llmobs_eval_metric),
             web.post("/evp_proxy/v2/api/v2/exposures", agent.handle_evp_proxy_v2_api_v2_exposures),
             web.post("/evp_proxy/v4/api/v2/errorsintake", agent.handle_evp_proxy_v4_api_v2_errorsintake),
             web.post("/evp_proxy/v4/api/v2/llmobs", agent.handle_evp_proxy_v4_api_v2_llmobs),
@@ -2091,7 +2097,9 @@ def make_app(
     valid_auth = _is_valid_api_key_and_site_combination(dd_api_key, dd_site) if dd_api_key and dd_site else False
     app["authenticated"] = valid_auth
     if not disable_llmobs_data_forwarding and not valid_auth:
-        log.warning("Cannot forward LLM Observability data with an invalid DD_API_KEY and DD_SITE, disabling LLM Observability data forwarding.")
+        log.warning(
+            "Cannot forward LLM Observability data with an invalid DD_API_KEY and DD_SITE, disabling LLM Observability data forwarding."
+        )
         disable_llmobs_data_forwarding = True
 
     app["disable_llmobs_data_forwarding"] = disable_llmobs_data_forwarding

--- a/ddapm_test_agent/llmobs_event_platform.py
+++ b/ddapm_test_agent/llmobs_event_platform.py
@@ -13,7 +13,9 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import TYPE_CHECKING
+from typing import Tuple
 import uuid
 
 from aiohttp import web
@@ -22,6 +24,13 @@ import msgpack
 
 from . import llmobs_query_parser
 from ._clock import monotonic_wall_ns
+from .markers import MarkerEvaluator
+from .markers import apply_eval_metrics
+from .markers import build_enrichment_outputs
+from .markers import enabled_from_env
+from .markers import eval_metric_key
+from .markers import parse_enrichment_body
+from .markers import parse_eval_metric_payload
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -1050,6 +1059,10 @@ class LLMObsEventPlatformAPI:
         self._query_results: Dict[str, Dict[str, Any]] = {}
         self.decoded_llmobs_span_events: Dict[int, List[Dict[str, Any]]] = {}
         self._claude_hooks_api: Optional["ClaudeHooksAPI"] = None
+        self._eval_metrics: List[Dict[str, Any]] = []
+        self._eval_metric_keys: Set[Tuple[str, str, str, int]] = set()
+        self._enrichment_events: List[Dict[str, Any]] = []
+        self._marker_evaluator: Optional[MarkerEvaluator] = MarkerEvaluator() if enabled_from_env() else None
 
     def set_claude_hooks_api(self, api: "ClaudeHooksAPI") -> None:
         """Wire up the Claude hooks API so its spans appear in LLMObs queries."""
@@ -1079,8 +1092,42 @@ class LLMObsEventPlatformAPI:
         if self._claude_hooks_api:
             all_spans.extend(self._claude_hooks_api._assembled_spans)
 
+        apply_eval_metrics(all_spans, self._eval_metrics)
+
+        if self._marker_evaluator:
+            marker_output = self._marker_evaluator.evaluate(all_spans)
+            apply_eval_metrics(all_spans, marker_output.eval_metrics)
+            all_spans.extend(marker_output.synthetic_spans)
+
+        if self._enrichment_events:
+            enrichment_output = build_enrichment_outputs(self._enrichment_events, all_spans)
+            apply_eval_metrics(all_spans, enrichment_output.eval_metrics)
+            all_spans.extend(enrichment_output.synthetic_spans)
+
         all_spans.sort(key=lambda s: s.get("start_ns", 0), reverse=True)
         return all_spans
+
+    def ingest_eval_metric_payload(self, payload: Any) -> int:
+        """Store valid LLMObs eval-metric payload entries for later span joins."""
+        accepted = 0
+        for metric in parse_eval_metric_payload(payload):
+            key = eval_metric_key(metric)
+            if key in self._eval_metric_keys:
+                continue
+            self._eval_metric_keys.add(key)
+            self._eval_metrics.append(metric)
+            accepted += 1
+        return accepted
+
+    async def handle_enrichment(self, request: Request) -> web.Response:
+        """Accept and list local trajectory-spec enrichment events."""
+        if request.method == "GET":
+            return web.json_response({"events": self._enrichment_events})
+
+        data = await request.read()
+        events, ignored = parse_enrichment_body(request.content_type or "", data)
+        self._enrichment_events.extend(events)
+        return web.json_response({"accepted": len(events), "ignored": ignored})
 
     def update_spans(self, update_data: bytes, content_type: str) -> int:
         """Update existing spans by span_id. Accepts same payload format as creation."""
@@ -1376,6 +1423,9 @@ class LLMObsEventPlatformAPI:
                 "status": status,
                 "tags": tags,
                 "trace_id": trace_id,
+                "evaluation": found_span.get("evaluation", {}),
+                "evaluations": found_span.get("evaluations", {}),
+                "evaluation_assessments": found_span.get("evaluation_assessments", {}),
             }
 
             response = {
@@ -1714,4 +1764,6 @@ class LLMObsEventPlatformAPI:
             web.route("*", "/api/ui/llm-obs/v1/trace/{trace_id}", with_cors(self.handle_trace)),
             # Query scalar endpoint
             web.route("*", "/api/ui/query/scalar", with_cors(self.handle_query_scalar)),
+            # Local trajectory enrichment testing endpoint
+            web.route("*", "/test/session/llmobs/enrichment", with_cors(self.handle_enrichment)),
         ]

--- a/ddapm_test_agent/markers.py
+++ b/ddapm_test_agent/markers.py
@@ -1,0 +1,1206 @@
+"""Lightweight trajectory marker support for local LLMObs testing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import datetime
+import fnmatch
+import hashlib
+import json
+import logging
+import os
+import re
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import cast
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MARKERS_YAML = r"""
+version: 1
+points:
+  - name: user-frustration
+    severity: warn
+    confidence: high
+    match:
+      prompt: "stop doing|don't do|never do|I told you|why do you keep|not what I asked|wrong again"
+    extract:
+      pattern: "(stop doing|don't do|never do|I told you|why do you keep|not what I asked|wrong again)"
+  - name: git-commit
+    severity: success
+    confidence: high
+    match:
+      tool: [Bash, Shell, run_shell, terminal, exec_command, bash]
+      command: '\bgit(?:\s+-[cC]\s+\S+|\s+--\S+=\S+)*\s+commit\b'
+      success: true
+    extract:
+      message: '-m\s+["'']([^"'']+)'
+  - name: git-push
+    severity: success
+    confidence: high
+    match:
+      tool: [Bash, Shell, run_shell, terminal, exec_command, bash]
+      command: '\bgit(?:\s+-[cC]\s+\S+|\s+--\S+=\S+)*\s+push\b'
+      success: true
+  - name: test-passed
+    severity: success
+    confidence: high
+    match:
+      tool: [Bash, Shell, run_shell, terminal, exec_command, bash]
+      command: "pytest|npm test|jest|cargo test|go test|make test"
+      success: true
+      output: 'passed|\bok\b|all tests passed|0 failed|PASS'
+  - name: test-failed
+    severity: error
+    confidence: high
+    match:
+      tool: [Bash, Shell, run_shell, terminal, exec_command, bash]
+      command: "pytest|npm test|jest|cargo test|go test|make test"
+      success: false
+  - name: tool-error
+    severity: warn
+    confidence: high
+    match:
+      success: false
+  - name: permission-denied
+    severity: warn
+    confidence: high
+    match:
+      denied: true
+ranges:
+  - name: test-fix-cycle
+    sequence:
+      - point: test-failed
+      - tool: [Edit, Write, apply_patch]
+      - point: test-passed
+    on_complete: success
+    on_session_end: abandoned
+measures:
+  - name: frustration-count
+    count:
+      point: user-frustration
+  - name: commit-count
+    count:
+      point: git-commit
+  - name: test-fix-cycle-count
+    count:
+      range: test-fix-cycle
+      outcome: success
+  - name: test-pass-rate
+    ratio:
+      numerator:
+        point: test-passed
+      denominator:
+        any_point: [test-passed, test-failed]
+"""
+
+
+@dataclass
+class SpanContext:
+    span: Dict[str, Any]
+    session_id: str
+    trace_id: str
+    span_id: str
+    kind: str
+    name: str
+    start_ns: int
+    duration: int
+    turn_id: int
+    success: bool
+    denied: bool
+    tool_name: str
+    command: str
+    input_text: str
+    output_text: str
+    files: List[str]
+
+
+@dataclass
+class PointMatch:
+    name: str
+    severity: str
+    confidence: str
+    context: SpanContext
+    detail: Dict[str, Any]
+
+
+@dataclass
+class RangeMatch:
+    name: str
+    outcome: str
+    start: SpanContext
+    end: SpanContext
+    detail: Dict[str, Any]
+
+
+@dataclass
+class MeasureMatch:
+    name: str
+    value: float
+    root: SpanContext
+
+
+@dataclass
+class MarkerEvaluation:
+    eval_metrics: List[Dict[str, Any]]
+    synthetic_spans: List[Dict[str, Any]]
+
+
+def enabled_from_env() -> bool:
+    value = os.environ.get("DD_APM_TEST_AGENT_MARKERS_ENABLED", "1").strip().lower()
+    return value not in ("0", "false", "no", "off")
+
+
+def parse_eval_metric_payload(payload: Any) -> List[Dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    data = payload.get("data")
+    if not isinstance(data, dict) or data.get("type") != "evaluation_metric":
+        return []
+    attrs = data.get("attributes")
+    if not isinstance(attrs, dict):
+        return []
+    metrics = attrs.get("metrics")
+    if not isinstance(metrics, list):
+        return []
+    return [metric for metric in metrics if isinstance(metric, dict)]
+
+
+def eval_metric_key(metric: Dict[str, Any]) -> Tuple[str, str, str, int]:
+    join_on = metric.get("join_on") if isinstance(metric.get("join_on"), dict) else {}
+    span: Dict[str, Any] = {}
+    span_value = join_on.get("span") if isinstance(join_on, dict) else None
+    if isinstance(span_value, dict):
+        span = span_value
+    timestamp_ms = metric.get("timestamp_ms", 0)
+    try:
+        timestamp_int = int(timestamp_ms)
+    except (TypeError, ValueError):
+        timestamp_int = 0
+    return (
+        str(span.get("trace_id", "")),
+        str(span.get("span_id", "")),
+        str(metric.get("label", "")),
+        timestamp_int,
+    )
+
+
+def apply_eval_metrics(spans: List[Dict[str, Any]], metrics: Iterable[Dict[str, Any]]) -> int:
+    by_ref: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for span in spans:
+        trace_id = str(span.get("trace_id", ""))
+        span_id = str(span.get("span_id", ""))
+        if trace_id and span_id:
+            by_ref[(trace_id, span_id)] = span
+
+    applied = 0
+    for metric in metrics:
+        for span in _matching_spans(metric, spans, by_ref):
+            _apply_metric_to_span(span, metric)
+            applied += 1
+    return applied
+
+
+def parse_enrichment_body(content_type: str, data: bytes) -> Tuple[List[Dict[str, Any]], int]:
+    text = data.decode("utf-8") if isinstance(data, bytes) else str(data)
+    events: List[Dict[str, Any]] = []
+    ignored = 0
+
+    parsed: Any
+    if "jsonl" in content_type.lower():
+        parsed = []
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                parsed.append(json.loads(stripped))
+            except json.JSONDecodeError:
+                ignored += 1
+    else:
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = []
+            for line in text.splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed.append(json.loads(stripped))
+                except json.JSONDecodeError:
+                    ignored += 1
+
+    candidates = parsed if isinstance(parsed, list) else [parsed]
+    for candidate in candidates:
+        if _valid_enrichment_event(candidate):
+            events.append(candidate)
+        else:
+            ignored += 1
+    return events, ignored
+
+
+def build_enrichment_outputs(events: List[Dict[str, Any]], spans: List[Dict[str, Any]]) -> MarkerEvaluation:
+    synthetic: List[Dict[str, Any]] = []
+    evals: List[Dict[str, Any]] = []
+    contexts = _build_contexts(spans)
+    by_session = _group_contexts_by_session(contexts)
+
+    for event in events:
+        session_id = str(event.get("session_id", ""))
+        session_contexts = by_session.get(session_id, [])
+        root = _root_context(session_contexts)
+        if root is None:
+            continue
+        enrichment_type = str(event.get("enrichment_type", ""))
+        if enrichment_type == "milestone":
+            span = _span_from_milestone_event(event, root, session_contexts)
+            synthetic.append(span)
+            eval_metric = _eval_from_milestone_event(event, root, session_contexts)
+            if eval_metric:
+                evals.append(eval_metric)
+        elif enrichment_type == "metric":
+            span = _span_from_metric_event(event, root)
+            synthetic.append(span)
+            evals.append(_score_eval(str(event.get("metric_name", "")), _numeric_value(event.get("value")), root))
+
+    return MarkerEvaluation(eval_metrics=evals, synthetic_spans=synthetic)
+
+
+class MarkerEvaluator:
+    def __init__(self, config_path: Optional[str] = None) -> None:
+        self.config = self._load_config(config_path)
+
+    def evaluate(self, spans: List[Dict[str, Any]]) -> MarkerEvaluation:
+        base_spans = [span for span in spans if "trajectory.marker.synthetic:true" not in span.get("tags", [])]
+        contexts = _build_contexts(base_spans)
+        by_session = _group_contexts_by_session(contexts)
+        evals: List[Dict[str, Any]] = []
+        synthetic: List[Dict[str, Any]] = []
+
+        for session_id, session_contexts in by_session.items():
+            points = self._evaluate_points(session_contexts)
+            ranges = self._evaluate_ranges(session_contexts, points)
+            root = _root_context(session_contexts)
+            if root is None:
+                continue
+
+            for point in points:
+                evals.append(_point_eval(point))
+                synthetic.append(_point_span(point))
+            for range_match in ranges:
+                evals.append(_range_eval(range_match))
+                synthetic.append(_range_span(range_match, root))
+            for measure in self._evaluate_measures(root, points, ranges):
+                evals.append(_score_eval(measure.name, measure.value, measure.root))
+                synthetic.append(_metric_span(measure.name, measure.value, measure.root, source="marker-evaluator"))
+
+        return MarkerEvaluation(eval_metrics=evals, synthetic_spans=synthetic)
+
+    def _load_config(self, config_path: Optional[str]) -> Dict[str, Any]:
+        path = config_path or os.environ.get("DD_APM_TEST_AGENT_MARKERS_PATH", "")
+        if path:
+            try:
+                with open(path, "r") as f:
+                    loaded = yaml.safe_load(f) or {}
+                if isinstance(loaded, dict):
+                    return loaded
+            except Exception as e:
+                log.warning("failed to load marker config %s: %s", path, e)
+        loaded_default = yaml.safe_load(DEFAULT_MARKERS_YAML) or {}
+        return loaded_default if isinstance(loaded_default, dict) else {}
+
+    def _evaluate_points(self, contexts: List[SpanContext]) -> List[PointMatch]:
+        points: List[PointMatch] = []
+        definitions = self.config.get("points", [])
+        if not isinstance(definitions, list):
+            return points
+        seen: Set[Tuple[str, str]] = set()
+        for definition in definitions:
+            if not isinstance(definition, dict) or definition.get("disabled"):
+                continue
+            name = str(definition.get("name", ""))
+            if not name:
+                continue
+            match = definition.get("match", {})
+            if not isinstance(match, dict):
+                continue
+            for context in contexts:
+                if _condition_matches(match, context):
+                    key = (name, context.span_id)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    detail = _extract_detail(definition, context)
+                    points.append(
+                        PointMatch(
+                            name=name,
+                            severity=str(definition.get("severity", "info")),
+                            confidence=str(definition.get("confidence", "medium")),
+                            context=context,
+                            detail=detail,
+                        )
+                    )
+        return points
+
+    def _evaluate_ranges(self, contexts: List[SpanContext], points: List[PointMatch]) -> List[RangeMatch]:
+        ranges: List[RangeMatch] = []
+        definitions = self.config.get("ranges", [])
+        if not isinstance(definitions, list):
+            return ranges
+        for definition in definitions:
+            if not isinstance(definition, dict) or definition.get("disabled"):
+                continue
+            name = str(definition.get("name", ""))
+            if not name:
+                continue
+            if isinstance(definition.get("sequence"), list):
+                ranges.extend(_evaluate_sequence_range(name, definition, contexts, points))
+            elif isinstance(definition.get("bracket"), dict):
+                bracket = definition["bracket"]
+                ranges.extend(_evaluate_bracket_range(name, definition, bracket, contexts))
+        return ranges
+
+    def _evaluate_measures(
+        self, root: SpanContext, points: List[PointMatch], ranges: List[RangeMatch]
+    ) -> List[MeasureMatch]:
+        measures: List[MeasureMatch] = []
+        definitions = self.config.get("measures", [])
+        if not isinstance(definitions, list):
+            return measures
+        for definition in definitions:
+            if not isinstance(definition, dict) or definition.get("disabled"):
+                continue
+            name = str(definition.get("name", ""))
+            if not name:
+                continue
+            count = definition.get("count")
+            ratio = definition.get("ratio")
+            if isinstance(count, dict):
+                value = _count_source(count, points, ranges)
+                if value:
+                    measures.append(MeasureMatch(name=name, value=float(value), root=root))
+            elif isinstance(ratio, dict):
+                numerator_value = ratio.get("numerator")
+                denominator_value = ratio.get("denominator")
+                numerator = cast(Dict[str, Any], numerator_value) if isinstance(numerator_value, dict) else {}
+                denominator = cast(Dict[str, Any], denominator_value) if isinstance(denominator_value, dict) else {}
+                den = _count_source(denominator, points, ranges)
+                if den == 0:
+                    continue
+                ratio_value = float(_count_source(numerator, points, ranges)) / float(den)
+                measures.append(MeasureMatch(name=name, value=ratio_value, root=root))
+        return measures
+
+
+def _matching_spans(
+    metric: Dict[str, Any],
+    spans: List[Dict[str, Any]],
+    by_ref: Dict[Tuple[str, str], Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    join_on = metric.get("join_on") if isinstance(metric.get("join_on"), dict) else {}
+    span_ref = join_on.get("span") if isinstance(join_on, dict) and isinstance(join_on.get("span"), dict) else None
+    if span_ref:
+        span = by_ref.get((str(span_ref.get("trace_id", "")), str(span_ref.get("span_id", ""))))
+        return [span] if span is not None else []
+
+    tag_ref = join_on.get("tag") if isinstance(join_on, dict) and isinstance(join_on.get("tag"), dict) else None
+    if tag_ref:
+        key = str(tag_ref.get("key", ""))
+        value = str(tag_ref.get("value", ""))
+        if not key:
+            return []
+        return [span for span in spans if _tag_value(span, key) == value]
+    return []
+
+
+def _apply_metric_to_span(span: Dict[str, Any], metric: Dict[str, Any]) -> None:
+    label = str(metric.get("label", ""))
+    metric_type = str(metric.get("metric_type", ""))
+    if not label or not metric_type:
+        return
+    value = _metric_value(metric)
+    evaluation = {
+        "eval_metric_type": metric_type,
+        "value": value,
+        "status": "OK",
+    }
+    for key in ("assessment", "reasoning", "metadata", "tags", "timestamp_ms", "ml_app"):
+        if key in metric and metric[key] not in (None, ""):
+            evaluation[key] = metric[key]
+    span.setdefault("evaluation", {})[label] = evaluation
+    span.setdefault("evaluations", {}).setdefault("custom", {})[label] = value
+    assessment = metric.get("assessment")
+    if assessment:
+        span.setdefault("evaluation_assessments", {}).setdefault("custom", {})[label] = assessment
+
+
+def _metric_value(metric: Dict[str, Any]) -> Any:
+    metric_type = str(metric.get("metric_type", ""))
+    if metric_type == "categorical":
+        return metric.get("categorical_value")
+    if metric_type == "score":
+        return metric.get("score_value")
+    if metric_type == "boolean":
+        return metric.get("boolean_value")
+    if metric_type == "json":
+        return metric.get("json_value")
+    return None
+
+
+def _valid_enrichment_event(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("event_kind") != "enrichment":
+        return False
+    if not value.get("session_id") or not value.get("timestamp"):
+        return False
+    enrichment_type = value.get("enrichment_type")
+    if enrichment_type == "milestone":
+        return bool(value.get("milestone_type"))
+    if enrichment_type == "metric":
+        return bool(value.get("metric_name")) and "value" in value
+    return False
+
+
+def _build_contexts(spans: List[Dict[str, Any]]) -> List[SpanContext]:
+    by_session: Dict[str, List[Dict[str, Any]]] = {}
+    for span in spans:
+        session_id = str(span.get("session_id", "") or _tag_value(span, "session_id") or span.get("trace_id", ""))
+        if session_id:
+            by_session.setdefault(session_id, []).append(span)
+
+    contexts: List[SpanContext] = []
+    for session_id, session_spans in by_session.items():
+        sorted_spans = sorted(session_spans, key=lambda s: int(s.get("start_ns", 0) or 0))
+        turn_by_root: Dict[str, int] = {}
+        next_turn = 1
+        for span in sorted_spans:
+            metadata = _metadata(span)
+            explicit_turn = _to_int(metadata.get("turn_id"))
+            span_id = str(span.get("span_id", ""))
+            if explicit_turn is not None:
+                turn_by_root[span_id] = explicit_turn
+            elif _is_turn_root(span):
+                turn_by_root[span_id] = next_turn
+                next_turn += 1
+
+        for span in sorted_spans:
+            kind = _span_kind(span)
+            metadata = _metadata(span)
+            span_id = str(span.get("span_id", ""))
+            parent_id = str(span.get("parent_id", ""))
+            turn_id = _to_int(metadata.get("turn_id"))
+            if turn_id is None:
+                turn_id = turn_by_root.get(span_id) or turn_by_root.get(parent_id) or next_turn
+            contexts.append(_span_context(span, session_id, kind, turn_id))
+
+    contexts.sort(key=lambda c: (c.session_id, c.start_ns, c.span_id))
+    return contexts
+
+
+def _span_context(span: Dict[str, Any], session_id: str, kind: str, turn_id: int) -> SpanContext:
+    input_text = _span_text(span, "input")
+    output_text = _span_text(span, "output")
+    command = _extract_command(input_text)
+    tool_name = _tool_name(span, kind)
+    return SpanContext(
+        span=span,
+        session_id=session_id,
+        trace_id=str(span.get("trace_id", "")),
+        span_id=str(span.get("span_id", "")),
+        kind=kind,
+        name=str(span.get("name", "")),
+        start_ns=int(span.get("start_ns", 0) or 0),
+        duration=int(span.get("duration", 0) or 0),
+        turn_id=turn_id,
+        success=_span_success(span),
+        denied=_span_denied(span),
+        tool_name=tool_name,
+        command=command,
+        input_text=input_text,
+        output_text=output_text,
+        files=_extract_files(input_text),
+    )
+
+
+def _span_kind(span: Dict[str, Any]) -> str:
+    meta = span.get("meta", {})
+    if isinstance(meta, dict):
+        span_meta = meta.get("span")
+        if isinstance(span_meta, dict) and span_meta.get("kind"):
+            return str(span_meta["kind"])
+        if meta.get("span.kind"):
+            return str(meta["span.kind"])
+    return str(span.get("_ui_kind", ""))
+
+
+def _is_turn_root(span: Dict[str, Any]) -> bool:
+    tags = span.get("tags", [])
+    return "trajectory.semantic_type:turn" in tags or (
+        _span_kind(span) == "agent" and str(span.get("parent_id", "undefined")) in ("", "undefined", "0")
+    )
+
+
+def _metadata(span: Dict[str, Any]) -> Dict[str, Any]:
+    meta = span.get("meta", {})
+    if isinstance(meta, dict):
+        metadata = meta.get("metadata", {})
+        if isinstance(metadata, dict):
+            return metadata
+    return {}
+
+
+def _span_text(span: Dict[str, Any], key: str) -> str:
+    meta = span.get("meta", {})
+    if not isinstance(meta, dict):
+        return ""
+    value = meta.get(key, {})
+    if not isinstance(value, dict):
+        return _stringify(value)
+    if "value" in value:
+        return _stringify(value.get("value"))
+    messages = value.get("messages")
+    if isinstance(messages, list):
+        return "\n".join(_message_text(message) for message in messages if isinstance(message, dict))
+    return _stringify(value)
+
+
+def _message_text(message: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    for key in ("content", "text"):
+        if key in message:
+            parts.append(_stringify(message.get(key)))
+    tool_calls = message.get("tool_calls")
+    if isinstance(tool_calls, list):
+        parts.append(_stringify(tool_calls))
+    return "\n".join(part for part in parts if part)
+
+
+def _tool_name(span: Dict[str, Any], kind: str) -> str:
+    tag_tool = _tag_value(span, "tool_name")
+    if tag_tool:
+        return tag_tool
+    if kind == "tool":
+        return str(span.get("name", ""))
+    return ""
+
+
+def _span_success(span: Dict[str, Any]) -> bool:
+    status = str(span.get("status", "ok")).lower()
+    if status in ("error", "failed", "fail"):
+        return False
+    meta = span.get("meta", {})
+    if isinstance(meta, dict) and meta.get("error"):
+        return False
+    return True
+
+
+def _span_denied(span: Dict[str, Any]) -> bool:
+    metadata = _metadata(span)
+    if str(metadata.get("permission_denied", "")).lower() == "true":
+        return True
+    text = (_span_text(span, "output") + "\n" + _stringify(span.get("meta", {}).get("error", ""))).lower()
+    return "permission denied" in text or "denied" in text
+
+
+def _extract_command(text: str) -> str:
+    parsed = _parse_jsonish(text)
+    if isinstance(parsed, dict):
+        for key in ("command", "input", "cmd"):
+            value = parsed.get(key)
+            if isinstance(value, str):
+                return value
+    return text
+
+
+def _extract_files(text: str) -> List[str]:
+    parsed = _parse_jsonish(text)
+    values: List[str] = []
+    if isinstance(parsed, dict):
+        for key in ("path", "file", "file_path", "filepath"):
+            value = parsed.get(key)
+            if isinstance(value, str):
+                values.append(value)
+        files = parsed.get("files")
+        if isinstance(files, list):
+            values.extend(str(item) for item in files)
+    values.extend(re.findall(r"[\w./-]+\.(?:py|go|ts|tsx|js|jsx|json|yaml|yml|md|toml|rs|java|rb)", text))
+    return sorted(set(values))
+
+
+def _condition_matches(condition: Dict[str, Any], context: SpanContext) -> bool:
+    any_of = condition.get("any_of")
+    if isinstance(any_of, list):
+        return any(isinstance(item, dict) and _condition_matches(item, context) for item in any_of)
+
+    for key, expected in condition.items():
+        if key == "any_of":
+            continue
+        if key == "tool" and not _value_in(expected, context.tool_name):
+            return False
+        if key == "command" and not _regex_search(expected, context.command):
+            return False
+        if key == "output" and not _regex_search(expected, context.output_text):
+            return False
+        if key == "prompt" and not _regex_search(expected, context.input_text):
+            return False
+        if key == "response" and not _regex_search(expected, context.output_text):
+            return False
+        if key == "success" and bool(expected) != context.success:
+            return False
+        if key == "denied" and bool(expected) != context.denied:
+            return False
+        if key == "file" and not any(_path_matches(str(expected), path) for path in context.files):
+            return False
+        if key == "turn_cost_above" and not _turn_cost_above(context, expected):
+            return False
+    return True
+
+
+def _value_in(expected: Any, actual: str) -> bool:
+    if not actual:
+        return False
+    actual_lower = actual.lower()
+    if isinstance(expected, list):
+        return any(str(item).lower() == actual_lower for item in expected)
+    return str(expected).lower() == actual_lower
+
+
+def _regex_search(pattern: Any, value: str) -> bool:
+    try:
+        return re.search(str(pattern), value or "", re.IGNORECASE | re.MULTILINE) is not None
+    except re.error:
+        log.debug("invalid marker regex ignored: %r", pattern)
+        return False
+
+
+def _path_matches(pattern: str, path: str) -> bool:
+    for part in pattern.split("|"):
+        if fnmatch.fnmatch(path, part) or _regex_search(part, path):
+            return True
+    return False
+
+
+def _turn_cost_above(context: SpanContext, expected: Any) -> bool:
+    threshold = _to_float(expected)
+    if threshold is None:
+        return False
+    metrics = context.span.get("metrics", {})
+    candidates = []
+    if isinstance(metrics, dict):
+        candidates.extend([metrics.get("estimated_total_cost"), metrics.get("estimated_cost_usd")])
+    metadata = _metadata(context.span)
+    candidates.extend([metadata.get("estimated_total_cost"), metadata.get("estimated_cost_usd")])
+    return any(value is not None and value > threshold for value in (_to_float(c) for c in candidates))
+
+
+def _extract_detail(definition: Dict[str, Any], context: SpanContext) -> Dict[str, Any]:
+    detail = {
+        "severity": str(definition.get("severity", "info")),
+        "confidence": str(definition.get("confidence", "medium")),
+        "source": "marker-evaluator",
+    }
+    extract = definition.get("extract")
+    if isinstance(extract, dict):
+        corpus = "\n".join([context.input_text, context.output_text, context.command])
+        for key, pattern in extract.items():
+            try:
+                match = re.search(str(pattern), corpus, re.IGNORECASE | re.MULTILINE)
+            except re.error:
+                continue
+            if match:
+                detail[str(key)] = match.group(1) if match.groups() else match.group(0)
+    if context.command:
+        detail["command"] = context.command
+    if context.tool_name:
+        detail["tool"] = context.tool_name
+    return detail
+
+
+def _evaluate_sequence_range(
+    name: str,
+    definition: Dict[str, Any],
+    contexts: List[SpanContext],
+    points: List[PointMatch],
+) -> List[RangeMatch]:
+    steps = definition.get("sequence", [])
+    if not isinstance(steps, list) or not steps:
+        return []
+    ranges: List[RangeMatch] = []
+    ordered = sorted(contexts, key=lambda c: (c.start_ns, c.span_id))
+    point_by_context: Dict[Tuple[str, str], List[PointMatch]] = {}
+    for point in points:
+        point_by_context.setdefault((point.context.span_id, point.name), []).append(point)
+
+    index = 0
+    start_context: Optional[SpanContext] = None
+    for context in ordered:
+        step = steps[index]
+        if not isinstance(step, dict):
+            continue
+        if _range_step_matches(step, context, point_by_context):
+            if index == 0:
+                start_context = context
+            index += 1
+            if index == len(steps) and start_context is not None:
+                ranges.append(
+                    RangeMatch(
+                        name=name,
+                        outcome=str(definition.get("on_complete", "success")),
+                        start=start_context,
+                        end=context,
+                        detail={"source": "marker-evaluator"},
+                    )
+                )
+                index = 0
+                start_context = None
+    if index > 0 and start_context is not None and definition.get("on_session_end"):
+        ranges.append(
+            RangeMatch(
+                name=name,
+                outcome=str(definition.get("on_session_end")),
+                start=start_context,
+                end=ordered[-1],
+                detail={"source": "marker-evaluator", "incomplete": True},
+            )
+        )
+    return ranges
+
+
+def _evaluate_bracket_range(
+    name: str,
+    definition: Dict[str, Any],
+    bracket: Dict[str, Any],
+    contexts: List[SpanContext],
+) -> List[RangeMatch]:
+    starts_when = bracket.get("starts_when")
+    ends_when = bracket.get("ends_when")
+    if not isinstance(starts_when, dict) or not isinstance(ends_when, dict):
+        return []
+    ranges: List[RangeMatch] = []
+    active: Optional[SpanContext] = None
+    for context in sorted(contexts, key=lambda c: (c.start_ns, c.span_id)):
+        if active is None and _condition_matches(starts_when, context):
+            active = context
+            continue
+        if active is not None and _condition_matches(ends_when, context):
+            ranges.append(
+                RangeMatch(
+                    name=name,
+                    outcome=str(definition.get("on_complete", "success")),
+                    start=active,
+                    end=context,
+                    detail={"source": "marker-evaluator"},
+                )
+            )
+            active = None
+    if active is not None and definition.get("on_session_end") and contexts:
+        ranges.append(
+            RangeMatch(
+                name=name,
+                outcome=str(definition.get("on_session_end")),
+                start=active,
+                end=contexts[-1],
+                detail={"source": "marker-evaluator", "incomplete": True},
+            )
+        )
+    return ranges
+
+
+def _range_step_matches(
+    step: Dict[str, Any],
+    context: SpanContext,
+    point_by_context: Dict[Tuple[str, str], List[PointMatch]],
+) -> bool:
+    point = step.get("point")
+    if point:
+        return bool(point_by_context.get((context.span_id, str(point))))
+    return _condition_matches(step, context)
+
+
+def _count_source(source: Dict[str, Any], points: List[PointMatch], ranges: List[RangeMatch]) -> int:
+    if "point" in source:
+        return sum(1 for point in points if point.name == source["point"])
+    if "any_point" in source and isinstance(source["any_point"], list):
+        names = {str(name) for name in source["any_point"]}
+        return sum(1 for point in points if point.name in names)
+    if "range" in source:
+        outcome = source.get("outcome")
+        return sum(
+            1
+            for range_match in ranges
+            if range_match.name == source["range"] and (not outcome or range_match.outcome == outcome)
+        )
+    return 0
+
+
+def _point_eval(point: PointMatch) -> Dict[str, Any]:
+    value = point.severity
+    return {
+        "join_on": {"span": {"trace_id": point.context.trace_id, "span_id": point.context.span_id}},
+        "label": point.name,
+        "metric_type": "categorical",
+        "categorical_value": value,
+        "assessment": _severity_assessment(point.severity),
+        "reasoning": json.dumps(point.detail, sort_keys=True),
+        "metadata": point.detail,
+        "ml_app": str(point.context.span.get("ml_app", "")),
+        "timestamp_ms": _now_ms(),
+        "tags": ["source:trajectory", f"confidence:{point.confidence}"],
+    }
+
+
+def _range_eval(range_match: RangeMatch) -> Dict[str, Any]:
+    return {
+        "join_on": {"span": {"trace_id": range_match.start.trace_id, "span_id": range_match.start.span_id}},
+        "label": range_match.name,
+        "metric_type": "json",
+        "json_value": {
+            "turn_start": range_match.start.turn_id,
+            "turn_end": range_match.end.turn_id,
+            "outcome": range_match.outcome,
+            "detail": range_match.detail,
+        },
+        "assessment": _outcome_assessment(range_match.outcome),
+        "ml_app": str(range_match.start.span.get("ml_app", "")),
+        "timestamp_ms": _now_ms(),
+        "tags": ["source:trajectory"],
+    }
+
+
+def _score_eval(label: str, value: float, root: SpanContext) -> Dict[str, Any]:
+    return {
+        "join_on": {"span": {"trace_id": root.trace_id, "span_id": root.span_id}},
+        "label": label,
+        "metric_type": "score",
+        "score_value": value,
+        "ml_app": str(root.span.get("ml_app", "")),
+        "timestamp_ms": _now_ms(),
+        "tags": ["source:trajectory"],
+    }
+
+
+def _point_span(point: PointMatch) -> Dict[str, Any]:
+    detail = dict(point.detail)
+    detail.setdefault("turn_id", point.context.turn_id)
+    return _task_span(
+        session_id=point.context.session_id,
+        name=point.name,
+        start_ns=point.context.start_ns,
+        duration=0,
+        ml_app=str(point.context.span.get("ml_app", "")),
+        service=str(point.context.span.get("service", "")),
+        env=str(point.context.span.get("env", "")),
+        span_key=f"milestone-{point.name}-{point.context.span_id}",
+        input_value=point.name,
+        output_value=json.dumps(detail, sort_keys=True),
+        metadata={"milestone_type": point.name, "turn_id": point.context.turn_id, "severity": point.severity},
+        link_span=point.context,
+        semantic_type="milestone",
+    )
+
+
+def _range_span(range_match: RangeMatch, root: SpanContext) -> Dict[str, Any]:
+    metadata = {
+        "milestone_type": range_match.name,
+        "turn_start": range_match.start.turn_id,
+        "turn_end": range_match.end.turn_id,
+        "outcome": range_match.outcome,
+    }
+    metadata.update(range_match.detail)
+    end_ns = range_match.end.start_ns + max(range_match.end.duration, 0)
+    duration = max(0, end_ns - range_match.start.start_ns)
+    return _task_span(
+        session_id=range_match.start.session_id,
+        name=range_match.name,
+        start_ns=range_match.start.start_ns,
+        duration=duration,
+        ml_app=str(root.span.get("ml_app", "")),
+        service=str(root.span.get("service", "")),
+        env=str(root.span.get("env", "")),
+        span_key=f"milestone-{range_match.name}-{range_match.start.turn_id}-{range_match.end.turn_id}",
+        input_value=range_match.name,
+        output_value=json.dumps(metadata, sort_keys=True),
+        metadata=metadata,
+        link_span=root,
+        semantic_type="milestone",
+    )
+
+
+def _metric_span(name: str, value: float, root: SpanContext, source: str) -> Dict[str, Any]:
+    return _task_span(
+        session_id=root.session_id,
+        name=f"metric.{name}",
+        start_ns=root.start_ns + max(root.duration, 0),
+        duration=0,
+        ml_app=str(root.span.get("ml_app", "")),
+        service=str(root.span.get("service", "")),
+        env=str(root.span.get("env", "")),
+        span_key=f"metric-{name}",
+        input_value=name,
+        output_value=str(value),
+        metadata={"metric_name": name, "metric_value": value, "source": source},
+        link_span=root,
+        semantic_type="metric",
+    )
+
+
+def _span_from_milestone_event(event: Dict[str, Any], root: SpanContext, contexts: List[SpanContext]) -> Dict[str, Any]:
+    name = str(event.get("milestone_type", ""))
+    turn_start = _to_int(event.get("turn_start"))
+    turn_end = _to_int(event.get("turn_end"))
+    anchor = _context_for_turn(contexts, turn_start or _to_int(event.get("turn_id"))) or root
+    end = _context_for_turn(contexts, turn_end) or anchor
+    start_ns = anchor.start_ns if anchor else _timestamp_ns(str(event.get("timestamp", "")))
+    duration = 0
+    if turn_start is not None and turn_end is not None:
+        duration = max(0, end.start_ns + max(end.duration, 0) - start_ns)
+    metadata: Dict[str, Any] = {"milestone_type": name}
+    for key in ("turn_id", "turn_start", "turn_end"):
+        if key in event:
+            metadata[key] = event[key]
+    detail_value = event.get("detail")
+    detail = cast(Dict[str, Any], detail_value) if isinstance(detail_value, dict) else {}
+    metadata.update(detail)
+    return _task_span(
+        session_id=str(event.get("session_id", "")),
+        name=name,
+        start_ns=start_ns,
+        duration=duration,
+        ml_app=str(root.span.get("ml_app", "")),
+        service=str(root.span.get("service", "")),
+        env=str(root.span.get("env", "")),
+        span_key=f"enrichment-milestone-{name}-{event.get('timestamp', '')}",
+        input_value=name,
+        output_value=json.dumps(detail, sort_keys=True) if detail else "",
+        metadata=metadata,
+        link_span=anchor,
+        semantic_type="milestone",
+    )
+
+
+def _span_from_metric_event(event: Dict[str, Any], root: SpanContext) -> Dict[str, Any]:
+    return _metric_span(
+        str(event.get("metric_name", "")), _numeric_value(event.get("value")), root, source="enrichment"
+    )
+
+
+def _eval_from_milestone_event(
+    event: Dict[str, Any], root: SpanContext, contexts: List[SpanContext]
+) -> Optional[Dict[str, Any]]:
+    name = str(event.get("milestone_type", ""))
+    anchor = _context_for_turn(contexts, _to_int(event.get("turn_start")) or _to_int(event.get("turn_id"))) or root
+    detail = event.get("detail") if isinstance(event.get("detail"), dict) else {}
+    if event.get("turn_start") is not None and event.get("turn_end") is not None:
+        turn_start = int(event.get("turn_start", anchor.turn_id))
+        turn_end = int(event.get("turn_end", anchor.turn_id))
+        return {
+            "join_on": {"span": {"trace_id": anchor.trace_id, "span_id": anchor.span_id}},
+            "label": name,
+            "metric_type": "json",
+            "json_value": {"turn_start": turn_start, "turn_end": turn_end, "detail": detail},
+            "ml_app": str(root.span.get("ml_app", "")),
+            "timestamp_ms": _now_ms(),
+            "tags": ["source:trajectory"],
+        }
+    return {
+        "join_on": {"span": {"trace_id": anchor.trace_id, "span_id": anchor.span_id}},
+        "label": name,
+        "metric_type": "categorical",
+        "categorical_value": "info",
+        "reasoning": json.dumps(detail, sort_keys=True),
+        "metadata": detail,
+        "ml_app": str(root.span.get("ml_app", "")),
+        "timestamp_ms": _now_ms(),
+        "tags": ["source:trajectory"],
+    }
+
+
+def _task_span(
+    *,
+    session_id: str,
+    name: str,
+    start_ns: int,
+    duration: int,
+    ml_app: str,
+    service: str,
+    env: str,
+    span_key: str,
+    input_value: str,
+    output_value: str,
+    metadata: Dict[str, Any],
+    link_span: SpanContext,
+    semantic_type: str,
+) -> Dict[str, Any]:
+    trace_id = deterministic_trace_id(session_id + ".enrichment")
+    span_id = deterministic_span_id(session_id, span_key)
+    tags = [
+        f"ml_app:{ml_app or 'lapdog'}",
+        f"session_id:{session_id}",
+        f"service:{service or ml_app or 'lapdog'}",
+        f"env:{env or 'local'}",
+        f"trajectory.semantic_type:{semantic_type}",
+        "trajectory.marker.synthetic:true",
+        "source:trajectory-markers",
+    ]
+    return {
+        "span_id": span_id,
+        "trace_id": trace_id,
+        "parent_id": "undefined",
+        "name": name,
+        "status": "ok",
+        "duration": duration,
+        "start_ns": start_ns or _now_ns(),
+        "ml_app": ml_app or "lapdog",
+        "service": service or ml_app or "lapdog",
+        "env": env or "local",
+        "session_id": session_id,
+        "tags": tags,
+        "meta": {
+            "span": {"kind": "task"},
+            "input": {"value": input_value},
+            "output": {"value": output_value},
+            "metadata": metadata,
+        },
+        "metrics": {},
+        "span_links": [
+            {
+                "span_id": link_span.span_id,
+                "trace_id": link_span.trace_id,
+                "attributes": {"trajectory.link.type": "enrichment"},
+            }
+        ],
+    }
+
+
+def deterministic_trace_id(value: str) -> str:
+    return _big_endian_uint64_decimal(hashlib.sha256(value.encode("utf-8")).digest()[:8])
+
+
+def deterministic_span_id(session_id: str, span_key: str) -> str:
+    return _big_endian_uint64_decimal(hashlib.sha256(f"{session_id}::{span_key}".encode("utf-8")).digest()[:8])
+
+
+def _big_endian_uint64_decimal(data: bytes) -> str:
+    value = int.from_bytes(data, byteorder="big", signed=False)
+    return str(value or 1)
+
+
+def _severity_assessment(severity: str) -> str:
+    if severity == "error":
+        return "fail"
+    if severity == "success":
+        return "pass"
+    if severity == "warn":
+        return "needs_review"
+    return ""
+
+
+def _outcome_assessment(outcome: str) -> str:
+    if outcome == "success":
+        return "pass"
+    if outcome == "abandoned":
+        return "fail"
+    return ""
+
+
+def _group_contexts_by_session(contexts: List[SpanContext]) -> Dict[str, List[SpanContext]]:
+    result: Dict[str, List[SpanContext]] = {}
+    for context in contexts:
+        result.setdefault(context.session_id, []).append(context)
+    return result
+
+
+def _root_context(contexts: List[SpanContext]) -> Optional[SpanContext]:
+    roots = [
+        context for context in contexts if str(context.span.get("parent_id", "undefined")) in ("", "undefined", "0")
+    ]
+    if roots:
+        return sorted(roots, key=lambda c: (c.start_ns, c.span_id))[0]
+    return contexts[0] if contexts else None
+
+
+def _context_for_turn(contexts: List[SpanContext], turn_id: Optional[int]) -> Optional[SpanContext]:
+    if turn_id is None:
+        return None
+    matches = [context for context in contexts if context.turn_id == turn_id]
+    if not matches:
+        return None
+    roots = [context for context in matches if context.kind in ("agent", "step")]
+    return sorted(roots or matches, key=lambda c: (c.start_ns, c.span_id))[0]
+
+
+def _numeric_value(value: Any) -> float:
+    coerced = _to_float(value)
+    return 0.0 if coerced is None else coerced
+
+
+def _to_int(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _tag_value(span: Dict[str, Any], key: str) -> Optional[str]:
+    prefix = f"{key}:"
+    for tag in span.get("tags", []):
+        if isinstance(tag, str) and tag.startswith(prefix):
+            return tag.split(":", 1)[1]
+    return None
+
+
+def _parse_jsonish(text: str) -> Any:
+    if not isinstance(text, str):
+        return None
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, sort_keys=True)
+    except TypeError:
+        return str(value)
+
+
+def _timestamp_ns(timestamp: str) -> int:
+    if not timestamp:
+        return _now_ns()
+    try:
+        parsed = datetime.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        return int(parsed.timestamp() * 1_000_000_000)
+    except ValueError:
+        return _now_ns()
+
+
+def _now_ns() -> int:
+    return int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1_000_000_000)
+
+
+def _now_ms() -> int:
+    return int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1_000)

--- a/releasenotes/notes/llmobs-trajectory-markers-8f7c9d2a4b6e.yaml
+++ b/releasenotes/notes/llmobs-trajectory-markers-8f7c9d2a4b6e.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add local LLMObs trajectory marker support, including eval-metric ingestion,
+    YAML-backed marker evaluation, and a `/test/session/llmobs/enrichment`
+    endpoint for rendering trajectory enrichment milestones and metrics.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,6 @@ from ddapm_test_agent.trace import Span
 from ddapm_test_agent.trace import Trace
 from ddapm_test_agent.trace_snapshot import DEFAULT_SNAPSHOT_IGNORES
 
-
 # Fix the service name to make tests consistently pass local and in CI.
 config.service = ""
 
@@ -662,13 +661,17 @@ def do_reference_v2_http_apmtelemetry(
     yield fn
 
 
-@pytest.fixture
-def available_port() -> str:
+def _available_port() -> str:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(("", 0))  # Bind to a free port provided by the host.
     port = s.getsockname()[1]  # Get the port number assigned.
     s.close()  # Release the socket.
     return str(port)
+
+
+@pytest.fixture
+def available_port() -> str:
+    return _available_port()
 
 
 @pytest.fixture
@@ -704,6 +707,8 @@ def test_agent_env(testagent_connection_type, testagent_uds_socket_path):
     env = os.environ.copy()
     if testagent_connection_type == "uds":
         env["DD_APM_RECEIVER_SOCKET"] = str(testagent_uds_socket_path)
+        env["OTLP_HTTP_PORT"] = _available_port()
+        env["OTLP_GRPC_PORT"] = _available_port()
     return env
 
 
@@ -882,7 +887,9 @@ async def grpc_client_with_failure_type(agent_app, available_port, aiohttp_serve
     if service_type not in ["logs", "metrics", "traces"]:
         raise ValueError(f"service_type must be 'logs', 'metrics', or 'traces', got: {service_type}")
 
-    endpoint = LOGS_ENDPOINT if service_type == "logs" else METRICS_ENDPOINT if service_type == "metrics" else TRACES_ENDPOINT
+    endpoint = (
+        LOGS_ENDPOINT if service_type == "logs" else METRICS_ENDPOINT if service_type == "metrics" else TRACES_ENDPOINT
+    )
 
     http_handlers = {
         "http_400": lambda _: web.HTTPBadRequest(text="invalid"),

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,6 +2,7 @@ import json
 import os
 import platform
 import signal
+import socket
 import subprocess
 import time
 
@@ -11,8 +12,15 @@ import pytest
 from ddapm_test_agent.trace import decode_v1
 from ddapm_test_agent.trace import trace_id
 
-
 _FAST_EXIT_ARGS = ["--port=4318", "--otlp-http-port=4318"]
+
+
+def _available_port() -> str:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return str(port)
 
 
 def test_log_level_info_includes_info_messages():
@@ -450,6 +458,8 @@ async def test_uds(tmp_path, agent, available_port, loop):
     env = os.environ.copy()
     env["DD_APM_RECEIVER_SOCKET"] = str(tmp_path / "apm.socket")
     env["PORT"] = str(available_port)
+    env["OTLP_HTTP_PORT"] = _available_port()
+    env["OTLP_GRPC_PORT"] = _available_port()
     p = subprocess.Popen(["ddapm-test-agent"], env=env)
 
     # Sleep for 1 second to give time for the testagent to start up

--- a/tests/test_llmobs_event_platform.py
+++ b/tests/test_llmobs_event_platform.py
@@ -1,4 +1,6 @@
+import copy
 import gzip
+import json
 import time
 
 import msgpack
@@ -56,6 +58,26 @@ async def _submit_llmobs_payload(agent, payload, path="/evp_proxy/v2/api/v2/llmo
         headers={"Content-Type": "application/msgpack", "Content-Encoding": "gzip"},
         data=data,
     )
+
+
+def _eval_metric(label, trace_id="trace-123", span_id="span-child", value=0.9, timestamp_ms=123):
+    return {
+        "join_on": {"span": {"trace_id": trace_id, "span_id": span_id}},
+        "label": label,
+        "metric_type": "score",
+        "score_value": value,
+        "assessment": "pass",
+        "timestamp_ms": timestamp_ms,
+    }
+
+
+def _eval_metric_payload(*metrics):
+    return {"data": {"type": "evaluation_metric", "attributes": {"metrics": list(metrics)}}}
+
+
+def _event_by_span_id(list_response, span_id):
+    events = list_response["result"]["events"]
+    return next(event["event"]["custom"] for event in events if event["event"]["custom"]["span_id"] == span_id)
 
 
 # Tests from master branch (testing empty/stub responses)
@@ -500,6 +522,151 @@ async def test_llmobs_trace(agent, llmobs_payload):
     data = await resp.json()
     assert "data" in data
     assert data["data"]["attributes"]["root_id"] is not None
+
+
+async def test_eval_metric_ingestion_attaches_to_existing_span(agent, llmobs_payload):
+    await _submit_llmobs_payload(agent, llmobs_payload)
+    resp = await agent.post(
+        "/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric",
+        json=_eval_metric_payload(_eval_metric("quality-score")),
+    )
+    assert resp.status == 200
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": ""}, "limit": 50}},
+    )
+    data = await resp.json()
+    custom = _event_by_span_id(data, "span-child")
+    assert custom["evaluation"]["quality-score"]["value"] == 0.9
+    assert custom["evaluations"]["custom"]["quality-score"] == 0.9
+    assert custom["evaluation_assessments"]["custom"]["quality-score"] == "pass"
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/fetch_one?type=llmobs",
+        json={"eventId": "span-child"},
+    )
+    fetched = await resp.json()
+    assert fetched["result"]["custom"]["evaluation"]["quality-score"]["value"] == 0.9
+
+    resp = await agent.get("/api/ui/llm-obs/v1/trace/trace-123")
+    trace = await resp.json()
+    child = next(span for span in trace["data"]["attributes"]["spans"].values() if span["span_id"] == "span-child")
+    assert child["evaluation"]["quality-score"]["value"] == 0.9
+
+
+async def test_eval_metric_pending_attaches_when_span_arrives(agent, llmobs_payload):
+    resp = await agent.post(
+        "/v2/eval-metric",
+        json=_eval_metric_payload(_eval_metric("pending-score", value=0.7)),
+    )
+    assert resp.status == 200
+    await _submit_llmobs_payload(agent, llmobs_payload)
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": ""}, "limit": 50}},
+    )
+    data = await resp.json()
+    custom = _event_by_span_id(data, "span-child")
+    assert custom["evaluations"]["custom"]["pending-score"] == 0.7
+
+
+async def test_eval_metric_tag_join_and_dedupe(agent, llmobs_payload):
+    metric = {
+        "join_on": {"tag": {"key": "env", "value": "test"}},
+        "label": "tag-score",
+        "metric_type": "score",
+        "score_value": 1.0,
+        "timestamp_ms": 456,
+    }
+    await agent.post(
+        "/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric",
+        json=_eval_metric_payload(metric, metric),
+    )
+    await _submit_llmobs_payload(agent, llmobs_payload)
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": ""}, "limit": 50}},
+    )
+    data = await resp.json()
+    root = _event_by_span_id(data, "span-root")
+    child = _event_by_span_id(data, "span-child")
+    assert root["evaluation"]["tag-score"]["value"] == 1.0
+    assert child["evaluation"]["tag-score"]["value"] == 1.0
+
+
+async def test_enrichment_endpoint_accepts_json_shapes_and_renders_spans(agent, llmobs_payload):
+    payload = copy.deepcopy(llmobs_payload)
+    for span in payload["spans"]:
+        span["session_id"] = "session-enrich"
+        span["tags"] = span.get("tags", []) + ["session_id:session-enrich"]
+    payload["spans"][0]["meta"]["metadata"] = {"turn_id": 1}
+    payload["spans"][1]["meta"]["metadata"] = {"turn_id": 2}
+    await _submit_llmobs_payload(agent, payload)
+
+    point = {
+        "event_kind": "enrichment",
+        "enrichment_type": "milestone",
+        "session_id": "session-enrich",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "milestone_type": "user-frustration",
+        "turn_id": 1,
+        "detail": {"severity": "warn"},
+    }
+    range_event = {
+        "event_kind": "enrichment",
+        "enrichment_type": "milestone",
+        "session_id": "session-enrich",
+        "timestamp": "2026-01-01T00:00:01Z",
+        "milestone_type": "test-fix-cycle",
+        "turn_start": 1,
+        "turn_end": 2,
+        "detail": {"outcome": "success"},
+    }
+    metric = {
+        "event_kind": "enrichment",
+        "enrichment_type": "metric",
+        "session_id": "session-enrich",
+        "timestamp": "2026-01-01T00:00:02Z",
+        "metric_name": "trajectory.score",
+        "value": 0.42,
+    }
+    for body in (point, [range_event]):
+        resp = await agent.post("/test/session/llmobs/enrichment", json=body)
+        assert resp.status == 200
+        assert (await resp.json())["accepted"] == (len(body) if isinstance(body, list) else 1)
+    resp = await agent.post(
+        "/test/session/llmobs/enrichment",
+        data=json.dumps(metric) + "\n",
+        headers={"Content-Type": "application/jsonl"},
+    )
+    assert resp.status == 200
+
+    resp = await agent.get("/test/session/llmobs/enrichment")
+    stored = await resp.json()
+    assert len(stored["events"]) == 3
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": "@meta.span.kind:task"}, "limit": 50}},
+    )
+    data = await resp.json()
+    task_spans = {event["event"]["custom"]["name"]: event["event"]["custom"] for event in data["result"]["events"]}
+    assert task_spans["user-frustration"]["tags"].count("trajectory.semantic_type:milestone") == 1
+    expected_range_duration = (
+        payload["spans"][1]["start_ns"] + payload["spans"][1]["duration"] - payload["spans"][0]["start_ns"]
+    )
+    assert task_spans["test-fix-cycle"]["duration"] == expected_range_duration
+    assert task_spans["metric.trajectory.score"]["tags"].count("trajectory.semantic_type:metric") == 1
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/fetch_one?type=llmobs",
+        json={"eventId": "span-root"},
+    )
+    fetched = await resp.json()
+    assert fetched["result"]["custom"]["evaluations"]["custom"]["trajectory.score"] == 0.42
 
 
 async def test_llmobs_aggregate(agent, llmobs_payload):

--- a/tests/test_llmobs_markers.py
+++ b/tests/test_llmobs_markers.py
@@ -1,0 +1,173 @@
+from ddapm_test_agent.markers import MarkerEvaluator
+from ddapm_test_agent.markers import apply_eval_metrics
+
+
+def _span(
+    span_id,
+    name,
+    kind,
+    start_ns,
+    *,
+    input_value="",
+    output_value="",
+    status="ok",
+    parent_id="root",
+    turn_id=1,
+    metrics=None,
+):
+    return {
+        "name": name,
+        "span_id": span_id,
+        "trace_id": "trace-marker",
+        "parent_id": parent_id,
+        "session_id": "session-marker",
+        "status": status,
+        "duration": 1_000_000,
+        "start_ns": start_ns,
+        "ml_app": "test-app",
+        "service": "test-service",
+        "env": "test",
+        "meta": {
+            "span": {"kind": kind},
+            "input": {"value": input_value},
+            "output": {"value": output_value},
+            "metadata": {"turn_id": turn_id},
+        },
+        "metrics": metrics or {},
+        "tags": ["session_id:session-marker"],
+    }
+
+
+def _metric_by_label(metrics, label):
+    return [metric for metric in metrics if metric["label"] == label]
+
+
+def test_marker_evaluator_detects_builtin_points_ranges_and_measures():
+    spans = [
+        _span(
+            "root",
+            "agent",
+            "agent",
+            1_000_000_000,
+            input_value="Why do you keep doing the wrong thing?",
+            parent_id="undefined",
+            turn_id=1,
+        ),
+        _span(
+            "failed-test",
+            "Bash",
+            "tool",
+            2_000_000_000,
+            input_value='{"command": "pytest tests"}',
+            output_value="FAILED tests/test_example.py",
+            status="error",
+            turn_id=1,
+        ),
+        _span(
+            "edit",
+            "Edit",
+            "tool",
+            3_000_000_000,
+            input_value='{"file_path": "tests/test_example.py"}',
+            turn_id=2,
+        ),
+        _span(
+            "passed-test",
+            "Bash",
+            "tool",
+            4_000_000_000,
+            input_value='{"command": "pytest tests"}',
+            output_value="1 passed",
+            turn_id=3,
+        ),
+        _span(
+            "commit",
+            "Bash",
+            "tool",
+            5_000_000_000,
+            input_value='{"command": "git commit -m \'fix tests\'"}',
+            output_value="[main abc123] fix tests",
+            turn_id=4,
+        ),
+        _span(
+            "denied",
+            "Bash",
+            "tool",
+            6_000_000_000,
+            input_value='{"command": "cat /private/file"}',
+            output_value="permission denied",
+            status="error",
+            turn_id=5,
+        ),
+    ]
+
+    output = MarkerEvaluator().evaluate(spans)
+    labels = {metric["label"] for metric in output.eval_metrics}
+
+    assert "user-frustration" in labels
+    assert "git-commit" in labels
+    assert "test-failed" in labels
+    assert "test-passed" in labels
+    assert "permission-denied" in labels
+    assert "test-fix-cycle" in labels
+    assert _metric_by_label(output.eval_metrics, "frustration-count")[0]["score_value"] == 1.0
+    assert _metric_by_label(output.eval_metrics, "commit-count")[0]["score_value"] == 1.0
+    assert _metric_by_label(output.eval_metrics, "test-fix-cycle-count")[0]["score_value"] == 1.0
+    assert _metric_by_label(output.eval_metrics, "test-pass-rate")[0]["score_value"] == 0.5
+
+    task_names = {span["name"] for span in output.synthetic_spans if span["meta"]["span"]["kind"] == "task"}
+    assert "test-fix-cycle" in task_names
+    assert "metric.test-pass-rate" in task_names
+
+    apply_eval_metrics(spans, output.eval_metrics)
+    assert spans[0]["evaluations"]["custom"]["user-frustration"] == "warn"
+    assert spans[1]["evaluations"]["custom"]["test-fix-cycle"]["outcome"] == "success"
+    assert spans[0]["evaluations"]["custom"]["test-pass-rate"] == 0.5
+
+
+def test_marker_evaluator_supports_yaml_any_of_bracket_and_cost(tmp_path):
+    config_path = tmp_path / "markers.yaml"
+    config_path.write_text(
+        """
+version: 1
+points:
+  - name: costly-or-denied
+    severity: warn
+    match:
+      any_of:
+        - turn_cost_above: 1.5
+        - denied: true
+ranges:
+  - name: edit-window
+    bracket:
+      starts_when:
+        tool: Edit
+      ends_when:
+        tool: Bash
+    on_complete: success
+measures:
+  - name: costly-count
+    count:
+      point: costly-or-denied
+""",
+        encoding="utf-8",
+    )
+    spans = [
+        _span(
+            "root",
+            "agent",
+            "agent",
+            1_000_000_000,
+            parent_id="undefined",
+            metrics={"estimated_total_cost": 2.0},
+        ),
+        _span("edit", "Edit", "tool", 2_000_000_000),
+        _span("bash", "Bash", "tool", 3_000_000_000),
+    ]
+
+    output = MarkerEvaluator(str(config_path)).evaluate(spans)
+    labels = {metric["label"] for metric in output.eval_metrics}
+
+    assert "costly-or-denied" in labels
+    assert "edit-window" in labels
+    assert _metric_by_label(output.eval_metrics, "costly-count")[0]["score_value"] == 1.0

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -318,6 +318,37 @@ async def test_list_api_filters_step_kind(agent):
     assert data["result"]["events"][0]["event"]["custom"]["meta"]["span"]["kind"] == "step"
 
 
+async def test_llmobs_marker_evaluation_applies_to_hook_generated_spans(agent):
+    sid = "pi-marker-frustration"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid, prompt="Why do you keep doing the wrong thing?"))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": f"@meta.span.kind:agent @session_id:{sid}"}, "limit": 50}},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["hitCount"] == 1
+    root = data["result"]["events"][0]["event"]["custom"]
+    assert root["evaluations"]["custom"]["user-frustration"] == "warn"
+    assert root["evaluation_assessments"]["custom"]["user-frustration"] == "needs_review"
+
+    resp = await agent.post(
+        "/api/unstable/llm-obs-query-rewriter/list?type=llmobs",
+        json={"list": {"search": {"query": f"@meta.span.kind:task @session_id:{sid}"}, "limit": 50}},
+    )
+    task_data = await resp.json()
+    task_names = {event["event"]["custom"]["name"] for event in task_data["result"]["events"]}
+    assert "user-frustration" in task_names
+    assert "metric.frustration-count" in task_names
+
+
 async def test_step_finalized_on_agent_end_without_turn_end(agent):
     """If turn_end is missed, agent_end still finalizes the active step."""
     sid = "pi-no-turn-end"


### PR DESCRIPTION
## Summary

Adds local Trajectory marker support to `dd-apm-test-agent` for LLMObs sessions.

This ports the useful local subset rather than the full Trajectory evaluator: eval-metric ingestion, a bundled/default YAML marker evaluator, and trajectory-spec enrichment rendering into LLMObs-compatible spans/evaluations.

## Implementation Plan

1. Ingest existing LLM Obs eval-metric payloads from `/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric`, `/evp_proxy/v2/api/intake/llm-obs/v2/eval-metric`, and `/v2/eval-metric`.
2. Store valid eval metrics in memory, dedupe them by `(trace_id, span_id, label, timestamp_ms)`, and apply them during LLMObs span assembly.
3. Support `join_on.span` and `join_on.tag`, leaving unmatched metrics pending until matching spans arrive.
4. Add a PyYAML-backed marker evaluator with bundled defaults modeled on Trajectory builtins.
5. Support point markers, sequence/bracket range markers, and count/ratio measures over in-memory LLMObs spans.
6. Render point markers as categorical span evaluations plus synthetic milestone `task` spans.
7. Render range markers as JSON span evaluations plus synthetic range milestone `task` spans.
8. Render measures as score evaluations on the session root plus synthetic metric companion `task` spans.
9. Add `/test/session/llmobs/enrichment` for trajectory-spec `milestone` and `metric` enrichment events, accepting JSON object, JSON list, and JSONL.
10. Keep existing list, fetch_one, trace, facet, aggregate, and scalar query behavior on normal span fields.

## Problem Patterns Analysis Conclusions

Trajectory problem patterns map cleanly onto three marker shapes:

- Points are instantaneous observations on a single turn/tool/LLM span, such as user frustration, permission denial, failed tests, passed tests, git commits, or tool errors.
- Ranges describe work episodes over a trajectory, either as ordered sequences or start/end brackets. The important built-in example is `test-fix-cycle`: a failed test, an edit/write/apply-patch step, then a passing test.
- Measures summarize patterns over a session, usually counts or ratios. Examples include frustration count, commit count, completed test-fix-cycle count, and test pass rate.

The trajectory-spec enrichment model separates derived facts from raw telemetry. Milestones and metrics are transported as enrichment events, and the LLMObs transport represents them as synthetic `task` spans linked back to original session/turn/tool spans. That means marker facts can be visible in traces without changing the original span schema.

For the test agent, the practical integration point is already present: the LLMObs query/list/fetch/trace responses read `evaluation`, `evaluations.custom`, and `evaluation_assessments.custom` directly from spans. Marker results can therefore surface through existing UI/query endpoints with no separate marker query API.

This implementation intentionally stops at useful local parity. It does not port advanced Trajectory evaluator features such as SQL-backed conditions, compute blocks, distributions, org/user/project layered precedence, or mechanize integration.

## Tests

- `python -m pytest tests/test_llmobs_event_platform.py tests/test_agent.py tests/test_codex_hooks.py tests/test_pi_hooks.py tests/test_llmobs_markers.py`
- `python -m black --check ddapm_test_agent/markers.py ddapm_test_agent/llmobs_event_platform.py ddapm_test_agent/agent.py tests/test_llmobs_event_platform.py tests/test_llmobs_markers.py tests/test_pi_hooks.py tests/conftest.py tests/test_agent.py`
- `python -m flake8 ddapm_test_agent/markers.py ddapm_test_agent/llmobs_event_platform.py ddapm_test_agent/agent.py tests/test_llmobs_event_platform.py tests/test_llmobs_markers.py tests/test_pi_hooks.py tests/conftest.py tests/test_agent.py`
- `python -m mypy ddapm_test_agent/markers.py`
- `git diff --check`

Note: a broader mypy run over `agent.py`/`llmobs_event_platform.py` still reports existing errors in `ddapm_test_agent/trace.py` and `ddapm_test_agent/tracestats_snapshot.py`; `markers.py` is clean.