### PR TITLE
feat(vcr): add regex body normalizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,18 @@ To ignore headers in recorded cassettes, you can use the `--vcr-ignore-headers` 
 
 To normalize JSON bodies in recorded cassettes, you can use the `--vcr-json-body-normalizers` flag or `VCR_JSON_BODY_NORMALIZERS` environment variable. The list should take the form of `json.path1,json.path2,json.path3`, and the values at those JSON paths will be replaced with a placeholder in the recorded cassettes. This is particularly useful for normalizing request bodies with dynamic values such as timestamps or ids.
 
+#### Normalizing request bodies with regex in recorded cassettes
+
+For non-JSON content (or for values embedded in JSON strings that aren't reachable via a path), use the `--vcr-body-regex-normalizers` flag or `VCR_BODY_REGEX_NORMALIZERS` environment variable. The list should take the form of `pattern1,pattern2,pattern3`. Each pattern is a Python regex; every match in the request body is replaced with `<normalized>` before the cassette hash is computed.
+
+```
+VCR_BODY_REGEX_NORMALIZERS=agentId: [a-f0-9]+,"client_timestamp":"[^"]+",cc_version=[^;]+
+```
+
+This is useful for masking volatile identifiers, timestamps, or telemetry fields that vary every run but should be collapsed to a single cassette. Anchor each pattern on a unique prefix or surrounding key so it does not match unrelated content.
+
+Regex normalizers run before JSON-path normalizers, and both can be configured at the same time.
+
 #### AWS Services
 AWS service proxying, specifically recording cassettes for the first time, requires a `AWS_SECRET_ACCESS_KEY` environment variable to be set for the container running the test agent. This is used to recalculate the AWS signature for the request, as the one generated client-side likely used `{test-agent-host}:{test-agent-port}/vcr/{aws-service}` as the host, and the signature will mismatch that on the actual AWS service.
 

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -2052,6 +2052,7 @@ def make_app(
     vcr_provider_map: str,
     vcr_ignore_headers: str,
     vcr_json_body_normalizers: str,
+    vcr_body_regex_normalizers: str,
     dd_site: str,
     dd_api_key: Optional[str],
     disable_llmobs_data_forwarding: bool,
@@ -2204,6 +2205,7 @@ def make_app(
     app["vcr_provider_map"] = vcr_provider_map
     app["vcr_ignore_headers"] = vcr_ignore_headers
     app["vcr_json_body_normalizers"] = vcr_json_body_normalizers
+    app["vcr_body_regex_normalizers"] = vcr_body_regex_normalizers
     app["dd_site"] = dd_site
     app["dd_api_key"] = dd_api_key
     app["org_prop_marker"] = org_prop_marker
@@ -2525,6 +2527,12 @@ def main(args: Optional[List[str]] = None) -> None:
         help="Comma-separated list of normalizers to apply when recording VCR cassettes.",
     )
     parser.add_argument(
+        "--vcr-body-regex-normalizers",
+        type=str,
+        default=os.environ.get("VCR_BODY_REGEX_NORMALIZERS", ""),
+        help="Comma-separated list of regex patterns to replace with <normalized> in the body before hashing.",
+    )
+    parser.add_argument(
         "--web-ui-port",
         type=int,
         default=int(os.environ.get("WEB_UI_PORT", 0)),
@@ -2619,6 +2627,7 @@ def main(args: Optional[List[str]] = None) -> None:
         vcr_provider_map=parsed_args.vcr_provider_map,
         vcr_ignore_headers=parsed_args.vcr_ignore_headers,
         vcr_json_body_normalizers=parsed_args.vcr_json_body_normalizers,
+        vcr_body_regex_normalizers=parsed_args.vcr_body_regex_normalizers,
         dd_site=parsed_args.dd_site,
         dd_api_key=parsed_args.dd_api_key,
         disable_llmobs_data_forwarding=parsed_args.disable_llmobs_data_forwarding,

--- a/ddapm_test_agent/vcr_proxy.py
+++ b/ddapm_test_agent/vcr_proxy.py
@@ -186,7 +186,11 @@ def _apply_json_path_normalizer(body_dict: Dict[str, Any], path: str, placeholde
         obj[parts[-1]] = placeholder
 
 
-def _normalize_body(body: bytes, vcr_json_body_normalizers: Optional[List[str]] = None) -> str:
+def _normalize_body(
+    body: bytes,
+    vcr_json_body_normalizers: Optional[List[str]] = None,
+    vcr_body_regex_normalizers: Optional[List[str]] = None,
+) -> str:
     if not body:
         return ""
 
@@ -201,6 +205,10 @@ def _normalize_body(body: bytes, vcr_json_body_normalizers: Optional[List[str]] 
 
     for pattern, replacement in NORMALIZERS:
         body_str = re.sub(pattern, replacement, body_str)
+
+    if vcr_body_regex_normalizers:
+        for pattern in vcr_body_regex_normalizers:
+            body_str = re.sub(pattern, "<normalized>", body_str)
 
     if vcr_json_body_normalizers:
         try:
@@ -269,8 +277,9 @@ def _generate_cassette_name(
     body: bytes,
     vcr_cassette_prefix: Optional[str],
     vcr_json_body_normalizers: Optional[List[str]] = None,
+    vcr_body_regex_normalizers: Optional[List[str]] = None,
 ) -> str:
-    decoded_body = _normalize_body(body, vcr_json_body_normalizers) if body else ""
+    decoded_body = _normalize_body(body, vcr_json_body_normalizers, vcr_body_regex_normalizers) if body else ""
     try:
         parsed_body = json.loads(decoded_body) if decoded_body else {}
     except json.JSONDecodeError:
@@ -468,6 +477,7 @@ async def proxy_request(
     vcr_provider_map: str = request.app["vcr_provider_map"]
     vcr_ignore_headers: str = request.app["vcr_ignore_headers"]
     vcr_json_body_normalizers: str = request.app["vcr_json_body_normalizers"]
+    vcr_body_regex_normalizers: str = request.app["vcr_body_regex_normalizers"]
 
     provider_base_urls = PROVIDER_BASE_URLS.copy()
     provider_base_urls.update(_get_custom_vcr_providers(vcr_provider_map))
@@ -493,6 +503,7 @@ async def proxy_request(
         body_bytes,
         vcr_cassette_prefix,
         _get_vcr_normalizers(vcr_json_body_normalizers),
+        _get_vcr_normalizers(vcr_body_regex_normalizers),
     )
     cassette_file_path = os.path.join(vcr_cassettes_directory, provider, cassette_name)
     cassette_exists = len(glob(f"{cassette_file_path}.*")) > 0

--- a/releasenotes/notes/vcr-general-regex-normalizers-089d532efaf87807.yaml
+++ b/releasenotes/notes/vcr-general-regex-normalizers-089d532efaf87807.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    vcr: Add support for normalizing parts of JSON request bodies via regular expression when recording requests via ``--vcr-body-regex-normalizers`` or ``VCR_BODY_REGEX_NORMALIZERS``. This option should take a comma-separated list of regular expressions to normalize, e.g. ``agentId: [a-f0-9]+,duration_ms: \\d+``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,6 +144,11 @@ def vcr_json_body_normalizers() -> Generator[str, None, None]:
 
 
 @pytest.fixture
+def vcr_body_regex_normalizers() -> Generator[str, None, None]:
+    yield ""
+
+
+@pytest.fixture
 def dd_site() -> Generator[str, None, None]:
     yield "datadoghq.com"
 
@@ -178,6 +183,7 @@ async def agent_app(
     vcr_provider_map,
     vcr_ignore_headers,
     vcr_json_body_normalizers,
+    vcr_body_regex_normalizers,
     dd_site,
     dd_api_key,
     disable_llmobs_data_forwarding,
@@ -201,6 +207,7 @@ async def agent_app(
             vcr_provider_map=vcr_provider_map,
             vcr_ignore_headers=vcr_ignore_headers,
             vcr_json_body_normalizers=vcr_json_body_normalizers,
+            vcr_body_regex_normalizers=vcr_body_regex_normalizers,
             dd_site=dd_site,
             dd_api_key=dd_api_key,
             disable_llmobs_data_forwarding=disable_llmobs_data_forwarding,

--- a/tests/test_vcr_proxy.py
+++ b/tests/test_vcr_proxy.py
@@ -120,6 +120,11 @@ def vcr_json_body_normalizers() -> Generator[str, None, None]:
 
 
 @pytest.fixture
+def vcr_body_regex_normalizers() -> Generator[str, None, None]:
+    yield "agentId: [a-f0-9]+,duration_ms: \\d+"
+
+
+@pytest.fixture
 def vcr_legacy_cassette(vcr_cassettes_directory: str) -> Generator[str, None, None]:
     cassette_name = _generate_cassette_name("custom/serve", "POST", b'{"foo": "bar"}', None)
     os.makedirs(os.path.join(vcr_cassettes_directory, "custom"), exist_ok=True)
@@ -343,3 +348,73 @@ async def test_vcr_proxy_normalizes_nested_json_field_to_single_cassette(
 
     cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
     assert len(cassette_files) == 1  # same cassette despite different nested dummy_id
+
+
+async def test_vcr_proxy_normalizes_body_regex_to_single_cassette(
+    agent: TestClient[Any, Any], vcr_cassettes_directory: str
+) -> None:
+    resp = await agent.post(
+        "/vcr/custom/serve",
+        json={"foo": "bar", "note": "agentId: a8abe56defff0d36b ran the task"},
+    )
+
+    assert resp.status == 200
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 1
+
+    resp = await agent.post(
+        "/vcr/custom/serve",
+        json={"foo": "bar", "note": "agentId: ae218d131137d15da ran the task"},
+    )
+
+    assert resp.status == 200
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 1  # same cassette despite different agentId hex
+
+
+async def test_vcr_proxy_body_regex_supports_multiple_patterns(
+    agent: TestClient[Any, Any], vcr_cassettes_directory: str
+) -> None:
+    resp = await agent.post(
+        "/vcr/custom/serve",
+        json={"note": "agentId: abc123 finished in duration_ms: 6399"},
+    )
+
+    assert resp.status == 200
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 1
+
+    # both the hex agentId and the duration_ms vary; the second pattern in the list must also normalize
+    resp = await agent.post(
+        "/vcr/custom/serve",
+        json={"note": "agentId: deadbeef finished in duration_ms: 45"},
+    )
+
+    assert resp.status == 200
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 1
+
+
+async def test_vcr_proxy_body_regex_does_not_collapse_other_body_differences(
+    agent: TestClient[Any, Any], vcr_cassettes_directory: str
+) -> None:
+    resp = await agent.post(
+        "/vcr/custom/serve",
+        json={"foo": "bar", "note": "agentId: abc123 ran"},
+    )
+
+    assert resp.status == 200
+
+    resp = await agent.post(
+        "/vcr/custom/serve",
+        json={"foo": "DIFFERENT", "note": "agentId: def456 ran"},
+    )
+
+    assert resp.status == 200
+
+    cassette_files = get_cassettes_for_provider("custom", vcr_cassettes_directory)
+    assert len(cassette_files) == 2  # different `foo` values still produce separate cassettes


### PR DESCRIPTION
Adds regex-based body normalizations. Previously, static normalizer pattern support was added, for something like `metadata.foo`, in the request body. Now, for more granular normalization for fields that might change between otherwise semantically-equivalent requests, a regex support parser is added, and normalizes the texts for _hash computation only_.