### PR TITLE
fix(lapdog): drop duplicate Claude Code hook deliveries that emit phantom traces

### DIFF
--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -7,6 +7,7 @@ into LLMObs-format spans that can be queried through the Event Platform APIs.
 import asyncio
 import getpass
 import gzip
+import hashlib
 import json
 import logging
 import os
@@ -36,7 +37,6 @@ from .coding_agent_metadata import project_metadata_tags
 from .coding_agent_metadata import resolve_project_metadata
 from .llmobs_event_platform import with_cors
 
-
 log = logging.getLogger(__name__)
 
 _HOSTNAME = socket.gethostname()
@@ -60,6 +60,26 @@ def _get_context_limit(model: str) -> int:
         if model.startswith(prefix):
             return 1_000_000
     return 200_000
+
+
+# A single Claude Code hook firing can be POSTed to /claude/hooks more than once
+# when the lapdog hooks are registered in two places at the same time — e.g. a
+# stale ``~/.claude/settings.json`` block left over from the pre-plugin
+# ``--enable-claude-code-hooks`` flow *and* the ``lapdog`` Claude Code plugin.
+# Both run the same curl, so every event is delivered twice. A duplicate
+# UserPromptSubmit makes ``_handle_user_prompt_submit`` treat the just-started
+# turn as interrupted, emitting a phantom errored zero-duration root span before
+# the real trace. We drop byte-identical events seen within this window. The two
+# duplicate deliveries are effectively simultaneous, so a few seconds is ample
+# while staying well below the gap between genuinely distinct turns.
+_DUPLICATE_EVENT_WINDOW_NS = 5 * 1_000_000_000
+
+# SubagentStart / SubagentStop carry no per-subagent discriminator in their hook
+# payloads, so two *distinct* concurrent subagents legitimately produce identical
+# bodies (see test_concurrent_subagents_parent_correctly). They are excluded from
+# dedup so real sibling subagents are never collapsed; the trade-off is that
+# genuine duplicate delivery of these two events is not suppressed.
+_NON_DEDUPED_HOOK_EVENTS = frozenset({"SubagentStart", "SubagentStop"})
 
 
 def _to_json_str(value: Any) -> str:
@@ -298,6 +318,10 @@ class ClaudeHooksAPI:
         self._raw_events: List[Dict[str, Any]] = []
         self._link_tracker = link_tracker
         self._app: Optional[web.Application] = None
+        # Fingerprint -> monotonic_wall_ns of the last time an identical hook body
+        # was seen, used to suppress duplicate hook deliveries (see
+        # _DUPLICATE_EVENT_WINDOW_NS).
+        self._recent_event_fingerprints: Dict[str, int] = {}
 
     def set_app(self, app: web.Application) -> None:
         """Set the aiohttp app reference for backend forwarding."""
@@ -1757,6 +1781,37 @@ class ClaudeHooksAPI:
             url, headers, json.dumps(payload).encode(), f"forward {len(metrics)} eval metric(s) for trace {trace_id}"
         )
 
+    def _is_duplicate_event(self, body: Dict[str, Any]) -> bool:
+        """Return True if an identical hook body was already seen within the dedup window.
+
+        Guards against a single Claude Code hook firing being POSTed to
+        ``/claude/hooks`` more than once (duplicate registration). Events whose
+        type is in ``_NON_DEDUPED_HOOK_EVENTS`` are never treated as duplicates
+        because distinct instances share an identical payload.
+
+        Must run synchronously (no ``await``) so the check-and-record is atomic
+        with respect to concurrently handled requests on the event loop.
+        """
+        if body.get("hook_event_name") in _NON_DEDUPED_HOOK_EVENTS:
+            return False
+        try:
+            fingerprint = hashlib.sha256(
+                json.dumps(body, sort_keys=True, ensure_ascii=False).encode("utf-8")
+            ).hexdigest()
+        except (TypeError, ValueError):
+            # Unserializable body — fall back to processing it rather than dropping.
+            return False
+
+        now_ns = monotonic_wall_ns()
+        cutoff = now_ns - _DUPLICATE_EVENT_WINDOW_NS
+        # Evict expired fingerprints so the map only retains the recent window.
+        for fp in [fp for fp, seen_ns in self._recent_event_fingerprints.items() if seen_ns < cutoff]:
+            del self._recent_event_fingerprints[fp]
+
+        is_duplicate = fingerprint in self._recent_event_fingerprints
+        self._recent_event_fingerprints[fingerprint] = now_ns
+        return is_duplicate
+
     async def handle_hook(self, request: Request) -> web.Response:
         """Handle POST /claude/hooks — receives hook JSON and dispatches by event name."""
         try:
