### PR TITLE
Lapdog: Fix pi error spans, input-less traces, and stale turn ends

### DIFF
--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -51,7 +51,6 @@ from .codex_cost_tracker import compute_openai_cost_metrics
 from .coding_agent_metadata import apply_project_metadata_to_span
 from .llmobs_event_platform import with_cors
 
-
 log = logging.getLogger(__name__)
 
 _ML_APP = os.environ.get("DD_PI_CODING_AGENT_ML_APP", "pi-coding-agent")
@@ -156,6 +155,8 @@ class ActiveStepSpan:
         self.tool_use_ids: List[str] = []
         self.has_thinking = False
         self.stop_reason = ""
+        self.status = "ok"
+        self.error_message = ""
         self.span_ref: Optional[Dict[str, Any]] = None
 
 
@@ -373,14 +374,76 @@ class PiHooksAPI:
         self._active_steps[sid] = active
         return active
 
-    def _finalize_active_step(self, session_id: str, end_ns: Optional[int] = None) -> None:
-        """Close the active step span, updating its metadata in-place."""
-        active = self._active_steps.pop(session_id, None)
-        if not active:
+    def _flush_orphaned_pending_llm(self, session_id: str, end_ns: Optional[int] = None) -> None:
+        """Emit an error LLM span for a pending call that never got ``message_end``.
+
+        When an LLM call raises (e.g. connection refused / auth failure) pi
+        unwinds without emitting ``message_end``/``turn_end``/``agent_end``, so
+        the ``PendingLLMSpan`` created in ``_handle_message_start`` is orphaned
+        and the step would otherwise render empty.  Emit a placeholder LLM span
+        marked as an error so the failure is visible.
+
+        The normal flow pops ``_pending_llm`` in ``_handle_message_end``, so any
+        entry still present here is a genuine orphan.
+        """
+        pending = self._pending_llm.pop(session_id, None)
+        if pending is None:
+            return
+        session = self._hooks_api._sessions.get(session_id)
+        if session is None:
             return
 
         if end_ns is None:
             end_ns = monotonic_wall_ns()
+
+        error_message = "LLM call did not complete"
+        span: Dict[str, Any] = {
+            "span_id": pending.span_id,
+            "trace_id": session.trace_id,
+            "parent_id": pending.parent_id,
+            "name": session.model or "unknown",
+            "status": "error",
+            "start_ns": pending.start_ns,
+            "duration": end_ns - pending.start_ns,
+            "ml_app": _ML_APP,
+            "service": _ML_APP,
+            "env": "local",
+            "session_id": session.session_id,
+            "tags": self._hooks_api.base_tags(session, source="pi-hooks", ml_app=_ML_APP),
+            "meta": {
+                "span": {"kind": "llm"},
+                "model_name": session.model,
+                "model_provider": session.model_provider,
+                "input": {"messages": pending.input_messages},
+                "output": {"messages": []},
+                "error": {"message": error_message},
+                "metadata": {"stop_reason": "error"},
+            },
+            "metrics": {},
+        }
+        self._append_span(span)
+
+        # Reflect the failure on the enclosing step so it is not empty.
+        active = self._active_steps.get(session_id)
+        if active is not None:
+            active.status = "error"
+            if not active.error_message:
+                active.error_message = error_message
+            if not active.stop_reason:
+                active.stop_reason = "error"
+
+    def _finalize_active_step(self, session_id: str, end_ns: Optional[int] = None) -> None:
+        """Close the active step span, updating its metadata in-place."""
+        if end_ns is None:
+            end_ns = monotonic_wall_ns()
+
+        # Emit an error span for any LLM call that never completed before the
+        # step is finalized so the step row reflects the failure.
+        self._flush_orphaned_pending_llm(session_id, end_ns=end_ns)
+
+        active = self._active_steps.pop(session_id, None)
+        if not active:
+            return
 
         ref = active.span_ref
         if ref is None:
@@ -388,6 +451,9 @@ class PiHooksAPI:
 
         ref["duration"] = end_ns - active.start_ns
         ref["meta"]["output"]["value"] = active.output_text
+        ref["status"] = active.status
+        if active.status == "error":
+            ref["meta"]["error"] = {"message": active.error_message or "step failed"}
 
         metadata = ref["meta"].setdefault("metadata", {})
         metadata["message_index"] = active.message_index
