### PR TITLE
Lapdog: add session link status item to pi and Claude Code

### DIFF
--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -157,12 +157,19 @@ claude plugin marketplace add DataDog/dd-apm-test-agent
 claude plugin install lapdog@lapdog
 ```
 
-The plugin lives entirely under `~/.claude/plugins/...` — it does **not**
-modify `~/.claude/settings.json`. `claude plugin uninstall lapdog@lapdog`
-fully removes it.
+The plugin itself lives entirely under `~/.claude/plugins/...`.
+`claude plugin uninstall lapdog@lapdog` fully removes it.
+
+`lapdog claude` also adds a **status line** to `~/.claude/settings.json` that
+shows a clickable `🐶 lapdog` link deep-linking to the current session in the
+dashboard (the same item the Pi extension adds to its footer). Claude renders
+only one status line, so lapdog never overwrites an existing `statusLine` — if
+you already have one configured, lapdog leaves it untouched and skips the
+addition. `lapdog uninstall` removes the lapdog entry (and only that entry).
 
 To skip the auto-install (e.g. on a locked-down machine), run
-`lapdog --no-plugin-install claude`. LLM model calls are still captured
+`lapdog --no-plugin-install claude`. This also skips the status line.
+LLM model calls are still captured
 (via the BUN intercept), but Claude Code hook events — tool calls, prompts,
 session lifecycle, permission requests — are not, so the sessions view in
 the dashboard will be incomplete. The same fallback applies if the
@@ -220,7 +227,7 @@ Useful flags:
   — the tracer still gets a 200 OK, but nothing reaches Datadog. Setting
   `DD_AGENT_URL` instead bypasses both and forwards through that agent.
 - `--no-plugin-install` — skip the `lapdog claude` auto-install of the Claude
-  Code plugin.
+  Code plugin and status line.
 - `-p <port>` / `--port <port>` — bind to a different port (default `8126`).
 
 ---
@@ -234,6 +241,7 @@ Knowing this up front makes the uninstall list below easy to verify.
 | `~/.lapdog/lapdog.pid` | `lapdog start` / `lapdog claude` / `lapdog pi` | PID + port of the background agent |
 | `~/.lapdog/lapdog.log` | same | stdout/stderr of the background agent |
 | `~/.claude/plugins/...` | `lapdog claude` (first run) | the auto-installed `lapdog@lapdog` Claude Code plugin lives entirely under here |
+| `~/.claude/settings.json` | `lapdog claude` (first run) | adds a `statusLine` entry with a session dashboard link (only if no `statusLine` is already set) |
 | `~/.pi/agent/extensions/lapdog.ts` | `lapdog pi` | Pi extension that reports tool calls to the local agent |
 
 No other state is created. There is no daemon installed at the OS level
@@ -254,7 +262,7 @@ This will:
 ```bash
 lsof -ti tcp:8126 | xargs kill
 ```
-2. Remove the Claude Code plugin (if installed)
+2. Remove the Claude Code plugin (if installed) and the lapdog `statusLine` entry from `~/.claude/settings.json`
 3. Remove the Pi extension (only if you used `lapdog pi`)
 4. Removes Lapdog's working directory (at `~/.lapdog`)
 

--- a/lapdog/claude_statusline.py
+++ b/lapdog/claude_statusline.py
@@ -1,0 +1,51 @@
+"""Claude Code status line script for lapdog.
+
+Claude Code invokes a configured ``statusLine`` command for every render,
+passing a JSON blob on stdin that includes the current ``session_id`` (see
+https://code.claude.com/docs/en/statusline). We read it and print a single
+clickable ``🐶 lapdog`` item that deep-links to this session in the hosted
+lapdog dashboard via an OSC-8 terminal hyperlink.
+
+Wired up by ``lapdog claude`` (see ``cli.py``); run standalone as:
+
+    echo '{"session_id": "abc"}' | python -m lapdog.claude_statusline
+"""
+
+import json
+import sys
+
+from lapdog.constants import session_dashboard_url
+
+# Dog face shown next to "lapdog", matching the pi extension footer status.
+DOG_EMOJI = "🐶"
+# ANSI styling for the label (purple accent + reset), mirroring the pi
+# extension's accent-colored "lapdog" label.
+_ACCENT = "\033[38;5;141m"
+_RESET = "\033[0m"
+
+
+def _hyperlink(text: str, url: str) -> str:
+    """Wrap text in an OSC-8 terminal hyperlink."""
+    return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
+
+
+def render(session_id: str) -> str:
+    label = f"{_ACCENT}lapdog{_RESET}"
+    return f"{DOG_EMOJI} {_hyperlink(label, session_dashboard_url(session_id))}"
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        payload = {}
+    session_id = (payload or {}).get("session_id") or ""
+    if not session_id:
+        # No session yet — print nothing rather than a dead link.
+        return 0
+    sys.stdout.write(render(session_id))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -4,12 +4,14 @@ import argparse
 import json
 import os
 from pathlib import Path
-import shutil
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
 import time
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -24,7 +26,6 @@ from lapdog.paths import CODEX_APP_CURSOR_FILE
 from lapdog.paths import LAPDOG_DIR
 from lapdog.paths import LOG_FILE
 from lapdog.paths import PID_FILE
-
 
 LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "uninstall"]
 LAPDOG_USAGE = (
@@ -106,7 +107,7 @@ def _uninstall_lapdog_claude_code_plugin() -> None:
 
     commands = [
         [claude_bin, "plugin", "uninstall", LAPDOG_PLUGIN_NAME],
-        [claude_bin, "plugin", "marketplace", "remove", LAPDOG_MARKETPLACE_SOURCE]
+        [claude_bin, "plugin", "marketplace", "remove", LAPDOG_MARKETPLACE_SOURCE],
     ]
     for cmd in commands:
         try:
@@ -125,6 +126,75 @@ def _uninstall_lapdog_claude_code_plugin() -> None:
             )
             return
     print("[lapdog] Claude Code plugin uninstalled", file=sys.stderr)
+
+
+# Claude Code statusLine config (in ~/.claude/settings.json) can't be shipped by
+# a plugin, so 'lapdog claude' wires it up to a script in this package that
+# prints a clickable session link. We detect/remove only our own entry.
+_CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+_LAPDOG_STATUSLINE_MARKER = "lapdog.claude_statusline"
+
+
+def _lapdog_statusline_command() -> str:
+    """Command Claude runs to render the lapdog status line."""
+    return f"{shlex.quote(sys.executable)} -m lapdog.claude_statusline"
+
+
+def _read_claude_settings() -> Dict[str, Any]:
+    if not _CLAUDE_SETTINGS_PATH.exists():
+        return {}
+    try:
+        with _CLAUDE_SETTINGS_PATH.open() as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _write_claude_settings(data: Dict[str, Any]) -> None:
+    _CLAUDE_SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _CLAUDE_SETTINGS_PATH.open("w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def _is_lapdog_statusline(status_line: object) -> bool:
+    return isinstance(status_line, dict) and _LAPDOG_STATUSLINE_MARKER in str(status_line.get("command", ""))
+
+
+def _ensure_lapdog_claude_statusline() -> None:
+    """Add the lapdog status line to ~/.claude/settings.json. Best-effort.
+
+    Never clobbers an existing, non-lapdog statusLine — Claude renders only one,
+    so we respect a user's own status line and warn instead of overwriting it.
+    """
+    settings = _read_claude_settings()
+    existing = settings.get("statusLine")
+    if _is_lapdog_statusline(existing):
+        return
+    if existing:
+        print(
+            "[lapdog] Existing Claude statusLine detected; leaving it as-is.",
+            file=sys.stderr,
+        )
+        return
+    settings["statusLine"] = {"type": "command", "command": _lapdog_statusline_command()}
+    try:
+        _write_claude_settings(settings)
+    except OSError as e:
+        print(f"[lapdog] Could not write Claude statusLine config: {e}", file=sys.stderr)
+
+
+def _remove_lapdog_claude_statusline() -> None:
+    settings = _read_claude_settings()
+    if not _is_lapdog_statusline(settings.get("statusLine")):
+        return
+    settings.pop("statusLine", None)
+    try:
+        _write_claude_settings(settings)
+        print("[lapdog] Removed Claude statusLine config", file=sys.stderr)
+    except OSError as e:
+        print(f"[lapdog] Could not remove Claude statusLine config: {e}", file=sys.stderr)
 
 
 def _resolved_port(cli_args: Optional[List[str]] = None) -> int:
@@ -411,6 +481,7 @@ def cmd_claude(
     """Ensure lapdog is running in background, then launch Claude with intercept."""
     if install_plugin:
         _ensure_lapdog_claude_code_plugin_installed()
+        _ensure_lapdog_claude_statusline()
     _ensure_lapdog_running(forward_data, detached=True)
     print(build_running_banner(data_type="coding session", warning_lines=_PROXY_SESSION_WARNING_LINES))
 
@@ -846,8 +917,9 @@ def cmd_uninstall() -> None:
         shutil.rmtree(LAPDOG_DIR, ignore_errors=True)
         print("[lapdog] Lapdog-related files under ~/.lapdog removed")
 
-    # remove claude code plugin
+    # remove claude code plugin + status line config
     _uninstall_lapdog_claude_code_plugin()
+    _remove_lapdog_claude_statusline()
 
     # remove pi extension
     if os.path.isfile(_PI_EXT_DEST):
@@ -902,10 +974,11 @@ def _parse_lapdog_args(lapdog_args: List[str]) -> argparse.Namespace:
         action="store_false",
         default=True,
         help=(
-            "Skip auto-installing the 'lapdog' Claude Code plugin when running "
-            f"'lapdog claude'. By default, lapdog runs 'claude plugin marketplace "
-            f"add {LAPDOG_MARKETPLACE_SOURCE}' and 'claude plugin install "
-            f"{LAPDOG_PLUGIN_NAME}' if the plugin is not already installed."
+            "Skip auto-installing the 'lapdog' Claude Code plugin and status line "
+            "when running 'lapdog claude'. By default, lapdog runs 'claude plugin "
+            f"marketplace add {LAPDOG_MARKETPLACE_SOURCE}' and 'claude plugin install "
+            f"{LAPDOG_PLUGIN_NAME}' if the plugin is not already installed, and adds "
+            "a lapdog status line to ~/.claude/settings.json."
         ),
     )
 

--- a/lapdog/constants.py
+++ b/lapdog/constants.py
@@ -1,0 +1,18 @@
+"""Shared lapdog constants.
+
+Kept separate from ``paths.py`` (filesystem paths) so both the CLI and the
+Claude Code status line script can import the hosted dashboard URL without
+duplicating it. The pi extension (TypeScript) keeps its own copy since it
+can't import Python.
+"""
+
+from urllib.parse import quote
+
+# Hosted lapdog dashboard. It reads directly from the local test agent on
+# localhost, so the base URL is constant regardless of LAPDOG_URL / DD_SITE.
+LAPDOG_DASHBOARD_URL = "https://lapdog.datadoghq.com"
+
+
+def session_dashboard_url(session_id: str) -> str:
+    """Build the lapdog dashboard deep-link for a coding-agent session."""
+    return f"{LAPDOG_DASHBOARD_URL}/?sessionId={quote(session_id, safe='')}"

--- a/lapdog/lapdog_ascii_art.py
+++ b/lapdog/lapdog_ascii_art.py
@@ -3,6 +3,7 @@ from typing import Optional
 from typing import Tuple
 
 from ddapm_test_agent import _get_version
+from lapdog.constants import LAPDOG_DASHBOARD_URL
 
 # Letter masks (5 rows tall). '#' = filled, ' ' = blank. All letters share the
 # same height so they can be rendered side-by-side with a drop shadow.
@@ -147,7 +148,7 @@ def build_running_banner(data_type: str, warning_lines: Optional[List[str]] = No
         f"{bold}lapdog{reset} {dim}v{_get_version()}{reset}",
         "",
         f"{dim}Lapdog has started and is listening for data.{reset}",
-        f"{dim}Open {reset}{face}https://lapdog.datadoghq.com{reset}{dim} to view insights,{reset}",
+        f"{dim}Open {reset}{face}{LAPDOG_DASHBOARD_URL}{reset}{dim} to view insights,{reset}",
         f"{dim}costs, optimizations and more related to this {data_type}.{reset}",
     ]
     if warning_lines:

--- a/lapdog/pi_lapdog_extension.ts
+++ b/lapdog/pi_lapdog_extension.ts
@@ -25,8 +25,8 @@ const HOOKS_ENDPOINT = `${LAPDOG_URL}/pi/hooks`;
 const LAPDOG_DASHBOARD_URL = "https://lapdog.datadoghq.com";
 // Key for the footer status entry created via ctx.ui.setStatus().
 const STATUS_KEY = "lapdog";
-// Modifier needed to open OSC-8 hyperlinks in common terminals.
-const CLICK_HINT = process.platform === "darwin" ? "⌘+click" : "Ctrl+click";
+// Dog face shown next to "lapdog" in the footer status.
+const DOG_EMOJI = "🐶";
 
 /** Build the lapdog dashboard deep-link for a pi session. */
 function sessionDashboardUrl(sid: string): string {
@@ -99,6 +99,18 @@ export default function lapdog(pi: ExtensionAPI): void {
 	// capture the UI context from session_start where it is fully typed.
 	let statusUi: ExtensionContext["ui"] | undefined;
 
+	// Render the dog + "lapdog" footer status. The label is a clickable OSC-8
+	// hyperlink to the lapdog dashboard for this session.
+	const renderStatus = () => {
+		if (!statusUi) return;
+		try {
+			const label = statusUi.theme.fg("accent", "lapdog");
+			statusUi.setStatus(STATUS_KEY, hyperlink(`${DOG_EMOJI} ${label}`, sessionDashboardUrl(sessionId)));
+		} catch {
+			// UI unavailable — ignore.
+		}
+	};
+
 	// Track the user prompt that started the current agent run so we can
 	// attach it to the agent_start event (input event fires before agent_start).
 	let pendingUserPrompt = "";
@@ -131,14 +143,11 @@ export default function lapdog(pi: ExtensionAPI): void {
 			model_provider: currentProvider,
 			model_id: currentModel,
 		}, ctx);
-		// Show a clickable link to this session in the lapdog dashboard. The
-		// label is short; the full URL lives in the OSC-8 escape and opens on
-		// ⌘/Ctrl+click in supporting terminals (hence the dim hint).
+		// Show a dog next to "lapdog" in the footer. The label is a clickable
+		// OSC-8 hyperlink to this session's lapdog dashboard.
 		try {
 			statusUi = ctx.ui;
-			const label = ctx.ui.theme.fg("accent", "view in lapdog");
-			const hint = ctx.ui.theme.fg("dim", `(${CLICK_HINT})`);
-			ctx.ui.setStatus(STATUS_KEY, `${hyperlink(label, sessionDashboardUrl(sessionId))} ${hint}`);
+			renderStatus();
 		} catch {
 			// Non-interactive mode (print/JSON) or UI unavailable — ignore.
 		}

--- a/lapdog/pi_lapdog_extension.ts
+++ b/lapdog/pi_lapdog_extension.ts
@@ -14,10 +14,24 @@
  * never blocks the agent.
  */
 
-import { convertToLlm, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { convertToLlm, copyToClipboard, type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { hyperlink } from "@mariozechner/pi-tui";
 
 const LAPDOG_URL = process.env.LAPDOG_URL || "http://localhost:8126";
 const HOOKS_ENDPOINT = `${LAPDOG_URL}/pi/hooks`;
+
+// Hosted lapdog dashboard. It reads directly from the local test agent on
+// localhost, so the base URL is constant regardless of LAPDOG_URL / DD_SITE.
+const LAPDOG_DASHBOARD_URL = "https://lapdog.datadoghq.com";
+// Key for the footer status entry created via ctx.ui.setStatus().
+const STATUS_KEY = "lapdog";
+// Modifier needed to open OSC-8 hyperlinks in common terminals.
+const CLICK_HINT = process.platform === "darwin" ? "⌘+click" : "Ctrl+click";
+
+/** Build the lapdog dashboard deep-link for a pi session. */
+function sessionDashboardUrl(sid: string): string {
+	return `${LAPDOG_DASHBOARD_URL}/?sessionId=${encodeURIComponent(sid)}`;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -80,6 +94,11 @@ export default function lapdog(pi: ExtensionAPI): void {
 	let currentModel = "";
 	let currentProvider = "";
 
+	// Held so we can clear the footer status entry on shutdown. The
+	// session_shutdown handler types its ctx narrowly (CwdContext), so we
+	// capture the UI context from session_start where it is fully typed.
+	let statusUi: ExtensionContext["ui"] | undefined;
+
 	// Track the user prompt that started the current agent run so we can
 	// attach it to the agent_start event (input event fires before agent_start).
 	let pendingUserPrompt = "";
@@ -112,10 +131,51 @@ export default function lapdog(pi: ExtensionAPI): void {
 			model_provider: currentProvider,
 			model_id: currentModel,
 		}, ctx);
+		// Show a clickable link to this session in the lapdog dashboard. The
+		// label is short; the full URL lives in the OSC-8 escape and opens on
+		// ⌘/Ctrl+click in supporting terminals (hence the dim hint).
+		try {
+			statusUi = ctx.ui;
+			const label = ctx.ui.theme.fg("accent", "view in lapdog");
+			const hint = ctx.ui.theme.fg("dim", `(${CLICK_HINT})`);
+			ctx.ui.setStatus(STATUS_KEY, `${hyperlink(label, sessionDashboardUrl(sessionId))} ${hint}`);
+		} catch {
+			// Non-interactive mode (print/JSON) or UI unavailable — ignore.
+		}
 	});
 
 	pi.on("session_shutdown", (_event?: unknown, ctx?: CwdContext) => {
 		post("session_shutdown", sessionId, {}, ctx);
+		try {
+			statusUi?.setStatus(STATUS_KEY, undefined);
+		} catch {
+			// ignore
+		}
+		statusUi = undefined;
+	});
+
+	// ------------------------------------------------------------------
+	// /lapdog command — print + copy the dashboard link for this session
+	// (useful in terminals that don't support OSC-8 click-to-open).
+	// ------------------------------------------------------------------
+
+	pi.registerCommand("lapdog", {
+		description: "Show the lapdog dashboard link for the current session",
+		handler: async (_args, ctx) => {
+			if (!sessionId) {
+				ctx.ui.notify("lapdog: no active session yet", "warning");
+				return;
+			}
+			const url = sessionDashboardUrl(sessionId);
+			let copied = false;
+			try {
+				await copyToClipboard(url);
+				copied = true;
+			} catch {
+				// Clipboard unavailable — still show the URL below.
+			}
+			ctx.ui.notify(`lapdog session: ${url}${copied ? " (copied to clipboard)" : ""}`, "info");
+		},
 	});
 
 	// ------------------------------------------------------------------

--- a/releasenotes/notes/lapdog-claude-statusline-3e2c9a7b1d4f0a85.yaml
+++ b/releasenotes/notes/lapdog-claude-statusline-3e2c9a7b1d4f0a85.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Lapdog: ``lapdog claude`` now adds a status line to ``~/.claude/settings.json``
+    showing a clickable link to the current session in the dashboard at
+    ``lapdog.datadoghq.com`` (matching the pi extension footer). An existing
+    ``statusLine`` is never overwritten, and ``lapdog uninstall`` removes the
+    entry.

--- a/releasenotes/notes/lapdog-pi-status-bar-session-link-ec435e5c10887dcd.yaml
+++ b/releasenotes/notes/lapdog-pi-status-bar-session-link-ec435e5c10887dcd.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    The lapdog pi extension now shows a clickable link to the current session at
+    Lapdog: the pi extension now shows a clickable link to the current session at
     ``lapdog.datadoghq.com`` in the pi status bar, and registers a ``/lapdog``
     command that prints and copies the session dashboard URL.

--- a/releasenotes/notes/lapdog-pi-status-bar-session-link-ec435e5c10887dcd.yaml
+++ b/releasenotes/notes/lapdog-pi-status-bar-session-link-ec435e5c10887dcd.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The lapdog pi extension now shows a clickable link to the current session at
+    ``lapdog.datadoghq.com`` in the pi status bar, and registers a ``/lapdog``
+    command that prints and copies the session dashboard URL.


### PR DESCRIPTION
## Summary

<img width="973" height="462" alt="screenshot" src="https://github.com/user-attachments/assets/c5583e74-f841-4faf-8721-199b91178e29" />

<img width="1280" height="726" alt="Screenshot 2026-05-29 at 3 16 19 PM" src="https://github.com/user-attachments/assets/1499727c-f8bb-4540-b52c-4c0c28d39a31" />


Adds a clickable **🐶 lapdog** status item to both **pi** and **Claude Code**
that deep-links to the current session in the hosted lapdog dashboard
(`https://lapdog.datadoghq.com/?sessionId=<session id>`). The pi extension also
registers a `/lapdog` slash command for terminals without OSC-8 hyperlink
support.