@@ -1769,6 +1824,16 @@ class ClaudeHooksAPI:
             return web.json_response({"error": "missing session_id"}, status=400)
 
         self._raw_events.append(body)
+
+        # Drop duplicate deliveries of the same hook firing (e.g. stale settings.json
+        # hooks + the lapdog plugin both POSTing) before they mutate session state.
+        if self._is_duplicate_event(body):
+            log.debug(
+                "Dropping duplicate %s hook for session %s",
+                body.get("hook_event_name", ""),
+                session_id,
+            )
+            return web.json_response({"status": "ok", "duplicate": True})
 
         # wait for the transcript to be fully flushed before dispatching the hook
         if body.get("hook_event_name") == "Stop":

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -27,7 +27,6 @@ from lapdog.paths import LAPDOG_DIR
 from lapdog.paths import LOG_FILE
 from lapdog.paths import PID_FILE
 
-
 LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "uninstall"]
 LAPDOG_USAGE = (
     "Usage: lapdog [OPTIONS] <command> [command-args...]\n"
@@ -49,10 +48,23 @@ _PROXY_SESSION_WARNING_LINES = ["Keep Lapdog running; stopping it can break prox
 LAPDOG_PLUGIN_NAME = "lapdog@lapdog"
 LAPDOG_MARKETPLACE_SOURCE = "DataDog/dd-apm-test-agent"
 
+# Substring identifying a lapdog hook command in Claude Code's settings.json.
+# Pre-plugin lapdog versions wrote `curl ... http://localhost:<port>/claude/hooks`
+# entries directly into settings.json; the path is lapdog-specific.
+_LEGACY_HOOK_COMMAND_MARKER = "/claude/hooks"
+
+
+def _claude_config_dir() -> Path:
+    """Return Claude Code's config directory, honoring CLAUDE_CONFIG_DIR (default ~/.claude)."""
+    override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".claude"
+
 
 def _lapdog_claude_code_plugin_installed() -> bool:
     """Return True if the lapdog Claude Code plugin is installed for this user."""
-    installed_path = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    installed_path = _claude_config_dir() / "plugins" / "installed_plugins.json"
     if not installed_path.exists():
         return False
     try:
@@ -108,7 +120,7 @@ def _uninstall_lapdog_claude_code_plugin() -> None:
 
     commands = [
         [claude_bin, "plugin", "uninstall", LAPDOG_PLUGIN_NAME],
-        [claude_bin, "plugin", "marketplace", "remove", LAPDOG_MARKETPLACE_SOURCE]
+        [claude_bin, "plugin", "marketplace", "remove", LAPDOG_MARKETPLACE_SOURCE],
     ]
     for cmd in commands:
         try:
@@ -127,6 +139,80 @@ def _uninstall_lapdog_claude_code_plugin() -> None:
             )
             return
     print("[lapdog] Claude Code plugin uninstalled", file=sys.stderr)
+
+
+def _remove_legacy_claude_code_hooks() -> int:
+    """Strip stale lapdog hook entries from Claude Code's settings.json.
+
+    Older lapdog versions wrote `curl ... /claude/hooks` commands directly into
+    `settings.json` (the pre-plugin `--enable-claude-code-hooks` flow). Now that
+    hooks ship via the `lapdog` Claude Code plugin, those leftover entries fire a
+    second, duplicate POST for every hook event, which makes lapdog emit a phantom
+    errored trace before each real one. Remove them so only the plugin remains.
+
+    Returns the number of hook entries removed. Best-effort: file/JSON errors warn
+    and return 0 without raising, so they never block `lapdog claude`.
+    """
+    settings_path = _claude_config_dir() / "settings.json"
+    if not settings_path.exists():
+        return 0
+    try:
+        data = json.loads(settings_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"[lapdog] Could not read {settings_path} to clean up legacy hooks: {e}", file=sys.stderr)
+        return 0
+    if not isinstance(data, dict) or not isinstance(data.get("hooks"), dict):
+        return 0
+
+    hooks: Dict[str, Any] = data["hooks"]
+
+    def _is_legacy(hook_obj: Any) -> bool:
+        return isinstance(hook_obj, dict) and _LEGACY_HOOK_COMMAND_MARKER in str(hook_obj.get("command", ""))
+
+    removed = 0
+    for event in list(hooks.keys()):
+        blocks = hooks.get(event)
+        if not isinstance(blocks, list):
+            continue
+        kept_blocks: List[Any] = []
+        event_removed = 0
+        for block in blocks:
+            cmds = block.get("hooks") if isinstance(block, dict) else None
+            if not isinstance(cmds, list):
+                kept_blocks.append(block)
+                continue
+            kept_cmds = [h for h in cmds if not _is_legacy(h)]
+            dropped = len(cmds) - len(kept_cmds)
+            event_removed += dropped
+            if dropped and not kept_cmds:
+                continue  # block had only legacy lapdog hooks -> drop the whole block
+            if dropped:
+                block["hooks"] = kept_cmds
+            kept_blocks.append(block)
+        removed += event_removed
+        # Only mutate events we actually touched; leave unrelated empty entries alone.
+        if event_removed and not kept_blocks:
+            del hooks[event]
+        elif event_removed:
+            hooks[event] = kept_blocks
+
+    if removed == 0:
+        return 0
+
+    data["hooks"] = hooks
+    try:
+        settings_path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    except OSError as e:
+        print(f"[lapdog] Could not write {settings_path} to clean up legacy hooks: {e}", file=sys.stderr)
+        return 0
+
+    plural = "entry" if removed == 1 else "entries"
+    print(
+        f"[lapdog] Removed {removed} legacy Claude Code hook {plural} from {settings_path} "
+        "(hooks now ship via the 'lapdog' plugin).",
+        file=sys.stderr,
+    )
+    return removed
 
 
 def _resolved_port(cli_args: Optional[List[str]] = None) -> int:
@@ -250,9 +336,7 @@ def _start_lapdog(
     if sys.platform == "win32":
         # On Windows, start_new_session is a no-op. Use creationflags to truly
         # detach the child so it survives after the launcher process exits.
-        popen_kwargs["creationflags"] = (
-            subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
-        )
+        popen_kwargs["creationflags"] = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
     else:
         popen_kwargs["start_new_session"] = True
     with open(log_path, "w") as log_file:
@@ -432,6 +516,9 @@ def cmd_claude(
     """Ensure lapdog is running in background, then launch Claude with intercept."""
     if install_plugin:
         _ensure_lapdog_claude_code_plugin_installed()
+        # Migrate users off pre-plugin settings.json hooks so events aren't
+        # delivered twice (plugin + stale settings.json -> phantom errored traces).
+        _remove_legacy_claude_code_hooks()
     _ensure_lapdog_running(forward_data, detached=True)
     print(build_running_banner(data_type="coding session", warning_lines=_PROXY_SESSION_WARNING_LINES))
 
@@ -869,6 +956,9 @@ def cmd_uninstall() -> None:
 
     # remove claude code plugin
     _uninstall_lapdog_claude_code_plugin()
+
+    # remove any legacy settings.json hooks written by pre-plugin lapdog versions
+    _remove_legacy_claude_code_hooks()
 
     # remove pi extension
     if os.path.isfile(_PI_EXT_DEST):

--- a/releasenotes/notes/fix-claude-duplicate-hook-traces-fa2955d0e59bfe88.yaml
+++ b/releasenotes/notes/fix-claude-duplicate-hook-traces-fa2955d0e59bfe88.yaml
@@ -1,0 +1,18 @@
+---
+fixes:
+  - |
+    Stop lapdog from emitting a phantom errored trace before each real Claude
+    Code trace. When the lapdog hooks were registered in two places at once —
+    a stale ``~/.claude/settings.json`` block left over from the pre-plugin
+    ``--enable-claude-code-hooks`` flow plus the ``lapdog`` Claude Code plugin —
+    every hook event was POSTed to ``/claude/hooks`` twice. The duplicate
+    ``UserPromptSubmit`` made the agent treat the just-started turn as
+    interrupted, producing an errored zero-duration root span before the real
+    one. The ``/claude/hooks`` endpoint now drops byte-identical duplicate hook
+    deliveries seen within a short window (``SubagentStart``/``SubagentStop`` are
+    excluded, since distinct concurrent subagents legitimately share a payload).
+  - |
+    ``lapdog claude`` and ``lapdog uninstall`` now remove legacy
+    ``/claude/hooks`` entries from Claude Code's ``settings.json``, migrating
+    users off the pre-plugin hook registration so events are no longer delivered
+    twice.

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -745,3 +745,79 @@ async def test_concurrent_subagents_parent_correctly(agent):
             f"Subagent {agent_span['name']} has parent_id={agent_span['parent_id']} "
             f"but expected root span_id={root['span_id']}"
         )
+
+
+async def test_duplicate_user_prompt_submit_emits_single_root(agent):
+    # A duplicate UserPromptSubmit delivery (e.g. stale settings.json hooks + the
+    # lapdog plugin both firing) must not produce a phantom errored root span.
+    session_id = "sess-dup-prompt"
+
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "SessionStart"})
+    prompt_event = {"session_id": session_id, "hook_event_name": "UserPromptSubmit", "prompt": "do the thing"}
+    await _post_hook(agent, prompt_event)
+    await _post_hook(agent, dict(prompt_event))  # duplicate delivery
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = (await resp.json())["spans"]
+    session_spans = [s for s in spans if s.get("session_id") == session_id]
+    root_spans = [s for s in session_spans if s["parent_id"] == "undefined"]
+
+    assert len(root_spans) == 1, f"Expected 1 root, got {len(root_spans)}"
+    assert root_spans[0]["status"] == "ok"
+    assert "error" not in root_spans[0]["meta"]
+
+    # The duplicate is still recorded in raw events for debugging, just not dispatched.
+    raw = (await (await agent.get("/claude/hooks/raw")).json())["events"]
+    prompt_raw = [
+        e for e in raw if e.get("session_id") == session_id and e.get("hook_event_name") == "UserPromptSubmit"
+    ]
+    assert len(prompt_raw) == 2
+
+
+async def test_duplicate_tool_use_emits_single_tool_span(agent):
+    # Duplicate PreToolUse/PostToolUse deliveries for the same tool_use_id collapse to one span.
+    session_id = "sess-dup-tool"
+
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "SessionStart"})
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "UserPromptSubmit", "prompt": "read it"})
+
+    pre = {
+        "session_id": session_id,
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_use_id": "tool-1",
+        "tool_input": {"file_path": "/tmp/a.txt"},
+    }
+    post = {
+        "session_id": session_id,
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Read",
+        "tool_use_id": "tool-1",
+        "tool_response": "contents",
+    }
+    await _post_hook(agent, pre)
+    await _post_hook(agent, dict(pre))  # duplicate
+    await _post_hook(agent, post)
+    await _post_hook(agent, dict(post))  # duplicate
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = (await resp.json())["spans"]
+    tool_spans = [s for s in spans if s.get("session_id") == session_id and s["meta"]["span"]["kind"] == "tool"]
+    assert len(tool_spans) == 1, f"Expected 1 tool span, got {len(tool_spans)}"
+
+
+async def test_distinct_prompts_not_deduplicated(agent):
+    # Two genuinely different prompts across two turns must both produce a root.
+    session_id = "sess-distinct-prompts"
+
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "SessionStart"})
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "UserPromptSubmit", "prompt": "first"})
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "Stop"})
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "UserPromptSubmit", "prompt": "second"})
+    await _post_hook(agent, {"session_id": session_id, "hook_event_name": "Stop"})
+
+    resp = await agent.get("/claude/hooks/spans")
+    spans = (await resp.json())["spans"]
+    root_spans = [s for s in spans if s.get("session_id") == session_id and s["parent_id"] == "undefined"]
+    assert len(root_spans) == 2, f"Expected 2 roots for 2 distinct prompts, got {len(root_spans)}"
+    assert all(r["status"] == "ok" for r in root_spans)

