### PR TITLE
`dd-trace-java` writer emits `span_kind=0` for spans without a `span.kind` tag for `v1` protocol;

### DIFF
--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -938,7 +938,10 @@ def _convert_v1_span(span: Any, string_table: List[str]) -> Span:
         elif k == V1SpanKeys.SPAN_KIND:
             if not isinstance(v, int):
                 raise TypeError("Span kind must be an integer, got type %r." % type(v))
-            if v == 1:
+            if v == 0:
+                # OTEL span kind 0 is "unspecified"; keep the v0.4-like output tag absent.
+                spanKind = ""
+            elif v == 1:
                 spanKind = "internal"
             elif v == 2:
                 spanKind = "server"

--- a/releasenotes/notes/accept-v1-unspecified-span-kind-fb91ada07b54a3c9.yaml
+++ b/releasenotes/notes/accept-v1-unspecified-span-kind-fb91ada07b54a3c9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Accept v1 trace payloads with OTEL ``span_kind`` set to ``0`` (unspecified)
+    and convert them without emitting a ``span.kind`` tag, matching the behavior
+    of equivalent ``v0.4`` payloads.

--- a/tests/test_trace_v1_span_kind.py
+++ b/tests/test_trace_v1_span_kind.py
@@ -1,0 +1,24 @@
+import msgpack
+
+from ddapm_test_agent.trace import V1ChunkKeys
+from ddapm_test_agent.trace import V1SpanKeys
+from ddapm_test_agent.trace import decode_v1
+
+
+def test_v1_span_kind_unspecified():
+    span = {
+        V1SpanKeys.SPAN_ID: 1234,
+        V1SpanKeys.SPAN_KIND: 0,  # OTEL "unspecified"; should not emit `span.kind`.
+    }
+
+    chunk = {
+        V1ChunkKeys.SPANS: [span],
+    }
+
+    # Top-level `v1` trace payload key `11` contains the list of chunks.
+    data = msgpack.packb({11: [chunk]})
+
+    result = decode_v1(data)
+
+    assert result[0][0]["span_id"] == 1234
+    assert "span.kind" not in result[0][0]["meta"]


### PR DESCRIPTION
# What Does This Do
Handles `V1SpanKeys.SPAN_KIND == 0` as OTEL `unspecified` and omits the `span.kind` tag from decoded v1 trace spans.

Adds a focused regression test for `decode_v1`.

# Motivation
OTEL span kind `0` means `unspecified`, so it should not be converted into a `span.kind` value or rejected as unknown.

# Additional Notes

Targeted test:
`tests/test_trace_v1_span_kind.py