@@ -444,8 +510,32 @@ class PiHooksAPI:
 
         The root agent span represents the proposal's "turn" — the full agentic
         response to one user input.
+
+        A *continuation* agent_start (``is_continuation``) is emitted by
+        ``agent.continue()`` after auto-compaction or auto-retry. It has no
+        fresh user input and belongs to the same turn, so it must extend the
+        existing trace rather than spawn a new, input-less one.
         """
         session = self._get_or_create_session(session_id)
+        is_continuation = bool(body.get("is_continuation", False))
+        has_existing_trace = getattr(session, "_root_span_ref", None) is not None
+
+        if is_continuation and has_existing_trace:
+            # Same user turn resuming. Finalize any open step but keep the
+            # trace_id / root span / user_prompts intact, then reopen the trace
+            # so the next agent_end re-finalizes and re-forwards it.
+            self._finalize_active_step(session_id)
+            session.root_span_emitted = False
+            model_id = body.get("model_id", "") or body.get("model", "") or session.model
+            model_provider = body.get("model_provider", session.model_provider)
+            if model_id:
+                session.model = model_id
+                if not session.models or session.models[-1] != model_id:
+                    session.models.append(model_id)
+            if model_provider:
+                session.model_provider = model_provider
+            log.debug("Pi continuation agent_start for session %s (trace %s)", session_id, session.trace_id)
+            return
 
         # Finalize previous turn if it wasn't finalized
         if not session.root_span_emitted and getattr(session, "_root_span_ref", None) is not None:
@@ -488,6 +578,14 @@ class PiHooksAPI:
 
         tags = self._hooks_api.base_tags(session, source="pi-hooks", ml_app=_ML_APP) + ["trajectory.semantic_type:turn"]
 
+        root_metadata: Dict[str, Any] = {"models_used": session.models[:]}
+        # Defense-in-depth: a genuine user turn should always carry a prompt.
+        # If it doesn't (and this is not a continuation), flag it so the gap is
+        # diagnosable rather than silently producing an input-less trace.
+        if not prompt:
+            root_metadata["missing_user_input"] = True
+            log.warning("Pi agent_start for session %s has no user_prompt (trace %s)", session_id, session.trace_id)
+
         root_span: Dict[str, Any] = {
             "span_id": session.root_span_id,
             "trace_id": session.trace_id,
@@ -507,7 +605,7 @@ class PiHooksAPI:
                 "output": {"value": ""},
                 "model_name": model_id,
                 "model_provider": model_provider,
-                "metadata": {"models_used": session.models[:]},
+                "metadata": root_metadata,
             },
             "metrics": {},
         }
@@ -697,6 +795,11 @@ class PiHooksAPI:
         model_provider = body.get("model_provider", session.model_provider)
         usage = body.get("usage") or {}
         stop_reason = body.get("stop_reason", "")
+        error_message = body.get("error_message", "") or ""
+        # pi reports failed LLM calls as an assistant message with
+        # stopReason "error" (and an errorMessage). Surface this as a real
+        # error span rather than an empty/ok span.
+        is_error = stop_reason == "error"
 
         # Extract tool calls and output text from the content array
         content = body.get("content", [])
@@ -717,6 +820,9 @@ class PiHooksAPI:
             active.tool_use_ids = tool_use_ids
             active.has_thinking = has_thinking
             active.stop_reason = stop_reason
+            if is_error:
+                active.status = "error"
+                active.error_message = error_message or "LLM call failed"
 
         # Build input/output messages in LLMObs format
         output_messages: List[Dict[str, Any]] = []
@@ -759,7 +865,7 @@ class PiHooksAPI:
             "trace_id": session.trace_id,
             "parent_id": parent_id,
             "name": model_id or "unknown",
-            "status": "ok",
+            "status": "error" if is_error else "ok",
             "start_ns": start_ns,
             "duration": duration,
             "ml_app": _ML_APP,
@@ -787,6 +893,8 @@ class PiHooksAPI:
                 **cost_metrics,
             },
         }
+        if is_error:
+            span["meta"]["error"] = {"message": error_message or "LLM call failed"}
         self._append_span(span)
 
     def _handle_tool_execution_start(self, session_id: str, body: Dict[str, Any]) -> None:

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -721,8 +721,20 @@ class PiHooksAPI:
 
     def _handle_turn_end(self, session_id: str, body: Dict[str, Any]) -> None:
         """Finalize the active step span (primary step finalization point)."""
+        active = self._active_steps.get(session_id)
+        turn_index = body.get("turn_index")
+        if active is not None and turn_index is not None and active.turn_index is not None:
+            if turn_index != active.turn_index:
+                log.debug(
+                    "Ignoring stale Pi turn_end for session %s: event turn_index=%s active turn_index=%s",
+                    session_id,
+                    turn_index,
+                    active.turn_index,
+                )
+                return
+
         self._finalize_active_step(session_id)
-        log.debug("Pi turn_end for session %s: turn_index=%s", session_id, body.get("turn_index"))
+        log.debug("Pi turn_end for session %s: turn_index=%s", session_id, turn_index)
 
     def _handle_message_start(self, session_id: str, body: Dict[str, Any]) -> None:
         """Begin tracking an LLM call.