--- a/tests/test_lapdog_cli.py
+++ b/tests/test_lapdog_cli.py
@@ -629,3 +629,75 @@ def test_run_codex_falls_back_without_openai_api_key(monkeypatch):
 
     assert exec_call["env"]["OPENAI_BASE_URL"] == "http://localhost:8126/codex/proxy/v1"
     assert exec_call["argv"] == ["/usr/local/bin/codex", "exec", "hello"]
+
+
+def _lapdog_hook_block():
+    return [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": (
+                        "curl -s --max-time 2 -X POST -H 'Content-Type: application/json' "
+                        "-d @- http://localhost:8126/claude/hooks >/dev/null 2>&1 || true"
+                    ),
+                    "async": True,
+                }
+            ],
+        }
+    ]
+
+
+def test_remove_legacy_claude_code_hooks_strips_lapdog_entries(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    settings = {
+        "permissions": {"allow": ["Bash"]},
+        "hooks": {
+            "UserPromptSubmit": _lapdog_hook_block(),
+            "PreToolUse": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {"type": "command", "command": "curl -s http://localhost:8126/claude/hooks || true"},
+                        {"type": "command", "command": "my-custom-linter"},
+                    ],
+                }
+            ],
+            "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "echo done"}]}],
+        },
+    }
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps(settings))
+
+    removed = cli._remove_legacy_claude_code_hooks()
+    assert removed == 2
+
+    result = json.loads(settings_path.read_text())
+    hooks = result["hooks"]
+    # Event that contained only the lapdog hook is gone entirely.
+    assert "UserPromptSubmit" not in hooks
+    # Unrelated hook in a shared block survives; only the lapdog command is dropped.
+    pre_cmds = [h["command"] for h in hooks["PreToolUse"][0]["hooks"]]
+    assert pre_cmds == ["my-custom-linter"]
+    # Untouched events and unrelated top-level keys are preserved.
+    assert hooks["Stop"][0]["hooks"][0]["command"] == "echo done"
+    assert result["permissions"] == {"allow": ["Bash"]}
+
+
+def test_remove_legacy_claude_code_hooks_noop_when_clean(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    settings = {"hooks": {"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "echo hi"}]}]}}
+    settings_path = tmp_path / "settings.json"
+    original = json.dumps(settings)
+    settings_path.write_text(original)
+
+    removed = cli._remove_legacy_claude_code_hooks()
+    assert removed == 0
+    # File left byte-for-byte unchanged when there is nothing to remove.
+    assert settings_path.read_text() == original
+
+
+def test_remove_legacy_claude_code_hooks_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    assert cli._remove_legacy_claude_code_hooks() == 0


### PR DESCRIPTION
## Problem

lapdog emits **double traces for each Claude Code user message — the first errored with a wrong (≈0) duration**.

Root cause: the lapdog hooks get registered in **two places at once** — a stale `~/.claude/settings.json` block left over from the pre-plugin `--enable-claude-code-hooks` flow (removed in #353/#356) **plus** the `lapdog` Claude Code plugin. Both run the same `curl`, so every hook event is POSTed to `/claude/hooks` twice.

The duplicate `UserPromptSubmit` is what produces the symptom:
1. 1st `UserPromptSubmit` → starts a fresh trace, creates root A (`root_span_emitted=False`).
2. 2nd (duplicate) `UserPromptSubmit` → sees `root_span_emitted is False` + an existing `_root_span_ref`, assumes the turn was interrupted, calls `_finalize_interrupted_turn(A)` → stamps A `status="error"`, `"interrupted by user"`, `duration = now - start_ns` (a few µs) → then starts *another* fresh trace, root B.

So every turn gets a phantom errored zero-duration root plus the real one. The state machine is correct under single delivery — verified that 2 clean turns → 2 clean roots; a single duplicated `UserPromptSubmit` → 1 errored + 1 ok root.

## Fix

**B — Harden the endpoint against duplicate delivery.** `handle_hook` now drops byte-identical hook bodies seen within a short window (`_DUPLICATE_EVENT_WINDOW_NS`, 5s) before they mutate session state. The check-and-record is synchronous so it's atomic across concurrently-handled requests, and it runs *before* the `Stop` sleep so duplicate `Stop`s are dropped too. `SubagentStart`/`SubagentStop` are **excluded** — distinct concurrent subagents legitimately share an identical payload (locked in by `test_concurrent_subagents_parent_correctly`). Duplicates are still recorded in `/claude/hooks/raw` for debugging; only dispatch/assembly is suppressed.

**C — Migrate users off the legacy registration.** `lapdog claude` (when auto-installing the plugin) and `lapdog uninstall` now strip leftover `/claude/hooks` entries from Claude Code's `settings.json` (honoring `CLAUDE_CONFIG_DIR`). Surgical: only lapdog commands are removed, unrelated hooks in shared blocks are preserved, and the file is left byte-for-byte unchanged when there's nothing to remove.

## Tests

- `test_duplicate_user_prompt_submit_emits_single_root` — the reported bug; one root, `ok`, no error.
- `test_duplicate_tool_use_emits_single_tool_span` — duplicate Pre/PostToolUse collapse to one span.
- `test_distinct_prompts_not_deduplicated` — two real turns still produce two roots.
- `test_concurrent_subagents_parent_correctly` (existing) — guards the subagent exclusion.
- `test_remove_legacy_claude_code_hooks_*` — strips lapdog entries / keeps unrelated / no-op when clean / missing file.

All 78 tests in the affected suites pass; `black`/`flake8` clean; new code is `mypy`-clean (pre-existing `trace.py` errors are unrelated).

Claude session: `821d4e14-1e83-4266-b4cb-bf8c63c3dbb4`
Resume: `claude --resume 821d4e14-1e83-4266-b4cb-bf8c63c3dbb4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)