### PR TITLE
fix: always bind TCP, and add the socket when configured.

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -2698,11 +2698,11 @@ def main(args: Optional[List[str]] = None) -> None:
             agent, parsed_args.otlp_http_port, parsed_args.otlp_grpc_port, host=parsed_args.host
         )
 
-        # Create sites for both apps
+        # Always expose the APM receiver over TCP. When a UDS socket is also
+        # configured, bind both so clients can reach the agent over either transport.
+        apm_sites = [web.TCPSite(apm_runner, host=parsed_args.host, port=parsed_args.port)]
         if apm_sock:
-            apm_site = web.SockSite(apm_runner, apm_sock)
-        else:
-            apm_site = web.TCPSite(apm_runner, host=parsed_args.host, port=parsed_args.port)
+            apm_sites.append(web.SockSite(apm_runner, apm_sock))
 
         otlp_http_site = web.TCPSite(otlp_http_runner, host=parsed_args.host, port=parsed_args.otlp_http_port)
 
@@ -2712,13 +2712,16 @@ def main(args: Optional[List[str]] = None) -> None:
             web_ui_site = web.TCPSite(web_ui_runner, host=parsed_args.host, port=parsed_args.web_ui_port)
 
         # Start servers concurrently
-        sites_to_start = [apm_site.start(), otlp_http_site.start()]
+        sites_to_start = [site.start() for site in apm_sites]
+        sites_to_start.append(otlp_http_site.start())
         if web_ui_site is not None:
             sites_to_start.append(web_ui_site.start())
 
         await asyncio.gather(*sites_to_start)
 
         print(f"======== Running APM server on port {parsed_args.port} ========")
+        if apm_sock:
+            print(f"======== Running APM server on UDS socket {parsed_args.trace_uds_socket} ========")
         print(f"======== Running OTLP HTTP server on port {parsed_args.otlp_http_port} ========")
         print(f"======== Running OTLP GRPC server on port {parsed_args.otlp_grpc_port} ========")
         if web_ui_site is not None:

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -2700,7 +2700,7 @@ def main(args: Optional[List[str]] = None) -> None:
 
         # Always expose the APM receiver over TCP. When a UDS socket is also
         # configured, bind both so clients can reach the agent over either transport.
-        apm_sites = [web.TCPSite(apm_runner, host=parsed_args.host, port=parsed_args.port)]
+        apm_sites: List[web.BaseSite] = [web.TCPSite(apm_runner, host=parsed_args.host, port=parsed_args.port)]
         if apm_sock:
             apm_sites.append(web.SockSite(apm_runner, apm_sock))
 

--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -47,6 +47,7 @@ SPAN_REQUIRED_ATTRS = [
 ]
 
 MetricType = Union[int, float]
+SpanEventAttributeValue = Union[str, bool, int, float, List[Union[str, bool, int, float]]]
 
 
 class SpanLink(TypedDict):
@@ -582,7 +583,7 @@ def add_span_event(
     s: Span,
     time_unix_nano: int = 1730405656000000000,
     name: str = "event",
-    attributes: Optional[Dict[str, Dict[str, Any]]] = None,
+    attributes: Optional[Dict[str, SpanEventAttributeValue]] = None,
 ) -> Span:
     if "span_events" not in s:
         s["span_events"] = []

--- a/releasenotes/notes/uds-and-tcp-listeners-7c1e2a9b4d3f8e60.yaml
+++ b/releasenotes/notes/uds-and-tcp-listeners-7c1e2a9b4d3f8e60.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The APM receiver now listens on its TCP port **and** the configured UDS socket simultaneously. Previously,
+    setting ``DD_APM_RECEIVER_SOCKET`` (or ``--trace-uds-socket``) replaced the TCP listener with a socket-only
+    listener, so clients and container healthchecks reaching the agent over the published port received "connection refused".
+    This restores the historical behavior where both transports are bound together.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -7,6 +7,7 @@ import time
 import urllib.error
 import urllib.request
 
+import aiohttp
 import msgpack
 import pytest
 
@@ -1279,3 +1280,36 @@ async def test_traces_via_uds(
     assert resp.status == 200
     received_traces = await resp.json()
     assert received_traces == v04_reference_http_trace_payload_data_raw
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix domain sockets are not supported on Windows")
+async def test_tcp_available_when_uds_configured(
+    testagent,
+    testagent_port,
+    testagent_uds_socket_path,
+    v04_reference_http_trace_payload_headers,
+    v04_reference_http_trace_payload_data,
+    v04_reference_http_trace_payload_data_raw,
+):
+    """Configuring a UDS socket must not drop the TCP listener.
+
+    Regression test: setting DD_APM_RECEIVER_SOCKET used to replace the TCP
+    listener with a socket-only listener, so clients (and container
+    healthchecks) reaching the agent over the published port got connection
+    refused. The agent must bind both transports simultaneously.
+    """
+    assert testagent_uds_socket_path.exists(), f"UDS socket does not exist at {testagent_uds_socket_path}"
+
+    base_url = f"http://127.0.0.1:{testagent_port}"
+    async with aiohttp.ClientSession() as tcp_session:
+        resp = await tcp_session.put(
+            f"{base_url}/v0.4/traces",
+            headers=v04_reference_http_trace_payload_headers,
+            data=v04_reference_http_trace_payload_data,
+        )
+        assert resp.status == 200
+
+        resp = await tcp_session.get(f"{base_url}/test/traces")
+        assert resp.status == 200
+        received_traces = await resp.json()
+        assert received_traces == v04_reference_http_trace_payload_data_raw


### PR DESCRIPTION
Since v1.32.0, configuring DD_APM_RECEIVER_SOCKET (or --trace-uds-socket) replaced the TCP listener with a socket-only listener instead of adding to it.

The pre-v1.32.0 startup used a single web.run_app(app, sock=apm_sock, port=...) call, and aiohttp binds both a TCPSite (whenever a port is given) and a SockSite (whenever a socket is given).

The v1.32.0 refactor that introduced the concurrent OTLP servers translated that additive behavior into a mutually-exclusive if/else, so any client reaching the agent over the published TCP port — container healthchecks, Kubernetes TCP readiness/liveness probes, and trace-fetch clients — got "connection refused" while the socket was in use.

Fix: Always bind the APM receiver over TCP and additionally bind the UDS socket when one is configured, restoring the historical dual-transport behavior.