--- a/lapdog/pi_lapdog_extension.ts
+++ b/lapdog/pi_lapdog_extension.ts
@@ -84,6 +84,13 @@ export default function lapdog(pi: ExtensionAPI): void {
 	// attach it to the agent_start event (input event fires before agent_start).
 	let pendingUserPrompt = "";
 
+	// True when the upcoming agent_start was triggered by a genuine user prompt
+	// (`before_agent_start` fires only via agent-session.prompt(), never via
+	// agent.continue()). When false, the agent_start is a continuation of the
+	// current turn (e.g. after auto-compaction or auto-retry) and must NOT spawn
+	// a new, input-less trace.
+	let userTurnPending = false;
+
 	// System prompt for the current turn, captured in before_agent_start.
 	// Reused for every LLM call inside the turn so each LLM span can record
 	// the system message as part of its input.
@@ -153,17 +160,35 @@ export default function lapdog(pi: ExtensionAPI): void {
 		} catch {
 			currentSystemPrompt = "";
 		}
+		// `before_agent_start` only fires for user-initiated prompts and carries
+		// the (expanded) prompt text. Use it as the authoritative "new turn"
+		// signal so the following agent_start is treated as a real turn, while
+		// agent.continue()'s agent_start (no before_agent_start) reads as a
+		// continuation.
+		userTurnPending = true;
+		const prompt = _event?.prompt;
+		if (typeof prompt === "string" && prompt) {
+			pendingUserPrompt = prompt;
+		}
 	});
 
 	pi.on("agent_start", (_event, ctx) => {
+		// A continuation is an agent_start with no preceding before_agent_start
+		// (i.e. agent.continue() after auto-compaction / auto-retry). These belong
+		// to the same user turn and must not start a fresh, input-less trace.
+		const isContinuation = !userTurnPending;
 		post("agent_start", sessionId, {
 			user_prompt: pendingUserPrompt,
+			is_continuation: isContinuation,
 			model: `${currentProvider}/${currentModel}`,
 			model_provider: currentProvider,
 			model_id: currentModel,
 			system_prompt: currentSystemPrompt,
 		}, ctx);
-		pendingUserPrompt = "";
+		userTurnPending = false;
+		if (!isContinuation) {
+			pendingUserPrompt = "";
+		}
 	});
 
 	pi.on("agent_end", (event, ctx) => {
@@ -240,6 +265,7 @@ export default function lapdog(pi: ExtensionAPI): void {
 				cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
 			};
 			stopReason?: string;
+			errorMessage?: string;
 		};
 
 		post("message_end", sessionId, {
@@ -249,6 +275,9 @@ export default function lapdog(pi: ExtensionAPI): void {
 			api: msg.api,
 			usage: msg.usage ?? null,
 			stop_reason: msg.stopReason ?? "",
+			// pi sets errorMessage when stopReason is "error" (or "aborted").
+			// Forward it so the LLM span can be marked as an error with detail.
+			error_message: msg.errorMessage ?? "",
 			content: msg.content,
 		}, ctx);
 	});

--- a/releasenotes/notes/pi-error-spans-and-turn-input-fb62af79c0192f7f.yaml
+++ b/releasenotes/notes/pi-error-spans-and-turn-input-fb62af79c0192f7f.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    lapdog (pi): a failed LLM call now produces an LLM span marked as an error
+    (with the provider error message) instead of an empty step. Covers both
+    pi's ``stopReason: "error"`` path and the case where an exception unwinds
+    the agent loop before ``message_end`` is emitted.
+  - |
+    lapdog (pi): continuation ``agent_start`` events emitted by
+    ``agent.continue()`` (after auto-compaction or auto-retry) no longer create
+    new, input-less traces. They now extend the current trace so each trace maps
+    to one user turn and always carries the user's prompt as input.

