### PR TITLE
feat(lapdog): add stdio MCP server for querying captured traces

### DIFF
--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -23,6 +23,7 @@ want to know what `lapdog start` actually does).
   - [Docker](#docker)
   - [From source](#from-source)
 - [Claude Code plugin](#claude-code-plugin)
+- [MCP server](#mcp-server)
 - [Quickstart](#quickstart)
 - [What lapdog touches on your machine](#what-lapdog-touches-on-your-machine)
 - [Uninstallation](#uninstallation)
@@ -168,6 +169,55 @@ session lifecycle, permission requests — are not, so the sessions view in
 the dashboard will be incomplete. The same fallback applies if the
 auto-install fails (no network, etc.): lapdog prints the manual commands
 and continues launching Claude rather than blocking the session.
+
+---
+
+## MCP server
+
+Lapdog can expose the traces it captures to an LLM agent over the
+[Model Context Protocol](https://modelcontextprotocol.io) so the agent can query
+its own sessions, spans, tokens, and costs. The server speaks MCP over **stdio** and
+is a thin client: it reads span data over HTTP from the lapdog agent you already have
+running (via `lapdog start` / `lapdog claude` / `lapdog codex`).
+
+Install the optional dependency and run it:
+
+```bash
+pip install "ddapm-test-agent[mcp]"
+lapdog start          # the agent must be running for the tools to return data
+lapdog mcp            # speaks MCP on stdio
+```
+
+Register it with an MCP client. For Claude Code:
+
+```bash
+claude mcp add lapdog -- lapdog mcp
+```
+
+Or via a client config file (e.g. Claude Desktop's `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "lapdog": {
+      "command": "lapdog",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+The server exposes three tools:
+
+| Tool | What it does |
+| --- | --- |
+| `list_sessions` | List captured sessions with per-session span count, error count, total tokens, estimated cost, and time range. |
+| `get_session` | Fetch all spans for one `session_id`, assembled into a parent/child tree with input/output and metrics. |
+| `search_spans` | Search spans using the agent's Datadog-style filter syntax (e.g. `@status:error`, `@ml_app:my-app`, `@meta.model_name:claude*`, `session_id:abc123`). |
+
+The lapdog agent must be running when a tool is called; if it is not reachable, the
+tools return an actionable error telling you to run `lapdog start`. The MCP server
+reads the agent's port from `~/.lapdog/lapdog.pid` (falling back to `PORT`, then 8126).
 
 ---
 

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -28,7 +28,7 @@ from lapdog.paths import LOG_FILE
 from lapdog.paths import PID_FILE
 
 
-LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "uninstall"]
+LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "mcp", "uninstall"]
 LAPDOG_USAGE = (
     "Usage: lapdog [OPTIONS] <command> [command-args...]\n"
     "Options must appear before <command>. Arguments after <command> are forwarded.\n"
@@ -38,6 +38,7 @@ LAPDOG_USAGE = (
     "  claude     Start lapdog in background if needed, then launch Claude with intercept\n"
     "  pi         Start lapdog in background if needed, install extension, then launch pi\n"
     "  codex      Start lapdog in background if needed, then launch Codex with tracing\n"
+    "  mcp        Run a stdio MCP server exposing the running lapdog agent's traces\n"
     "  uninstall  Stop lapdog and remove all state it wrote (~/.lapdog, Claude hooks, pi extension, Codex watchers)\n"
     "\n"
     "Any other command is treated as an app to run with tracing instrumentation:\n"
@@ -854,6 +855,24 @@ def cmd_codex(sub_cmd_args: List[str], forward_data: bool) -> None:
     _run_codex(args=sub_cmd_args, port=port, proxy_session_key=proxy_session_key)
 
 
+def cmd_mcp() -> None:
+    """Run a stdio MCP server that exposes the running lapdog agent's traces.
+
+    The MCP dependencies are optional; install them with
+    `pip install "ddapm-test-agent[mcp]"`.
+    """
+    try:
+        from lapdog import mcp_server
+    except ImportError as e:
+        print(
+            f"[lapdog] MCP support is not installed ({e}).\n"
+            '[lapdog] Install it with: pip install "ddapm-test-agent[mcp]"',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    mcp_server.run()
+
+
 def cmd_uninstall() -> None:
     """Stop the lapdog server, removes ~/.lapdog directory, and uninstalls managed plugins"""
 
@@ -982,6 +1001,8 @@ def main() -> None:
         cmd_pi(sub_cmd_args=sub_cmd_args, forward_data=lapdog_parsed_args.forward)
     elif sub_cmd == "codex":
         cmd_codex(sub_cmd_args=sub_cmd_args, forward_data=lapdog_parsed_args.forward)
+    elif sub_cmd == "mcp":
+        cmd_mcp()
     elif sub_cmd == "uninstall":
         cmd_uninstall()
 

--- a/lapdog/mcp_server.py
+++ b/lapdog/mcp_server.py
@@ -1,0 +1,254 @@
+"""Stdio MCP server for querying traces captured by a running lapdog agent.
+
+This is a thin client: it speaks the MCP protocol over stdio to the calling agent
+(Claude Code, Claude Desktop, ...) and fetches span data over HTTP from the lapdog
+agent already running on localhost (started by `lapdog start` / `lapdog claude`).
+
+It reuses the same query endpoints the lapdog dashboard uses, so span assembly,
+session_id normalization, and filter parsing all happen server-side in the agent.
+
+Run with: lapdog mcp
+"""
+
+import functools
+import os
+import sys
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+
+import requests
+
+from lapdog.cli import _read_pid_file
+
+# The agent endpoint that returns assembled, normalized LLMObs spans. Each event
+# carries the span under event["event"]["custom"]. Filtering (e.g. "error:true",
+# "ml_app:foo") is applied server-side via the agent's parse_filter_query.
+_LIST_PATH = "/api/unstable/llm-obs-query-rewriter/list?type=llmobs"
+
+# Upper bound when we need "all" spans for grouping/tree assembly. The agent stores
+# spans in memory for a single local session, so this is comfortably large.
+_MAX_SPANS = 5000
+
+_HTTP_TIMEOUT = 10.0
+
+
+class AgentUnavailable(Exception):
+    """Raised when the lapdog agent cannot be reached over HTTP."""
+
+
+def _agent_base_url() -> str:
+    """Return the base URL of the running lapdog agent.
+
+    Discovers the port from the lapdog pid file (~/.lapdog/lapdog.pid), falling
+    back to the PORT env var, then 8126.
+    """
+    _, port = _read_pid_file()
+    if port is None:
+        port = int(os.environ.get("PORT", "8126"))
+    return f"http://127.0.0.1:{port}"
+
+
+def _post_list(query: str, limit: int) -> List[Dict[str, Any]]:
+    """POST to the agent's list endpoint and return the raw span dicts (custom objects).
+
+    Raises AgentUnavailable with an actionable message if the agent is down.
+    """
+    url = f"{_agent_base_url()}{_LIST_PATH}"
+    body = {"list": {"limit": limit, "search": {"query": query}}}
+    try:
+        resp = requests.post(url, json=body, timeout=_HTTP_TIMEOUT)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise AgentUnavailable(
+            "Could not reach the lapdog agent at "
+            f"{_agent_base_url()} ({e}). Start it with `lapdog start` "
+            "(or `lapdog claude` / `lapdog codex`) and try again."
+        ) from e
+
+    data = resp.json()
+    events = data.get("result", {}).get("events", [])
+    spans: List[Dict[str, Any]] = []
+    for event in events:
+        custom = event.get("event", {}).get("custom")
+        if isinstance(custom, dict):
+            spans.append(custom)
+    return spans
+
+
+def _span_metrics(span: Dict[str, Any]) -> Dict[str, Any]:
+    metrics = span.get("metrics", {}) or {}
+    return {
+        "input_tokens": metrics.get("input_tokens", 0),
+        "output_tokens": metrics.get("output_tokens", 0),
+        "total_tokens": metrics.get("total_tokens", 0),
+        "estimated_total_cost": metrics.get("estimated_total_cost", 0),
+    }
+
+
+def _truncate(value: Any, limit: int = 500) -> Any:
+    """Truncate long string values so previews stay small in tool output."""
+    if isinstance(value, str) and len(value) > limit:
+        return value[:limit] + "…"
+    return value
+
+
+def _span_summary(span: Dict[str, Any]) -> Dict[str, Any]:
+    """Compact span representation for search results."""
+    meta = span.get("meta", {}) or {}
+    return {
+        "span_id": span.get("span_id", ""),
+        "trace_id": span.get("trace_id", ""),
+        "session_id": span.get("session_id", ""),
+        "name": span.get("name", ""),
+        "ml_app": span.get("ml_app", ""),
+        "status": span.get("status", "ok"),
+        "duration_ns": span.get("duration", 0),
+        "start_ns": span.get("start_ns", 0),
+        "metrics": _span_metrics(span),
+        "input": _truncate(meta.get("input")),
+        "output": _truncate(meta.get("output")),
+    }
+
+
+def list_sessions(limit: int = 50) -> Dict[str, Any]:
+    """List captured coding/LLM sessions with roll-up stats.
+
+    Returns up to `limit` sessions, most recent first. Each session aggregates its
+    spans: span count, error count, total tokens, estimated total cost, and time range.
+    """
+    spans = _post_list("", _MAX_SPANS)
+
+    sessions: Dict[str, Dict[str, Any]] = {}
+    order: List[str] = []
+    for span in spans:
+        sid = span.get("session_id") or "(no session)"
+        if sid not in sessions:
+            sessions[sid] = {
+                "session_id": sid,
+                "ml_app": span.get("ml_app", ""),
+                "span_count": 0,
+                "error_count": 0,
+                "total_tokens": 0,
+                "estimated_total_cost": 0.0,
+                "start_ns": None,
+                "end_ns": None,
+            }
+            order.append(sid)
+        agg = sessions[sid]
+        agg["span_count"] += 1
+        if span.get("status") == "error":
+            agg["error_count"] += 1
+        m = _span_metrics(span)
+        agg["total_tokens"] += m["total_tokens"] or 0
+        try:
+            agg["estimated_total_cost"] += float(m["estimated_total_cost"] or 0)
+        except (TypeError, ValueError):
+            pass
+        start_ns = span.get("start_ns")
+        if isinstance(start_ns, (int, float)):
+            end_ns = start_ns + (span.get("duration", 0) or 0)
+            if agg["start_ns"] is None or start_ns < agg["start_ns"]:
+                agg["start_ns"] = start_ns
+            if agg["end_ns"] is None or end_ns > agg["end_ns"]:
+                agg["end_ns"] = end_ns
+
+    # spans come back sorted desc by start_ns, so `order` is already most-recent-first.
+    result = [sessions[sid] for sid in order[:limit]]
+    return {"session_count": len(result), "sessions": result}
+
+
+def search_spans(query: str, limit: int = 50) -> Dict[str, Any]:
+    """Search spans using the lapdog agent's Datadog-style filter syntax.
+
+    Attributes use an `@` prefix; tags do not. Supports AND/OR/NOT and wildcards.
+    `query` examples: "@status:error", "@ml_app:my-app", "@meta.model_name:claude*",
+    "session_id:abc123". An empty query returns the most recent spans. Returns
+    compact span summaries.
+    """
+    spans = _post_list(query, limit)
+    return {"span_count": len(spans), "spans": [_span_summary(s) for s in spans]}
+
+
+def get_session(session_id: str) -> Dict[str, Any]:
+    """Fetch all spans for one session, assembled into parent/child trees.
+
+    Returns the root spans for the session, each with nested `children`, including
+    input/output and metrics per span.
+    """
+    spans = _post_list(f"session_id:{session_id}", _MAX_SPANS)
+    if not spans:
+        return {"session_id": session_id, "span_count": 0, "roots": []}
+
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for span in spans:
+        node = _span_summary(span)
+        node["children"] = []
+        by_id[span.get("span_id", "")] = node
+
+    roots: List[Dict[str, Any]] = []
+    for span in spans:
+        node = by_id[span.get("span_id", "")]
+        parent_id = span.get("parent_id")
+        if parent_id and parent_id not in ("undefined", "0", "") and parent_id in by_id:
+            by_id[parent_id]["children"].append(node)
+        else:
+            roots.append(node)
+
+    # Order siblings chronologically (ascending start) for readability.
+    def _sort(nodes: List[Dict[str, Any]]) -> None:
+        nodes.sort(key=lambda n: n.get("start_ns", 0))
+        for n in nodes:
+            _sort(n["children"])
+
+    _sort(roots)
+    return {"session_id": session_id, "span_count": len(spans), "roots": roots}
+
+
+def build_server() -> Any:
+    """Construct and return the FastMCP server with tools registered."""
+    from mcp.server.fastmcp import FastMCP
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    mcp = FastMCP("lapdog")
+
+    def _guard(fn: Callable[..., Any]) -> Callable[..., Any]:
+        """Translate AgentUnavailable into a clean MCP ToolError for the client.
+
+        functools.wraps preserves the wrapped function's signature (via
+        __wrapped__) so FastMCP can introspect the tool's parameters/annotations.
+        """
+
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return fn(*args, **kwargs)
+            except AgentUnavailable as e:
+                raise ToolError(str(e)) from e
+
+        return wrapper
+
+    mcp.tool()(_guard(list_sessions))
+    mcp.tool()(_guard(search_spans))
+    mcp.tool()(_guard(get_session))
+    return mcp
+
+
+def run() -> None:
+    """Run the stdio MCP server (blocks until the client disconnects)."""
+    if not _agent_reachable():
+        print(
+            "[lapdog] Warning: lapdog agent not reachable; start it with `lapdog start` "
+            "or `lapdog claude`. Serving MCP anyway; tool calls will report the agent is down.",
+            file=sys.stderr,
+        )
+    build_server().run(transport="stdio")
+
+
+def _agent_reachable() -> bool:
+    try:
+        requests.get(f"{_agent_base_url()}/info", timeout=2).raise_for_status()
+        return True
+    except requests.RequestException:
+        return False

--- a/releasenotes/notes/lapdog-mcp-server-e9291f1a31d8e47c.yaml
+++ b/releasenotes/notes/lapdog-mcp-server-e9291f1a31d8e47c.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Lapdog: adds a ``lapdog mcp`` command that runs a stdio MCP server exposing the
+    traces captured by a running lapdog agent. It provides ``list_sessions``,
+    ``get_session``, and ``search_spans`` tools so a coding agent can query its own
+    captured sessions, spans, tokens, and costs. Install the optional dependency with
+    ``pip install "ddapm-test-agent[mcp]"``.

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ setup(
     extras_require={
         "testing": testing_deps,
         "ddtrace": ["ddtrace"],  # todo: pin?
+        # Optional stdio MCP server (`lapdog mcp`). Kept out of install_requires so
+        # the package's >=3.8 floor and lean CI installs are unaffected; the mcp SDK
+        # requires Python >=3.10 (lapdog itself documents 3.11+).
+        "mcp": ["mcp>=1.0"],
     },
     # Required for mypy compatibility, see
     # https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages

--- a/tests/test_lapdog_mcp.py
+++ b/tests/test_lapdog_mcp.py
@@ -22,12 +22,12 @@ def test_cmd_mcp_runs_server():
 def test_cmd_mcp_missing_dependency(capsys):
     real_import = __import__
 
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    def fake_import(name, glbls=None, lcls=None, fromlist=(), level=0):
         if name == "lapdog" and fromlist and "mcp_server" in fromlist:
             raise ImportError("No module named 'mcp'")
         if name == "lapdog.mcp_server":
             raise ImportError("No module named 'mcp'")
-        return real_import(name, globals, locals, fromlist, level)
+        return real_import(name, glbls, lcls, fromlist, level)
 
     with mock.patch("builtins.__import__", side_effect=fake_import):
         with pytest.raises(SystemExit) as exc:

--- a/tests/test_lapdog_mcp.py
+++ b/tests/test_lapdog_mcp.py
@@ -1,0 +1,180 @@
+from unittest import mock
+
+import pytest
+
+from lapdog import cli
+
+
+def test_mcp_command_registered():
+    assert "mcp" in cli.LAPDOG_COMMANDS
+    assert "mcp" in cli.LAPDOG_USAGE
+
+
+def test_cmd_mcp_runs_server():
+    # cmd_mcp does `from lapdog import mcp_server`, which binds the attribute on
+    # the lapdog package, so patch it there.
+    fake_module = mock.Mock()
+    with mock.patch("lapdog.mcp_server", fake_module, create=True):
+        cli.cmd_mcp()
+    fake_module.run.assert_called_once_with()
+
+
+def test_cmd_mcp_missing_dependency(capsys):
+    real_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "lapdog" and fromlist and "mcp_server" in fromlist:
+            raise ImportError("No module named 'mcp'")
+        if name == "lapdog.mcp_server":
+            raise ImportError("No module named 'mcp'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with mock.patch("builtins.__import__", side_effect=fake_import):
+        with pytest.raises(SystemExit) as exc:
+            cli.cmd_mcp()
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "ddapm-test-agent[mcp]" in err
+
+
+# ---------------------------------------------------------------------------
+# mcp_server tool tests — only when the optional mcp dep is installed.
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("mcp")
+
+from lapdog import mcp_server  # noqa: E402
+
+
+def _event(custom):
+    return {"event": {"custom": custom}}
+
+
+def _list_response(spans):
+    return {"result": {"events": [_event(s) for s in spans]}}
+
+
+def _mock_post(spans):
+    resp = mock.Mock()
+    resp.json.return_value = _list_response(spans)
+    resp.raise_for_status.return_value = None
+    return mock.patch("lapdog.mcp_server.requests.post", return_value=resp)
+
+
+def test_agent_base_url_from_pid_file():
+    with mock.patch("lapdog.mcp_server._read_pid_file", return_value=(123, 9999)):
+        assert mcp_server._agent_base_url() == "http://127.0.0.1:9999"
+
+
+def test_agent_base_url_fallback(monkeypatch):
+    monkeypatch.delenv("PORT", raising=False)
+    with mock.patch("lapdog.mcp_server._read_pid_file", return_value=(None, None)):
+        assert mcp_server._agent_base_url() == "http://127.0.0.1:8126"
+
+
+def test_agent_base_url_env_fallback(monkeypatch):
+    monkeypatch.setenv("PORT", "7000")
+    with mock.patch("lapdog.mcp_server._read_pid_file", return_value=(None, None)):
+        assert mcp_server._agent_base_url() == "http://127.0.0.1:7000"
+
+
+def test_list_sessions_groups_and_rolls_up():
+    spans = [
+        {
+            "session_id": "s1",
+            "ml_app": "app-a",
+            "status": "ok",
+            "start_ns": 200,
+            "duration": 50,
+            "metrics": {"total_tokens": 10, "estimated_total_cost": 0.01},
+        },
+        {
+            "session_id": "s1",
+            "ml_app": "app-a",
+            "status": "error",
+            "start_ns": 100,
+            "duration": 50,
+            "metrics": {"total_tokens": 5, "estimated_total_cost": 0.02},
+        },
+        {
+            "session_id": "s2",
+            "ml_app": "app-b",
+            "status": "ok",
+            "start_ns": 300,
+            "duration": 10,
+            "metrics": {"total_tokens": 7, "estimated_total_cost": 0.03},
+        },
+    ]
+    with _mock_post(spans):
+        result = mcp_server.list_sessions()
+
+    assert result["session_count"] == 2
+    by_id = {s["session_id"]: s for s in result["sessions"]}
+    s1 = by_id["s1"]
+    assert s1["span_count"] == 2
+    assert s1["error_count"] == 1
+    assert s1["total_tokens"] == 15
+    assert s1["estimated_total_cost"] == pytest.approx(0.03)
+    assert s1["start_ns"] == 100
+    assert s1["end_ns"] == 250
+    assert by_id["s2"]["span_count"] == 1
+
+
+def test_search_spans_forwards_query_and_trims():
+    spans = [
+        {
+            "span_id": "a",
+            "trace_id": "t",
+            "session_id": "s1",
+            "name": "llm.call",
+            "ml_app": "app-a",
+            "status": "error",
+            "duration": 5,
+            "start_ns": 1,
+            "metrics": {"total_tokens": 3},
+            "meta": {"input": "x" * 1000, "output": "ok"},
+        }
+    ]
+    with _mock_post(spans) as post:
+        result = mcp_server.search_spans("@status:error", limit=10)
+
+    # query + limit are forwarded to the agent verbatim
+    _, kwargs = post.call_args
+    assert kwargs["json"] == {"list": {"limit": 10, "search": {"query": "@status:error"}}}
+
+    assert result["span_count"] == 1
+    span = result["spans"][0]
+    assert span["span_id"] == "a"
+    assert span["status"] == "error"
+    # long input is truncated
+    assert span["input"].endswith("…")
+    assert len(span["input"]) == 501
+
+
+def test_get_session_builds_tree():
+    spans = [
+        {"span_id": "root", "parent_id": "undefined", "session_id": "s1", "start_ns": 10, "name": "root"},
+        {"span_id": "child1", "parent_id": "root", "session_id": "s1", "start_ns": 30, "name": "c1"},
+        {"span_id": "child2", "parent_id": "root", "session_id": "s1", "start_ns": 20, "name": "c2"},
+        {"span_id": "grandchild", "parent_id": "child1", "session_id": "s1", "start_ns": 40, "name": "gc"},
+    ]
+    with _mock_post(spans):
+        result = mcp_server.get_session("s1")
+
+    assert result["span_count"] == 4
+    assert len(result["roots"]) == 1
+    root = result["roots"][0]
+    assert root["span_id"] == "root"
+    # siblings sorted ascending by start_ns
+    assert [c["name"] for c in root["children"]] == ["c2", "c1"]
+    c1 = next(c for c in root["children"] if c["span_id"] == "child1")
+    assert [g["span_id"] for g in c1["children"]] == ["grandchild"]
+
+
+def test_post_list_raises_agent_unavailable():
+    import requests
+
+    with mock.patch("lapdog.mcp_server.requests.post", side_effect=requests.ConnectionError("boom")):
+        with pytest.raises(mcp_server.AgentUnavailable) as exc:
+            mcp_server._post_list("", 10)
+    assert "lapdog start" in str(exc.value)


### PR DESCRIPTION
## What

Adds a `lapdog mcp` command that runs a **stdio MCP server** exposing the traces captured by a running lapdog agent, so a coding agent (Claude Code, Claude Desktop, …) can query its own sessions, spans, tokens, and costs over the [Model Context Protocol](https://modelcontextprotocol.io).

## How it works

The server is a thin client. It speaks MCP over stdio to the calling agent and fetches span data over **HTTP from the lapdog agent already running on localhost** — it does not store or re-decode anything itself.

```
MCP client (agent)  ──stdio──▶  lapdog mcp (FastMCP)  ──HTTP──▶  lapdog agent :8126
                                                                 (existing endpoints)
```

- Port is discovered from `~/.lapdog/lapdog.pid` (falling back to `PORT`, then `8126`).
- It reuses the agent's existing `/api/unstable/llm-obs-query-rewriter/list` endpoint, so span assembly, `session_id` normalization, and Datadog-style filter parsing all happen server-side — the same path the dashboard uses.
- If the agent isn't reachable, the server still starts and tool calls return an actionable "run `lapdog start`" error.

## Tools

| Tool | Description |
| --- | --- |
| `list_sessions` | Sessions with span count, error count, total tokens, estimated cost, time range. |
| `get_session` | All spans for one `session_id`, assembled into a parent/child tree with input/output + metrics. |
| `search_spans` | Filter spans with the agent's query syntax (e.g. `@status:error`, `@ml_app:foo`, `@meta.model_name:claude*`). |

## Packaging

The `mcp` SDK is an **optional extra** so the package's `>=3.8` floor and lean CI installs are unaffected (the SDK needs Python `>=3.10`; lapdog already documents 3.11+):

```bash
pip install "ddapm-test-agent[mcp]"
claude mcp add lapdog -- lapdog mcp
```

`lapdog mcp` prints an install hint if the dependency is missing rather than crashing.

## Testing

- New `tests/test_lapdog_mcp.py` (10 tests): command registration, `cmd_mcp` run + `ImportError` path, port discovery/fallback, and tool logic with mocked HTTP (grouping/roll-ups, query forwarding, tree assembly). Tool tests `importorskip("mcp")` so 3.8/3.9 suites without the extra still pass.
- Verified end-to-end against a live `--lapdog-mode` agent: ingested a 2-span session and confirmed all three tools return correct data (tree, roll-ups, and the `@status:error` filter).
- Full lapdog + llmobs-platform suites pass (90 tests); `black` clean.

## Release note

`releasenotes/notes/lapdog-mcp-server-*.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)