### PR TITLE
Add pi model cost fallback

### DIFF
--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -60,13 +60,10 @@ _AI_GATEWAY_COST_PROVIDERS = frozenset({"anthropic", "openai"})
 
 def _split_ai_gateway_model_id(model_id: str) -> Tuple[Optional[str], str]:
     """Return (provider, model) for AI Gateway-style IDs like ``openai/gpt-5.5``."""
-    parts = model_id.split("/")
-    for index, provider in enumerate(parts[:-1]):
-        normalized_provider = provider.lower()
-        if normalized_provider in _AI_GATEWAY_COST_PROVIDERS:
-            model = "/".join(parts[index + 1 :])
-            if model:
-                return normalized_provider, model
+    provider, _, model = model_id.partition("/")
+    normalized_provider = provider.lower()
+    if model and normalized_provider in _AI_GATEWAY_COST_PROVIDERS:
+        return normalized_provider, model
     return None, model_id
 
 
@@ -97,7 +94,7 @@ def _compute_pi_cost_metrics(
     cost_provider, pricing_model_id = _split_ai_gateway_model_id(model_id)
     provider = cost_provider or model_provider.lower()
 
-    if provider == "openai":
+    if provider == "openai" or _looks_like_openai_model(pricing_model_id):
         return compute_openai_cost_metrics(
             model_id=pricing_model_id,
             non_cached_input_tokens=non_cached_input_tokens + cache_write_tokens,
@@ -114,14 +111,6 @@ def _compute_pi_cost_metrics(
     )
     if anthropic_cost is not None:
         return anthropic_cost
-
-    if _looks_like_openai_model(pricing_model_id):
-        return compute_openai_cost_metrics(
-            model_id=pricing_model_id,
-            non_cached_input_tokens=non_cached_input_tokens + cache_write_tokens,
-            cached_input_tokens=cache_read_tokens,
-            output_tokens=output_tokens,
-        )
 
     return {}
 

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -33,6 +33,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import cast
 
 from aiohttp import web
 from aiohttp.web import Request
@@ -48,11 +49,81 @@ from .claude_hooks import _USER_HANDLE
 from .claude_hooks import _format_span_id
 from .claude_hooks import _format_trace_id
 from .claude_hooks import _to_json_str
+from .codex_cost_tracker import compute_openai_cost_metrics
 from .llmobs_event_platform import with_cors
 
 log = logging.getLogger(__name__)
 
 _ML_APP = os.environ.get("DD_PI_CODING_AGENT_ML_APP", "pi-coding-agent")
+_AI_GATEWAY_COST_PROVIDERS = frozenset({"anthropic", "openai"})
+
+
+def _split_ai_gateway_model_id(model_id: str) -> Tuple[Optional[str], str]:
+    """Return (provider, model) for AI Gateway-style IDs like ``openai/gpt-5.5``."""
+    parts = model_id.split("/")
+    for index, provider in enumerate(parts[:-1]):
+        normalized_provider = provider.lower()
+        if normalized_provider in _AI_GATEWAY_COST_PROVIDERS:
+            model = "/".join(parts[index + 1 :])
+            if model:
+                return normalized_provider, model
+    return None, model_id
+
+
+def _looks_like_openai_model(model_id: str) -> bool:
+    return model_id.lower().startswith("gpt-")
+
+
+def _has_provider_cost(provider_cost: Any) -> bool:
+    if not isinstance(provider_cost, dict):
+        return False
+    for key in ("input", "output", "cacheRead", "cacheWrite", "total"):
+        value = provider_cost.get(key, 0)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)) and value > 0:
+            return True
+    return False
+
+
+def _compute_pi_cost_metrics(
+    model_id: str,
+    model_provider: str,
+    non_cached_input_tokens: int,
+    cache_write_tokens: int,
+    cache_read_tokens: int,
+    output_tokens: int,
+) -> Dict[str, int]:
+    cost_provider, pricing_model_id = _split_ai_gateway_model_id(model_id)
+    provider = cost_provider or model_provider.lower()
+
+    if provider == "openai":
+        return compute_openai_cost_metrics(
+            model_id=pricing_model_id,
+            non_cached_input_tokens=non_cached_input_tokens + cache_write_tokens,
+            cached_input_tokens=cache_read_tokens,
+            output_tokens=output_tokens,
+        )
+
+    anthropic_cost = compute_cost_metrics(
+        model_id=pricing_model_id,
+        non_cached_input_tokens=non_cached_input_tokens,
+        cache_write_tokens=cache_write_tokens,
+        cache_read_tokens=cache_read_tokens,
+        output_tokens=output_tokens,
+    )
+    if anthropic_cost is not None:
+        return anthropic_cost
+
+    if _looks_like_openai_model(pricing_model_id):
+        return compute_openai_cost_metrics(
+            model_id=pricing_model_id,
+            non_cached_input_tokens=non_cached_input_tokens + cache_write_tokens,
+            cached_input_tokens=cache_read_tokens,
+            output_tokens=output_tokens,
+        )
+
+    return {}
 
 
 class PendingLLMSpan:
