### PR TITLE
 feat(trace): decode array span event attributes in v1 payloads

### DIFF
--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -1052,6 +1052,26 @@ def _convert_v1_span_link_attributes(attr: Any, string_table: List[str]) -> Dict
     return v4_attributes
 
 
+def _convert_v1_scalar_any_value(value_type: Any, value: Any, string_table: List[str]) -> Optional[Dict[str, Any]]:
+    """Map a v1 scalar AnyValue to its v0.4 typed-scalar representation ``{"type": <int>,
+    "<kind>_value": <value>}``, or return ``None`` for non-scalar value types
+    (ARRAY/BYTES/KEY_VALUE_LIST) so the caller can handle them.
+
+    Shared by span-event attribute decoding and array-element decoding to keep the
+    STRING/BOOL/INT/DOUBLE mapping in one place. Note the v0.4 ``type`` codes differ from the v1
+    wire codes (e.g. INT is 4 on the wire but 2 in v0.4).
+    """
+    if value_type == V1AnyValueKeys.STRING:
+        return {"type": 0, "string_value": _get_and_add_string(string_table, value)}
+    elif value_type == V1AnyValueKeys.BOOL:
+        return {"type": 1, "bool_value": value}
+    elif value_type == V1AnyValueKeys.INT:
+        return {"type": 2, "int_value": value}
+    elif value_type == V1AnyValueKeys.DOUBLE:
+        return {"type": 3, "double_value": value}
+    return None
+
+
 def _convert_v1_span_event_attributes(attr: Any, string_table: List[str]) -> Dict[str, Dict[str, Any]]:
     """
     Convert a v1 span event attributes to a v4 span event attributes. Unfortunately we need multiple implementations that
@@ -1063,32 +1083,50 @@ def _convert_v1_span_event_attributes(attr: Any, string_table: List[str]) -> Dic
         raise TypeError("Attribute list must have a multiple of 3 elements, got %r." % len(attr))
     attributes: Dict[str, Dict[str, Any]] = {}
     for i in range(0, len(attr), 3):
-        v4_attr_value: Dict[str, Any] = {}
         key = _get_and_add_string(string_table, attr[i])
         value_type = attr[i + 1]
         value = attr[i + 2]
-        if value_type == V1AnyValueKeys.STRING:
-            v4_attr_value["type"] = 0
-            v4_attr_value["string_value"] = _get_and_add_string(string_table, value)
-        elif value_type == V1AnyValueKeys.BOOL:
-            v4_attr_value["type"] = 1
-            v4_attr_value["bool_value"] = value
-        elif value_type == V1AnyValueKeys.DOUBLE:
-            v4_attr_value["type"] = 3
-            v4_attr_value["double_value"] = value
-        elif value_type == V1AnyValueKeys.INT:
-            v4_attr_value["type"] = 2  # Yes the constants are different here
-            v4_attr_value["int_value"] = value
+        scalar = _convert_v1_scalar_any_value(value_type, value, string_table)
+        if scalar is not None:
+            attributes[key] = scalar
+        elif value_type == V1AnyValueKeys.ARRAY:
+            attributes[key] = {"type": 4, "array_value": _convert_v1_array_value(value, string_table)}
         elif value_type == V1AnyValueKeys.BYTES:
             raise NotImplementedError("Bytes values are not supported yet.")
-        elif value_type == V1AnyValueKeys.ARRAY:
-            raise NotImplementedError("Array of strings values are not supported yet.")
         elif value_type == V1AnyValueKeys.KEY_VALUE_LIST:
             raise NotImplementedError("Key value list values are not supported yet.")
         else:
             raise TypeError("Unknown attribute value type %r." % value_type)
-        attributes[key] = v4_attr_value
     return attributes
+
+
+def _convert_v1_array_value(value: Any, string_table: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+    """Convert a v1 wire array attribute value into the v0.4 ``array_value`` representation.
+
+    The v1 wire format encodes an array attribute value as a flat list alternating item type and
+    item value: ``[item_type_0, item_value_0, item_type_1, item_value_1, ...]``.
+    Each item is converted to the same typed-scalar shape used elsewhere for v0.4 span event
+    attributes (``{"type": <int>, "<kind>_value": <value>}``).
+
+    Heterogeneous arrays are accepted on purpose: v1 attribute values derive from OTLP ``ArrayValue``
+    and the tracer (e.g. dd-trace-java's TraceMapperV1) emits mixed-type arrays. This is deliberately
+    more permissive than the v0.4 ``verify_span`` check that requires a single element type — that
+    check guards the raw v0.4/v0.7 verification path, which v1 decoding does not go through.
+    """
+    if not isinstance(value, list):
+        raise TypeError("Array value must be a list, got type %r." % type(value))
+    if len(value) % 2 != 0:
+        raise TypeError("Array value list must have a multiple of 2 elements, got %r." % len(value))
+    values: List[Dict[str, Any]] = []
+    for i in range(0, len(value), 2):
+        item_type = value[i]
+        item_value = value[i + 1]
+        v4_item = _convert_v1_scalar_any_value(item_type, item_value, string_table)
+        if v4_item is None:
+            # TraceMapperV1 only emits scalar array items (no nested arrays/bytes/key-value lists).
+            raise TypeError("Unsupported v1 array item value type %r." % item_type)
+        values.append(v4_item)
+    return {"values": values}
 
 
 def _convert_v1_attributes(

--- a/releasenotes/notes/decode-v1-span-event-array-attributes-f5fa362696319565.yaml
+++ b/releasenotes/notes/decode-v1-span-event-array-attributes-f5fa362696319565.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add support for span events with array attributes (for example a list of strings or numbers)
+    in ``v1`` trace payloads. These were previously unsupported; they are now decoded the same way
+    as in ``v0.4``/``v0.7`` payloads, including arrays that mix value types.

--- a/tests/test_trace_v1_span_event_attributes.py
+++ b/tests/test_trace_v1_span_event_attributes.py
@@ -1,0 +1,144 @@
+import msgpack
+import pytest
+
+from ddapm_test_agent.trace import V1AnyValueKeys
+from ddapm_test_agent.trace import V1ChunkKeys
+from ddapm_test_agent.trace import V1SpanEventKeys
+from ddapm_test_agent.trace import V1SpanKeys
+from ddapm_test_agent.trace import _convert_v1_array_value
+from ddapm_test_agent.trace import decode_v1
+
+
+def _decode_single_event_attributes(attributes):
+    """Decode a minimal v1 payload carrying one span event with the given (wire-encoded)
+    attribute triplet list, and return the decoded v0.4 attributes of that event.
+
+    A v1 span event attribute is a flat ``(key, type, value)`` triplet stream; an ARRAY value is a
+    flat ``[item_type, item_value, ...]`` list.
+    """
+    event = {
+        V1SpanEventKeys.TIME: 1,
+        V1SpanEventKeys.NAME: "event",
+        V1SpanEventKeys.ATTRIBUTES: attributes,
+    }
+    span = {V1SpanKeys.SPAN_ID: 1234, V1SpanKeys.SPAN_EVENTS: [event]}
+    chunk = {V1ChunkKeys.SPANS: [span]}
+    # Top-level v1 trace payload key `11` contains the list of chunks.
+    result = decode_v1(msgpack.packb({11: [chunk]}))
+    return result[0][0]["span_events"][0]["attributes"]
+
+
+def test_v1_span_event_string_array_attribute():
+    attrs = ["tags", V1AnyValueKeys.ARRAY, [V1AnyValueKeys.STRING, "checkout", V1AnyValueKeys.STRING, "payment"]]
+    assert _decode_single_event_attributes(attrs) == {
+        "tags": {
+            "type": 4,
+            "array_value": {
+                "values": [
+                    {"type": 0, "string_value": "checkout"},
+                    {"type": 0, "string_value": "payment"},
+                ]
+            },
+        }
+    }
+
+
+def test_v1_span_event_empty_array_attribute():
+    attrs = ["tags", V1AnyValueKeys.ARRAY, []]
+    assert _decode_single_event_attributes(attrs) == {"tags": {"type": 4, "array_value": {"values": []}}}
+
+
+def test_v1_span_event_mixed_scalar_and_array_attributes():
+    attrs = [
+        "message",
+        V1AnyValueKeys.STRING,
+        "hello",
+        "http.status_code",
+        V1AnyValueKeys.INT,
+        200,
+        "retry_delays_ms",
+        V1AnyValueKeys.ARRAY,
+        [V1AnyValueKeys.INT, 100, V1AnyValueKeys.INT, 200],
+    ]
+    decoded = _decode_single_event_attributes(attrs)
+    assert decoded["message"] == {"type": 0, "string_value": "hello"}
+    assert decoded["http.status_code"] == {"type": 2, "int_value": 200}
+    assert decoded["retry_delays_ms"] == {
+        "type": 4,
+        "array_value": {"values": [{"type": 2, "int_value": 100}, {"type": 2, "int_value": 200}]},
+    }
+
+
+@pytest.mark.parametrize(
+    "item_type, item_value, expected",
+    [
+        (V1AnyValueKeys.STRING, "ok", {"type": 0, "string_value": "ok"}),
+        (V1AnyValueKeys.BOOL, True, {"type": 1, "bool_value": True}),
+        (V1AnyValueKeys.BOOL, False, {"type": 1, "bool_value": False}),
+        (V1AnyValueKeys.INT, 5, {"type": 2, "int_value": 5}),
+        (V1AnyValueKeys.DOUBLE, 1.5, {"type": 3, "double_value": 1.5}),
+    ],
+)
+def test_v1_span_event_array_item_types(item_type, item_value, expected):
+    attrs = ["items", V1AnyValueKeys.ARRAY, [item_type, item_value]]
+    assert _decode_single_event_attributes(attrs)["items"]["array_value"]["values"] == [expected]
+
+
+def test_v1_span_event_heterogeneous_array_attribute():
+    # v1 array attributes derive from OTLP ArrayValue and may mix element types,
+    # for example: ["ok", 7, 2.5, false].
+    # The decoder accepts them on purpose; it does not enforce the single-type rule
+    # that v0.4 verify_span applies.
+    attrs = [
+        "mixed_values",
+        V1AnyValueKeys.ARRAY,
+        [V1AnyValueKeys.STRING, "ok", V1AnyValueKeys.INT, 7, V1AnyValueKeys.DOUBLE, 2.5, V1AnyValueKeys.BOOL, False],
+    ]
+    assert _decode_single_event_attributes(attrs)["mixed_values"]["array_value"]["values"] == [
+        {"type": 0, "string_value": "ok"},
+        {"type": 2, "int_value": 7},
+        {"type": 3, "double_value": 2.5},
+        {"type": 1, "bool_value": False},
+    ]
+
+
+def test_v1_span_event_array_attribute_resolves_string_table_indexes():
+    # End-to-end streaming-string check: the attribute key and a string array item arrive as
+    # indexes into the string table rather than inline strings. Payload keys 2-9 seed the table
+    # (index 1 -> "tags", index 2 -> "checkout") before the chunks (key 11) are decoded.
+    event = {
+        V1SpanEventKeys.TIME: 1,
+        V1SpanEventKeys.ATTRIBUTES: [1, V1AnyValueKeys.ARRAY, [V1AnyValueKeys.STRING, 2]],
+    }
+    span = {V1SpanKeys.SPAN_ID: 1234, V1SpanKeys.SPAN_EVENTS: [event]}
+    # Top-level v1 trace payload key `11` contains the list of chunks.
+    payload = msgpack.packb({2: "tags", 3: "checkout", 11: [{V1ChunkKeys.SPANS: [span]}]})
+
+    result = decode_v1(payload)
+
+    assert result[0][0]["span_events"][0]["attributes"] == {
+        "tags": {"type": 4, "array_value": {"values": [{"type": 0, "string_value": "checkout"}]}}
+    }
+
+
+def test_convert_v1_array_value_resolves_string_table_index():
+    # String items may arrive as an index into the streaming string table rather than inline.
+    string_table = ["", "indexed"]
+    assert _convert_v1_array_value([V1AnyValueKeys.STRING, 1], string_table) == {
+        "values": [{"type": 0, "string_value": "indexed"}]
+    }
+
+
+def test_convert_v1_array_value_rejects_non_list():
+    with pytest.raises(TypeError):
+        _convert_v1_array_value("not a list", [""])
+
+
+def test_convert_v1_array_value_rejects_odd_length():
+    with pytest.raises(TypeError):
+        _convert_v1_array_value([V1AnyValueKeys.INT], [""])
+
+
+def test_convert_v1_array_value_rejects_unknown_item_type():
+    with pytest.raises(TypeError):
+        _convert_v1_array_value([V1AnyValueKeys.KEY_VALUE_LIST, 0], [""])


### PR DESCRIPTION
# What Does This Do
 Adds decoding of **array-valued span event attributes** in `v1` trace payloads. Previously `_convert_v1_span_event_attributes` raised `NotImplementedError` on the `ARRAY` value type, so any payload with an array attribute (e.g. `["a", "b"]`) was rejected with a `400`.
  - New `_convert_v1_array_value` converts the flat `[item_type, item_value, ...]` wire array into the `{"array_value": {"values": [...]}}` shape used for `v0.4`/`v0.7` span events.
  - Extracted `_convert_v1_scalar_any_value` so the `STRING`/`BOOL`/`INT`/`DOUBLE` mapping is shared between scalar and array decoding instead of duplicated.
  - Heterogeneous (mixed-type) arrays are accepted on purpose — `verify_span`'s single-type rule is not on the `v1` decode path.
  - Adds `tests/test_trace_v1_span_event_attributes.py` and a `features` release note.

# Motivation
Tracers default to `v1` are now exercising the full test suite, and `dd-trace-java` emits span events with array attributes (matching OTLP `ArrayValue`). The test agent needs to decode them to keep those traces from being dropped.

# Additional Notes                                                                                                                                                                                                                     
  - No behavior change for `v0.4`/`v0.7` or for non-array `v1` attributes.
  - `BYTES`/`KEY_VALUE_LIST` array items remain unsupported and raise `TypeError`, consistent with the scalar paths.
