### PR TITLE
feat: add v1 to /info and missing payload attribute

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -1183,6 +1183,7 @@ class Agent:
                 "/v0.4/traces",
                 "/v0.5/traces",
                 "/v0.7/traces",
+                "/v1.0/traces",
                 "/v0.6/stats",
                 "/telemetry/proxy/",
                 "/v0.7/config",

--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -784,6 +784,8 @@ def _convert_v1_payload(data: Any) -> v04TracePayload:
     string_table: List[str] = [""]  # 0 is reserved for empty string
 
     v04Payload: List[List[Span]] = []
+    payload_meta: Dict[str, str] = {}
+    payload_metrics: Dict[str, MetricType] = {}
 
     for k, v in data.items():
         if k == 1:
@@ -792,6 +794,12 @@ def _convert_v1_payload(data: Any) -> v04TracePayload:
             # TODO: In the future we can assert on these keys
             if isinstance(v, str):
                 string_table.append(v)
+        elif k == 10:
+            # Payload-level attributes (e.g. `_dd.apm_mode`, `_dd.git.commit.sha`) — flat
+            # triplet array, same encoding as chunk/span attributes.
+            if not isinstance(v, list):
+                raise TypeError("Trace payload 'attributes' (10) must be a list, got type %r." % type(v))
+            _convert_v1_attributes(v, payload_meta, payload_metrics, string_table)
         elif k == 11:
             if not isinstance(v, list):
                 raise TypeError("Trace payload 'chunks' (11) must be a list.")
@@ -799,6 +807,14 @@ def _convert_v1_payload(data: Any) -> v04TracePayload:
                 v04Payload.append(_convert_v1_chunk(chunk, string_table))
         else:
             raise TypeError("Unknown key %r in v1 trace payload" % k)
+
+    if payload_meta or payload_metrics:
+        for chunk_spans in v04Payload:
+            for span in chunk_spans:
+                for meta_key, meta_value in payload_meta.items():
+                    span["meta"].setdefault(meta_key, meta_value)
+                for metric_key, metric_value in payload_metrics.items():
+                    span["metrics"].setdefault(metric_key, metric_value)
     return cast(v04TracePayload, v04Payload)
 
 

--- a/releasenotes/notes/v1-traces-info-and-payload-attributes-d25b84682f8c20ed.yaml
+++ b/releasenotes/notes/v1-traces-info-and-payload-attributes-d25b84682f8c20ed.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Advertise ``/v1.0/traces`` in the ``endpoints`` list returned by ``/info`` so tracers using the standard V1 enablement flow (``DD_TRACE_AGENT_PROTOCOL_VERSION=1.0``) can negotiate V1 against the test-agent without client-side overrides.
+  - |
+    Decode payload-level attributes (key ``10``) in V1 trace payloads. Attributes such as ``_dd.apm_mode`` and ``_dd.git.commit.sha`` are now propagated to every span in the payload, matching the behavior of the upstream Datadog Agent.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -134,6 +134,7 @@ async def test_info(agent):
             "/v0.4/traces",
             "/v0.5/traces",
             "/v0.7/traces",
+            "/v1.0/traces",
             "/v0.6/stats",
             "/telemetry/proxy/",
             "/v0.7/config",
@@ -835,6 +836,78 @@ async def test_trace_v1_span_event():
         "event-key3": {"type": 3, "double_value": 3.14},
         "event-key4": {"type": 2, "int_value": 123},
     }
+
+
+async def test_trace_v1_payload_attributes():
+    # Payload-level attributes at key 10 (e.g. `_dd.apm_mode`, `_dd.git.commit.sha`)
+    # should be decoded and propagated to every span across all chunks.
+    data = msgpack.packb(
+        {
+            10: [
+                "_dd.apm_mode",
+                1,
+                "off",
+                "_dd.git.commit.sha",
+                1,
+                "abc123",
+                "payload_num",
+                4,
+                7,
+            ],
+            11: [
+                {
+                    4: [
+                        {
+                            1: "svc-a",
+                            2: "span-a",
+                            3: "res-a",
+                            4: 1,
+                        },
+                        {
+                            1: "svc-a",
+                            2: "span-a2",
+                            3: "res-a2",
+                            4: 2,
+                            9: ["_dd.apm_mode", 1, "on"],  # span-level overrides payload-level
+                        },
+                    ],
+                    6: bytes(
+                        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0xE3]
+                    ),
+                },
+                {
+                    4: [
+                        {
+                            1: "svc-b",
+                            2: "span-b",
+                            3: "res-b",
+                            4: 3,
+                        }
+                    ],
+                    6: bytes(
+                        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0xE4]
+                    ),
+                },
+            ],
+        }
+    )
+    result = decode_v1(data)
+    assert len(result) == 2
+    # First chunk, first span — no per-span override, inherits payload-level attrs.
+    span_a = result[0][0]
+    assert span_a["meta"]["_dd.apm_mode"] == "off"
+    assert span_a["meta"]["_dd.git.commit.sha"] == "abc123"
+    assert span_a["metrics"]["payload_num"] == 7
+    # First chunk, second span — sets `_dd.apm_mode` itself, must win over payload-level.
+    span_a2 = result[0][1]
+    assert span_a2["meta"]["_dd.apm_mode"] == "on"
+    assert span_a2["meta"]["_dd.git.commit.sha"] == "abc123"
+    assert span_a2["metrics"]["payload_num"] == 7
+    # Second chunk also receives payload-level attrs.
+    span_b = result[1][0]
+    assert span_b["meta"]["_dd.apm_mode"] == "off"
+    assert span_b["meta"]["_dd.git.commit.sha"] == "abc123"
+    assert span_b["metrics"]["payload_num"] == 7
 
 
 async def test_trace_v1_span_links():


### PR DESCRIPTION
## Summary
  
Two small V1 trace payload improvements:
  
- [**APMSP-3028**](https://datadoghq.atlassian.net/browse/APMSP-3028) — Add `/v1.0/traces` to the `endpoints` list returned by `/info`. Tracers following the standard V1 enablement flow (`DD_TRACE_AGENT_PROTOCOL_VERSION=1.0`) can now negotiate V1 against the test-agent without client-side overrides.
- [APMSP-2934](https://datadoghq.atlassian.net/browse/APMSP-2934) — Decode payload-level attributes (msgpack key `10`) in V1 trace payloads. Attributes such as `_dd.apm_mode` and `_dd.git.commit.sha` are propagated onto every span. Span- and chunk-level values keep precedence over payload-level defaults.


[APMSP-2934]: https://datadoghq.atlassian.net/browse/APMSP-2934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