### PR TITLE
fix(lapdog): return live duration for in-flight spans

### DIFF
--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -1811,7 +1811,18 @@ class ClaudeHooksAPI:
 
     async def handle_spans(self, request: Request) -> web.Response:
         """Handle GET /claude/hooks/spans — return all assembled spans."""
-        return web.json_response({"spans": self._assembled_spans})
+        now_ns = monotonic_wall_ns()
+        in_flight: Dict[str, int] = {}
+        for session in self._sessions.values():
+            if not session.root_span_emitted and getattr(session, "_root_span_ref", None) is not None:
+                in_flight[session.root_span_id] = session.start_ns
+        if not in_flight:
+            return web.json_response({"spans": self._assembled_spans})
+        spans = [
+            {**s, "duration": now_ns - in_flight[s["span_id"]]} if s.get("span_id") in in_flight else s
+            for s in self._assembled_spans
+        ]
+        return web.json_response({"spans": spans})
 
     async def handle_raw_events(self, request: Request) -> web.Response:
         """Handle GET /claude/hooks/raw — return all raw received events for debugging."""

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -497,6 +497,29 @@ async def test_hook_sessions_endpoint(agent):
     assert session_id in session_ids
 
 
+async def test_hook_in_flight_span_has_live_duration(agent):
+    session_id = "sess-in-flight-duration"
+
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "SessionStart"})
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "UserPromptSubmit",
+            "user_prompt": "What is the meaning of life?",
+        },
+    )
+
+    resp = await agent.get("/claude/hooks/spans")
+    assert resp.status == 200
+    body = await resp.json()
+    spans = body["spans"]
+
+    root_spans = [s for s in spans if s.get("session_id") == session_id and s["parent_id"] == "undefined"]
+    assert len(root_spans) == 1
+    assert root_spans[0]["duration"] > 0
+
+
 async def test_concurrent_subagents_parent_correctly(agent):
     """Two Task tools spawn sibling subagents — both should be parented to root, not each other."""
     session_id = "sess-concurrent"


### PR DESCRIPTION
## What does this PR do?

Fix `GET /claude/hooks/spans` to return a live elapsed duration for root spans of sessions that are still running (prompt submitted, `Stop` not yet fired).

## Who will it impact?

* [slack/#k9-ask-cloud-siem](https://dd.enterprise.slack.com/archives/C02PKN3LV96)

## Motivation

While a prompt is running, the lapdog dashboard showed Time & Duration as `0` because the root span is created with `duration: 0` as a placeholder and only updated when the `Stop` hook fires. The `/claude/hooks/spans` endpoint now returns `now - start_ns` for in-flight root spans without mutating the underlying span (preserving the `-1` permission-wait sentinel).

## Testing Guidelines

- Added `test_hook_in_flight_span_has_live_duration`: submits a prompt without `Stop`, queries `/claude/hooks/spans`, asserts `duration > 0`.
- All 14 existing `test_claude_hooks` tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)