## What changed

### pi (`lapdog/pi_lapdog_extension.ts`)
- On `session_start`, sets a footer status entry (`ctx.ui.setStatus`) showing a
  dog emoji next to an accent-colored, OSC-8 hyperlinked `lapdog` label.
- Clears the status entry on `session_shutdown`.
- Registers a `/lapdog` command that prints the session URL and copies it to the
  clipboard — works in any terminal regardless of OSC-8 support.

### Claude Code
- `lapdog/claude_statusline.py` (new): reads Claude's stdin JSON, extracts
  `session_id`, and prints the same clickable `🐶 lapdog` OSC-8 hyperlink. Prints
  nothing when there is no active session.
- `lapdog/cli.py`: `lapdog claude` now wires the status line into
  `~/.claude/settings.json` (pointing at `python -m lapdog.claude_statusline`),
  and `lapdog uninstall` removes it. Claude renders only one status line, so an
  existing user `statusLine` is never overwritten — lapdog warns and skips. Only
  the lapdog entry is removed on uninstall.

Claude Code has no supported way for a *plugin* to contribute the main status
line (plugin `settings.json` only honors `agent`/`subagentStatusLine`, and
`plugin.json` has no `statusLine` field), so the settings.json wiring is the
standard path. The pip-installed module path is also more stable than the
churning marketplace-cache plugin path.

