### PR TITLE
docs(lapdog): note DD_SITE requirement for --forward

### DIFF
--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -211,7 +211,12 @@ is lost.
 
 Useful flags:
 
-- `--forward` — also forward LLMObs events to Datadog (requires `DD_API_KEY`).
+- `--forward` — also forward LLMObs events to Datadog. Requires both
+  `DD_API_KEY` and `DD_SITE` to be set in the environment when Lapdog
+  starts (e.g. `DD_SITE=datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`,
+  `ddog-gov.com`, …). If either is missing, forwarding is silently skipped
+  — the tracer still gets a 200 OK, but nothing reaches Datadog. Setting
+  `DD_AGENT_URL` instead bypasses both and forwards through that agent.
 - `--no-plugin-install` — skip the `lapdog claude` auto-install of the Claude
   Code plugin.
 - `-p <port>` / `--port <port>` — bind to a different port (default `8126`).


### PR DESCRIPTION
## Summary

- The `--forward` flag for lapdog requires both `DD_API_KEY` *and* `DD_SITE`, but the README only mentioned `DD_API_KEY`.
- If `DD_SITE` is missing, the test agent silently skips forwarding (logs an error and returns 200 OK to the tracer), so nothing reaches Datadog and the user sees no obvious failure — easy footgun.
- Updates the `--forward` bullet in `lapdog/README.md` to spell out the requirement, list common `DD_SITE` values, and mention `DD_AGENT_URL` as a bypass.

## Why

Confirmed in `ddapm_test_agent/agent.py:907-921` (and the duplicate paths at ~`952` and ~`1003`): the forwarding handlers read `DD_SITE` from the app config and bail with `log.error("No DD_SITE set …")` if it's unset, unless `DD_AGENT_URL` is configured.

## Test plan

- [ ] Render the README on GitHub and confirm the `--forward` bullet reads cleanly.
- [ ] No code changes — nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)