@@ -366,7 +437,7 @@ class PiHooksAPI:
 
     def _handle_session_start(self, session_id: str, body: Dict[str, Any]) -> None:
         session = self._get_or_create_session(session_id)
-        model_id = body.get("model_id", "")
+        model_id = body.get("model_id", "") or body.get("model", "")
         model_provider = body.get("model_provider", "")
         if model_id:
             session.model = model_id
@@ -378,7 +449,7 @@ class PiHooksAPI:
 
     def _handle_model_select(self, session_id: str, body: Dict[str, Any]) -> None:
         session = self._get_or_create_session(session_id)
-        model_id = body.get("model_id", "")
+        model_id = body.get("model_id", "") or body.get("model", "")
         model_provider = body.get("model_provider", "")
         if model_id:
             session.model = model_id
@@ -426,7 +497,7 @@ class PiHooksAPI:
         if prompt:
             session.user_prompts.append(prompt)
 
-        model_id = body.get("model_id", session.model)
+        model_id = body.get("model_id", "") or body.get("model", "") or session.model
         model_provider = body.get("model_provider", session.model_provider)
         if model_id:
             session.model = model_id
@@ -659,7 +730,7 @@ class PiHooksAPI:
 
         duration = now_ns - start_ns
 
-        model_id = body.get("model_id", session.model)
+        model_id = body.get("model_id", "") or body.get("model", "") or session.model
         model_provider = body.get("model_provider", session.model_provider)
         usage = body.get("usage") or {}
         stop_reason = body.get("stop_reason", "")
@@ -708,18 +779,16 @@ class PiHooksAPI:
         # Cost: prefer provider-reported cost, fall back to model-based estimate
         provider_cost = usage.get("cost")
         cost_metrics: Dict[str, int] = {}
-        if isinstance(provider_cost, dict) and provider_cost.get("total", 0) > 0:
-            cost_metrics = cost_from_provider_usage(provider_cost)
+        if _has_provider_cost(provider_cost):
+            cost_metrics = cost_from_provider_usage(cast(Dict[str, float], provider_cost))
         else:
-            cost_metrics = (
-                compute_cost_metrics(
-                    model_id=model_id or "",
-                    non_cached_input_tokens=input_tokens,
-                    cache_write_tokens=cache_write,
-                    cache_read_tokens=cache_read,
-                    output_tokens=output_tokens,
-                )
-                or {}
+            cost_metrics = _compute_pi_cost_metrics(
+                model_id=model_id or "",
+                model_provider=model_provider or "",
+                non_cached_input_tokens=input_tokens,
+                cache_write_tokens=cache_write,
+                cache_read_tokens=cache_read,
+                output_tokens=output_tokens,
             )
 
         span: Dict[str, Any] = {

--- a/releasenotes/notes/add-pi-model-cost-fallback-7b1edd5b17cdda45.yaml
+++ b/releasenotes/notes/add-pi-model-cost-fallback-7b1edd5b17cdda45.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add fallback cost estimation for pi based on model name.

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -40,13 +40,18 @@ def _session_start(
     }
 
 
-def _agent_start(session_id=SESSION, prompt="hello"):
+def _agent_start(
+    session_id=SESSION,
+    prompt="hello",
+    model_id="claude-sonnet-4-20250514",
+    model_provider="anthropic",
+):
     return {
         "session_id": session_id,
         "hook_event_name": "agent_start",
         "user_prompt": prompt,
-        "model_id": "claude-sonnet-4-20250514",
-        "model_provider": "anthropic",
+        "model_id": model_id,
+        "model_provider": model_provider,
     }
 
 
@@ -72,13 +77,20 @@ def _message_start(session_id=SESSION, system_prompt="", messages=None):
     }
 
 
-def _message_end(session_id=SESSION, content=None, usage=None, stop_reason="end_turn"):
+def _message_end(
+    session_id=SESSION,
+    content=None,
+    usage=None,
+    stop_reason="end_turn",
+    model_id="claude-sonnet-4-20250514",
+    model_provider="anthropic",
+):
     return {
         "session_id": session_id,
         "hook_event_name": "message_end",
         "message_role": "assistant",
-        "model_id": "claude-sonnet-4-20250514",
-        "model_provider": "anthropic",
+        "model_id": model_id,
+        "model_provider": model_provider,
         "content": content or [{"type": "text", "text": "Hello!"}],
         "usage": usage or {"input": 100, "output": 50, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 150},
         "stop_reason": stop_reason,
@@ -168,6 +180,95 @@ async def test_single_step_with_llm_no_tools(agent):
 
     # Step name
     assert step["name"] == "inference-0"
+
+
+async def test_ai_gateway_anthropic_model_id_gets_estimated_cost(agent):
+    """AI Gateway-style Anthropic model IDs still get local estimated costs."""
+    sid = "pi-ai-gateway-anthropic-cost"
+    model_id = "anthropic/claude-opus-4-7"
+    usage = {"input": 100, "output": 50, "cacheRead": 20, "cacheWrite": 10, "totalTokens": 180}
+    await _post(agent, _session_start(sid, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _agent_start(sid, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _turn_start(sid, turn_index=0))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, usage=usage, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _turn_end(sid, turn_index=0))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    llm = _by_kind([s for s in spans if s.get("session_id") == sid], "llm")[0]
+
+    metrics = llm["metrics"]
+    expected_input = 100 * 5_000 + 10 * 6_250 + 20 * 500
+    expected_output = 50 * 25_000
+    assert llm["meta"]["model_name"] == model_id
+    assert metrics["estimated_non_cached_input_cost"] == 100 * 5_000
+    assert metrics["estimated_cache_write_input_cost"] == 10 * 6_250
+    assert metrics["estimated_cache_read_input_cost"] == 20 * 500
+    assert metrics["estimated_output_cost"] == expected_output
+    assert metrics["estimated_total_cost"] == expected_input + expected_output
+
+
+async def test_ai_gateway_openai_model_id_gets_estimated_cost(agent):
+    """AI Gateway-style OpenAI model IDs are priced with the OpenAI cost table."""
+    sid = "pi-ai-gateway-openai-cost"
+    model_id = "openai/gpt-5.5"
+    usage = {"input": 80, "output": 30, "cacheRead": 20, "cacheWrite": 0, "totalTokens": 130}
+    await _post(agent, _session_start(sid, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _agent_start(sid, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _turn_start(sid, turn_index=0))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, usage=usage, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _turn_end(sid, turn_index=0))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    llm = _by_kind([s for s in spans if s.get("session_id") == sid], "llm")[0]
+
+    metrics = llm["metrics"]
+    assert llm["meta"]["model_name"] == model_id
+    assert metrics["estimated_input_cost"] == 410_000
+    assert metrics["estimated_output_cost"] == 900_000
+    assert metrics["estimated_total_cost"] == 1_310_000
+
+
+async def test_provider_reported_cost_is_preferred_over_model_estimate(agent):
+    """Use cost sent by pi hooks when present, even if model-based pricing is also known."""
+    sid = "pi-provider-cost-preferred"
+    model_id = "openai/gpt-5.5"
+    usage = {
+        "input": 80,
+        "output": 30,
+        "cacheRead": 20,
+        "cacheWrite": 0,
+        "totalTokens": 130,
+        "cost": {
+            "input": 0.000001,
+            "output": 0.000002,
+            "cacheRead": 0.000003,
+            "cacheWrite": 0.000004,
+        },
+    }
+    await _post(agent, _session_start(sid, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _agent_start(sid, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _turn_start(sid, turn_index=0))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, usage=usage, model_id=model_id, model_provider="ai-gateway"))
+    await _post(agent, _turn_end(sid, turn_index=0))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    llm = _by_kind([s for s in spans if s.get("session_id") == sid], "llm")[0]
+
+    metrics = llm["metrics"]
+    assert metrics["estimated_non_cached_input_cost"] == 1_000
+    assert metrics["estimated_output_cost"] == 2_000
+    assert metrics["estimated_cache_read_input_cost"] == 3_000
+    assert metrics["estimated_cache_write_input_cost"] == 4_000
+    assert metrics["estimated_total_cost"] == 10_000
 
 
 async def test_tools_parent_under_step(agent):


### PR DESCRIPTION
## Summary
- Prefer cost values reported directly by pi hook usage data when available.
- Fall back to model-name-based cost estimation for pi spans, including AI Gateway-style `openai/...` and `anthropic/...` model IDs.
- Add regression coverage and a release note.

## QA
- Add DD gateway models: https://github.com/ddoghq-sandbox/datadog-pi-packages/blob/main/packages/refresh-models/README.md (you'll need the fixed version in https://github.com/ddoghq-sandbox/datadog-pi-packages/pull/2)
- Check that cost shows up in Lapdog for these models
- Check for cost regressions for using models directly