### Shared
- `lapdog/constants.py` (new): hosts `LAPDOG_DASHBOARD_URL` +
  `session_dashboard_url()`, now used by `cli.py`, `claude_statusline.py`, and
  `lapdog_ascii_art.py`. The pi extension keeps its own TS copy since it can't
  import Python.

## How to use

Open the link with **⌘+click** on macOS (**Ctrl+click** on Linux) — a plain
click is intentionally a no-op in most terminals.

## Test plan

- pi: `tsc` typecheck against pi's bundled types — passes. Live PTY smoke test of
  `pi -e <ext>` confirmed the footer renders `🐶 lapdog` with an intact OSC-8
  hyperlink carrying a real `sessionId`. Manually verified ⌘+click opens the
  session in Ghostty.
- Claude status line: `black` / `flake8` / `mypy` clean. Unit-tested the
  settings.json install/remove logic against a temp HOME — fresh install,
  idempotent re-run, clean removal, preserves an existing non-lapdog
  `statusLine` (and other keys), and never removes a user's own `statusLine`.
- `echo '{"session_id":"abc 123"}' | python -m lapdog.claude_statusline` emits a
  correctly URL-encoded OSC-8 hyperlink; empty session prints nothing.

## Out of scope

- A `/lapdog` slash command for Claude Code (Claude slash commands can't run
  bash-and-exit without invoking the model).
