### PR TITLE
Add claude-opus-4-8 pricing

### DIFF
--- a/ddapm_test_agent/claude_cost_tracker.py
+++ b/ddapm_test_agent/claude_cost_tracker.py
@@ -19,7 +19,7 @@ Pricing data last updated 2025-11 based on:
   * dd-go/domains/ml-observability/libs/costtracker/model_prices.go
 
 Note: Anthropic significantly reduced Opus prices starting with Opus 4.5
-(Nov 2025).  Opus 4.5 / 4.6 / 4.7 cost $5 / $25 / $0.50 / $6.25 per Mtok,
+(Nov 2025).  Opus 4.5 / 4.6 / 4.7 / 4.8 cost $5 / $25 / $0.50 / $6.25 per Mtok,
 whereas Opus 4 / 4.1 / 3 still cost $15 / $75 / $1.50 / $18.75 per Mtok.
 Using the old Opus rates for 4.5+ overcharges by exactly 3x.
 
@@ -86,7 +86,15 @@ _PRICING: List[Tuple[str, List[_PriceTier]]] = [
     # Source: Anthropic pricing page; pi-ai models.generated.js entries
     # "anthropic.claude-opus-4-5-...", "...claude-opus-4-6-v1", "...claude-opus-4-7".
     #
-    # claude-opus-4-7 / claude-opus-4.7  (latest)
+    # claude-opus-4-8 / claude-opus-4.8  (latest; regular-usage pricing
+    # unchanged from 4.7. Fast mode is $10/$50 per Mtok but is not
+    # distinguishable from the model ID, so provider-reported cost is used
+    # for those turns when available.)
+    (
+        "claude-opus-4-8",
+        [_PriceTier(0, _ONE_TIER, 5_000, 6_250, 500, 25_000)],
+    ),
+    # claude-opus-4-7 / claude-opus-4.7
     (
         "claude-opus-4-7",
         [_PriceTier(0, _ONE_TIER, 5_000, 6_250, 500, 25_000)],

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -43,6 +43,7 @@ _ML_APP = os.environ.get("DD_CLAUDE_CODE_ML_APP", "claude-code")
 _1M_CONTEXT_MODELS = {
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
     "claude-sonnet-4-6",
 }
 

--- a/releasenotes/notes/add-opus-4-8-pricing-4c1f9a2b6d8e0a37.yaml
+++ b/releasenotes/notes/add-opus-4-8-pricing-4c1f9a2b6d8e0a37.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Add ``claude-opus-4-8`` to the Claude Code cost tracking table and 1M-token
+    Lapdog: Add ``claude-opus-4-8`` to the Claude Code cost tracking table and 1M-token
     context model set.  Regular-usage pricing matches Opus 4.7 ($5 / $25 / $0.50
     cache-read / $6.25 cache-write per Mtok).  Previously Opus 4.8 spans fell
     through the pricing table and received no cost estimate.

--- a/releasenotes/notes/add-opus-4-8-pricing-4c1f9a2b6d8e0a37.yaml
+++ b/releasenotes/notes/add-opus-4-8-pricing-4c1f9a2b6d8e0a37.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add ``claude-opus-4-8`` to the Claude Code cost tracking table and 1M-token
+    context model set.  Regular-usage pricing matches Opus 4.7 ($5 / $25 / $0.50
+    cache-read / $6.25 cache-write per Mtok).  Previously Opus 4.8 spans fell
+    through the pricing table and received no cost estimate.

--- a/tests/test_claude_cost_tracker.py
+++ b/tests/test_claude_cost_tracker.py
@@ -88,8 +88,8 @@ class TestCostCalculation:
             assert result["estimated_output_cost"] == 50 * 75_000, model
 
     def test_opus_share_reduced_pricing(self) -> None:
-        # Opus 4.5 / 4.6 / 4.7 all use the post-Nov-2025 reduced rates.
-        for model in ("claude-opus-4-5", "claude-opus-4-6", "claude-opus-4-7"):
+        # Opus 4.5 / 4.6 / 4.7 / 4.8 all use the post-Nov-2025 reduced rates.
+        for model in ("claude-opus-4-5", "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8"):
             result = compute_cost_metrics(model, 100, 200, 500, 50)
             assert result is not None, model
             assert result["estimated_non_cached_input_cost"] == 100 * 5_000, model


### PR DESCRIPTION
## Summary
- Claude Opus 4.8 spans fell through the cost tracking table (top entry was `claude-opus-4-7`), so `compute_cost_metrics` returned `None` and the spans received no cost estimate.
- Add `claude-opus-4-8` to the pricing table at Opus 4.7 rates ($5 / $25 / $0.50 cache-read / $6.25 cache-write per Mtok) and to the 1M-token context model set in `claude_hooks.py`.
- Extend the reduced-pricing test to cover 4.8 and add a release note.

Note: fast mode ($10/$50 per Mtok) can't be distinguished from the model ID, so fast-mode turns are only exact when the provider reports actual cost; the model-based fallback uses standard rates.

## QA
```
lapdog --forward claude --model claude-opus-4-8
```

Claude session: `92f3f0ea-8cf4-4472-9990-a4cf45daf218`
Resume: `claude --resume 92f3f0ea-8cf4-4472-9990-a4cf45daf218`

🤖 Generated with [Claude Code](https://claude.com/claude-code)