--- a/releasenotes/notes/pi-error-spans-and-turn-input-fb62af79c0192f7f.yaml
+++ b/releasenotes/notes/pi-error-spans-and-turn-input-fb62af79c0192f7f.yaml
@@ -10,3 +10,6 @@ fixes:
     ``agent.continue()`` (after auto-compaction or auto-retry) no longer create
     new, input-less traces. They now extend the current trace so each trace maps
     to one user turn and always carries the user's prompt as input.
+  - |
+    lapdog (pi): out-of-order stale ``turn_end`` events no longer close the
+    next active turn, preventing extra empty step spans.

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -426,6 +426,53 @@ async def test_multiple_steps(agent):
     assert tools[0]["parent_id"] == step0["span_id"]
 
 
+async def test_stale_turn_end_does_not_finalize_next_step(agent):
+    """Out-of-order turn_end for the previous turn must not emit an empty step."""
+    sid = "pi-stale-turn-end"
+    tool_call_id = "tc-a"
+    content1 = [
+        {"type": "toolCall", "id": tool_call_id, "name": "read", "arguments": {"path": "foo.py"}},
+    ]
+    content2 = [{"type": "text", "text": "Done!"}]
+
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid, turn_index=0))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, content=content1, stop_reason="toolUse"))
+    await _post(agent, _tool_start(sid, tool_call_id, "read"))
+    await _post(agent, _tool_end(sid, tool_call_id, "read", "file contents"))
+
+    # Pi can emit the next turn_start before the previous turn_end. The stale
+    # turn_end(0) should not close turn 1 before its message_start/message_end.
+    await _post(agent, _turn_start(sid, turn_index=1))
+    await _post(agent, _turn_end(sid, turn_index=0))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid, content=content2, stop_reason="stop"))
+    await _post(agent, _turn_end(sid, turn_index=1))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = _spans(await resp.json())
+    session_spans = [s for s in spans if s.get("session_id") == sid]
+
+    root = [s for s in session_spans if s["parent_id"] == "undefined"][0]
+    steps = sorted(_by_kind(session_spans, "step"), key=lambda s: s["name"])
+    llms = _by_kind(session_spans, "llm")
+    tools = _by_kind(session_spans, "tool")
+
+    assert [s["name"] for s in steps] == ["inference-0", "inference-1"]
+    assert [s["parent_id"] for s in steps] == [root["span_id"], root["span_id"]]
+    assert len(llms) == 2
+    assert len(tools) == 1
+
+    step1 = steps[1]
+    assert step1["meta"]["output"]["value"] == "Done!"
+    assert step1["meta"]["metadata"]["turn_index"] == 1
+    assert any(llm["parent_id"] == step1["span_id"] for llm in llms)
+    assert all(any(child.get("parent_id") == step["span_id"] for child in session_spans) for step in steps)
+
+
 async def test_trajectory_tags(agent):
     """Root has trajectory.semantic_type:turn, step has trajectory.semantic_type:agent_message."""
     sid = "pi-tags"

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -51,6 +51,7 @@ def _agent_start(
     model_id="claude-sonnet-4-20250514",
     model_provider="anthropic",
     cwd=None,
+    is_continuation=False,
 ):
     event = {
         "session_id": session_id,
@@ -58,6 +59,7 @@ def _agent_start(
         "user_prompt": prompt,
         "model_id": model_id,
         "model_provider": model_provider,
+        "is_continuation": is_continuation,
     }
     if cwd:
         event["cwd"] = cwd
@@ -93,6 +95,7 @@ def _message_end(
     stop_reason="end_turn",
     model_id="claude-sonnet-4-20250514",
     model_provider="anthropic",
+    error_message="",
 ):
     return {
         "session_id": session_id,
@@ -100,9 +103,10 @@ def _message_end(
         "message_role": "assistant",
         "model_id": model_id,
         "model_provider": model_provider,
-        "content": content or [{"type": "text", "text": "Hello!"}],
+        "content": content if content is not None else [{"type": "text", "text": "Hello!"}],
         "usage": usage or {"input": 100, "output": 50, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 150},
         "stop_reason": stop_reason,
+        "error_message": error_message,
     }
 
 
@@ -775,3 +779,165 @@ async def test_thinking_block_sets_has_thinking(agent):
     assert step["meta"]["metadata"].get("has_thinking") is True
     # Thinking text should NOT appear in output (only text blocks)
     assert step["meta"]["output"]["value"] == "Here's my answer."
+
+
+# ------------------------------------------------------------------
+# Bug 1: LLM errors should produce an error LLM span (not an empty step)
+# ------------------------------------------------------------------
+
+
+async def test_llm_error_emits_error_span(agent):
+    """A message_end with stop_reason=error yields an error LLM span + error step."""
+    sid = "pi-llm-error"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    # Errored assistant message: empty content, stop_reason error, errorMessage set.
+    await _post(
+        agent,
+        _message_end(sid, content=[], stop_reason="error", error_message="rate limit exceeded"),
+    )
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    session_spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+
+    llms = _by_kind(session_spans, "llm")
+    assert len(llms) == 1
+    llm = llms[0]
+    assert llm["status"] == "error"
+    assert llm["meta"]["error"]["message"] == "rate limit exceeded"
+    assert llm["meta"]["metadata"]["stop_reason"] == "error"
+
+    # The enclosing step reflects the failure (not silently empty/ok).
+    step = _by_kind(session_spans, "step")[0]
+    assert step["status"] == "error"
+    assert step["meta"]["error"]["message"] == "rate limit exceeded"
+
+
+async def test_orphaned_llm_call_emits_error_span_on_agent_end(agent):
+    """message_start with no message_end (thrown error) still yields an error LLM span."""
+    sid = "pi-llm-orphan"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    # No message_end — the LLM call raised and pi unwound without finalizing.
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    session_spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+
+    llms = _by_kind(session_spans, "llm")
+    assert len(llms) == 1, "orphaned pending LLM should still produce a span"
+    llm = llms[0]
+    assert llm["status"] == "error"
+    assert "did not complete" in llm["meta"]["error"]["message"]
+
+    step = _by_kind(session_spans, "step")[0]
+    assert step["status"] == "error"
+
+
+async def test_orphaned_llm_call_emits_error_span_on_session_shutdown(agent):
+    """Orphaned pending LLM is flushed as an error span on session_shutdown too."""
+    sid = "pi-llm-orphan-shutdown"
+    await _post(agent, _session_start(sid))
+    await _post(agent, _agent_start(sid))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _session_shutdown(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    session_spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+    llms = _by_kind(session_spans, "llm")
+    assert len(llms) == 1
+    assert llms[0]["status"] == "error"
+
+
+# ------------------------------------------------------------------
+# Bug 2: continuation agent_start must extend the current trace
+# ------------------------------------------------------------------
+
+
+async def test_continuation_agent_start_extends_trace(agent):
+    """A continuation agent_start (no user input) reuses the existing trace."""
+    sid = "pi-continuation"
+    await _post(agent, _session_start(sid))
+
+    # First (real) user turn.
+    await _post(agent, _agent_start(sid, prompt="do the thing"))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    session_spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+    root_before = next(s for s in session_spans if s["parent_id"] == "undefined")
+    trace_id = root_before["trace_id"]
+    root_span_id = root_before["span_id"]
+
+    # Continuation (e.g. after auto-compaction): no fresh user input.
+    await _post(agent, _agent_start(sid, prompt="", is_continuation=True))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    session_spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+
+    # Exactly one trace and one root span — the continuation did NOT spawn a new one.
+    roots = [s for s in session_spans if s["parent_id"] == "undefined"]
+    assert len(roots) == 1
+    root = roots[0]
+    assert root["span_id"] == root_span_id
+    assert root["trace_id"] == trace_id
+    assert all(s["trace_id"] == trace_id for s in session_spans)
+
+    # User input is preserved on the single trace.
+    assert root["meta"]["input"]["value"] == "do the thing"
+    assert root["meta"]["metadata"].get("missing_user_input") is None
+
+    # Both inference cycles' steps live under the same trace/root.
+    steps = _by_kind(session_spans, "step")
+    assert len(steps) == 2
+    assert all(s["parent_id"] == root_span_id for s in steps)
+
+
+async def test_second_real_turn_still_rotates_trace(agent):
+    """A genuine second user turn (is_continuation=False) still starts a new trace."""
+    sid = "pi-two-real-turns"
+    await _post(agent, _session_start(sid))
+
+    await _post(agent, _agent_start(sid, prompt="first"))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    session_spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+    first_trace = next(s for s in session_spans if s["parent_id"] == "undefined")["trace_id"]
+
+    await _post(agent, _agent_start(sid, prompt="second"))
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    resp = await agent.get("/claude/hooks/spans")
+    session_spans = [s for s in _spans(await resp.json()) if s.get("session_id") == sid]
+    roots = [s for s in session_spans if s["parent_id"] == "undefined"]
+    assert len(roots) == 2
+    trace_ids = {r["trace_id"] for r in roots}
+    assert len(trace_ids) == 2
+    assert first_trace in trace_ids
+    inputs = sorted(r["meta"]["input"]["value"] for r in roots)
+    assert inputs == ["first", "second"]

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -828,11 +828,6 @@ async def test_thinking_block_sets_has_thinking(agent):
     assert step["meta"]["output"]["value"] == "Here's my answer."
 
 
-# ------------------------------------------------------------------
-# Bug 1: LLM errors should produce an error LLM span (not an empty step)
-# ------------------------------------------------------------------
-
-
 async def test_llm_error_emits_error_span(agent):
     """A message_end with stop_reason=error yields an error LLM span + error step."""
     sid = "pi-llm-error"
@@ -901,11 +896,6 @@ async def test_orphaned_llm_call_emits_error_span_on_session_shutdown(agent):
     llms = _by_kind(session_spans, "llm")
     assert len(llms) == 1
     assert llms[0]["status"] == "error"
-
-
-# ------------------------------------------------------------------
-# Bug 2: continuation agent_start must extend the current trace
-# ------------------------------------------------------------------
 
 
 async def test_continuation_agent_start_extends_trace(agent):


### PR DESCRIPTION
## What

Fixes three bugs in the pi coding-agent lapdog integration.

### Bug 1 — failed LLM calls produced an empty step (no error span)

pi surfaces a failed LLM call as an assistant message with `stopReason: "error"`
(and an `errorMessage`); in the thrown-exception path (connection refused, etc.)
it may not emit `message_end` at all. Previously the handler always built the LLM
span with `status: "ok"` and dropped the error message, so the step looked empty.

- `pi_lapdog_extension.ts` now forwards `error_message` on `message_end`.
- `pi_hooks.py` marks the LLM span (and its enclosing step) as an error with the
  provider message when `stop_reason == "error"`.
- New `_flush_orphaned_pending_llm` emits an error LLM span when a step finalizes
  with a pending LLM call that never received `message_end`, so the step is never
  silently empty.

### Bug 2 — traces created without user input

`agent.continue()` (after auto-compaction or auto-retry) emits a fresh
`agent_start` with no user input. The handler treated every `agent_start` as a new
turn, rotating to a new `trace_id` — producing traces with an empty user prompt.

- `pi_lapdog_extension.ts` marks continuation `agent_start`s via
  `is_continuation`, driven by `before_agent_start` (which only fires for genuine
  user prompts, never for `continue()`).
- `pi_hooks.py` extends the current trace on a continuation (keeps `trace_id`,
  root span, and `user_prompts`; reopens it so the next `agent_end` re-finalizes
  and re-forwards) instead of starting a new one. A `missing_user_input` metadata
  flag is added as a diagnostic for any genuine turn that still lacks a prompt.

### Bug 3 — stale `turn_end` events closed the next active turn

Pi can emit `turn_start` for the next turn before the previous turn's `turn_end`
arrives. Previously, the stale `turn_end` finalized whatever step was active,
which could close the next turn before its LLM message arrived and produce an
extra empty step span.

- `pi_hooks.py` now compares the incoming `turn_end.turn_index` with the active
  step's `turn_index` and ignores stale mismatches instead of finalizing the
  active step.

## Tests

- 6 new tests in `tests/test_pi_hooks.py` (error span, orphaned pending LLM on
  `agent_end` and `session_shutdown`, continuation merge, real-second-turn still
  rotates, stale `turn_end` handling).
- Verified end-to-end against a real `pi` 0.76.0 process driving the test agent
  (see QA below).

## QA instructions

These run the real lapdog flow with forwarding on, so the resulting spans show up
in the lapdog UI at https://lapdog.datadoghq.com.

**Prereqs**

```bash
# From this branch:
git fetch origin ts/fix-pi && git checkout ts/fix-pi
pip install -e .

# Make sure DD_API_KEY (and DD_SITE if you are not on US1) is set so lapdog can
# forward to the backend, then drop any already-running agent so the new code is used:
lapdog stop
```

`lapdog --forward pi <pi-args>` starts the forwarding agent, installs this
branch's extension, and launches pi. After each run, open
https://lapdog.datadoghq.com and find your most recent **`pi-coding-agent`**
session (match it by the time you ran the command), then open the trace.

### Repro Bug 1 — error LLM span

Force a real LLM error with a bad API key (401 is not retryable, so you get one
clean error span):

```bash
lapdog --forward pi --provider anthropic --model claude-3-5-haiku-20241022 \
  --api-key "sk-ant-invalid-key-for-testing" --no-session \
  -p "Say hello in one word"
```

In the lapdog UI, open that session's trace. **Expected:** the turn
(`pi-request`) contains a step with an **LLM span marked as an error** whose
message is the 401 (`invalid x-api-key`) detail — the step is no longer empty.
On `master` the same run shows an empty step with no error.

### Repro Bug 2 — input-less traces on continuation (auto-retry / compaction)

Stand up a local provider that always returns a retryable `503 overloaded`, so pi
retries via `agent.continue()` (each retry emits a fresh `agent_start` with no
user input). A project-local fast-retry config keeps it quick.

```bash
mkdir -p /tmp/qa && cd /tmp/qa
mkdir -p .pi
echo '{"retry":{"enabled":true,"maxRetries":2,"baseDelayMs":200}}' > .pi/settings.json

# 503-overloaded server
cat > srv.py <<'PY'
import http.server, socketserver
class H(http.server.BaseHTTPRequestHandler):
    def _e(self):
        b=b'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}'
        self.send_response(503); self.send_header("Content-Length",str(len(b))); self.end_headers(); self.wfile.write(b)
    def do_POST(self):
        n=int(self.headers.get("Content-Length",0));
        if n: self.rfile.read(n)
        self._e()
    def do_GET(self): self._e()
    def log_message(self,*a): pass
socketserver.TCPServer(("127.0.0.1",8199),H).serve_forever()
PY
python3 srv.py & SRV=$!

# extension registering a provider that points at the 503 server
cat > badprovider.ts <<'TS'
import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
export default function badProvider(pi: ExtensionAPI): void {
  pi.registerProvider("badgw", {
    name: "Bad Gateway (test)", baseUrl: "http://localhost:8199",
    apiKey: "test-key", api: "anthropic-messages",
    models: [{ id: "bad-model", name: "Bad Model", reasoning: false, input: ["text"],
      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 200000, maxTokens: 4096 }],
  });
}
TS

lapdog --forward pi --provider badgw --model bad-model \
  -e badprovider.ts --no-session -p "Say hello"

kill $SRV
```

In the lapdog UI, open that session. **Expected:** the first attempt and both
retry continuations are a **single trace / turn** whose input is the original
`"Say hello"` prompt (every inference shows the error). On `master` you instead
see multiple separate traces in the session, two of which have **no user input**.

### Repro Bug 3 — stale `turn_end` closes the next active turn

This is covered by `test_stale_turn_end_does_not_finalize_next_step`, which
sends `turn_start(1)` before the delayed `turn_end(0)`. **Expected:** the stale
`turn_end(0)` is ignored, turn 1 stays open until its LLM response arrives, and
no extra empty step span is emitted.

> Optional extension-payload sanity check (not shown in the UI): the running
> agent exposes the raw hook events it received at `GET /pi/hooks/raw`. With
> forwarding-on lapdog that's `curl -s http://localhost:8126/pi/hooks/raw`. You
> should see one `agent_start` with `is_continuation:false` (and the real
> `user_prompt`) followed by `is_continuation:true` retries, and `message_end`
> events carrying `stop_reason:"error"` + a populated `error_message`.

## Risk

Scoped to the pi lapdog path (`pi_hooks.py` + `pi_lapdog_extension.ts`). Claude /
Codex hook paths are untouched. Continuation re-forwarding upserts by `span_id`, so
merged traces update cleanly.
