### PR TITLE
fix(lapdog): route path-form launcher invocations to dedicated launcher

### DIFF
--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -31,6 +31,11 @@ from lapdog.paths import LOG_FILE
 from lapdog.paths import PID_FILE
 
 LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "uninstall"]
+# Managed launchers that also exist as external binaries a user might invoke by
+# an explicit path (e.g. ``lapdog ~/.local/bin/claude``). Unlike start/stop/
+# status/uninstall, these must be recognized whether spelled as a bare name or
+# a path so they route to their dedicated launcher instead of ``cmd_exec``.
+_PATH_ROUTABLE_LAUNCHERS = ("claude", "pi", "codex")
 LAPDOG_USAGE = (
     "Usage: lapdog [OPTIONS] <command> [command-args...]\n"
     "Options must appear before <command>. Arguments after <command> are forwarded.\n"
@@ -1030,6 +1035,41 @@ def _consume_backfill_arg(args: List[str]) -> Tuple[List[str], bool]:
     return cleaned, backfill
 
 
+def _canonical_launcher(target: str) -> Optional[str]:
+    """Map an invocation target to a managed launcher name, or return None.
+
+    A managed launcher may be invoked either by bare name (``claude``) or by an
+    explicit path that resolves to the same binary (``~/.local/bin/claude``,
+    i.e. what ``which claude`` returns). Both must route to the dedicated
+    launcher (``cmd_claude``/``cmd_pi``/``cmd_codex``). The generic ``cmd_exec``
+    wrapper injects a ``PYTHONPATH`` pointing at ``lapdog/bootstrap`` that is
+    inherited by every Python subprocess the agent later spawns; each then
+    fails ``sitecustomize``'s ``import ddtrace`` check with
+    "[lapdog] ddtrace is not installed" (MLOB-7870).
+
+    A bare, unknown word (e.g. ``python``) returns None so it still falls
+    through to ``cmd_exec`` unchanged.
+
+    Matching is by resolved target, not basename: Claude Code installs as a
+    versioned binary (``.../versions/2.1.215``) with a ``claude`` symlink, so
+    ``realpath`` of the invoked path and of ``which claude`` both point at the
+    same versioned file even though its basename is not ``claude``.
+    """
+    if target.lower() in _PATH_ROUTABLE_LAUNCHERS:
+        return target.lower()
+
+    # Only treat the target as a path when it looks like one.
+    if not (target.startswith("~") or os.sep in target or (os.altsep and os.altsep in target)):
+        return None
+
+    invoked = os.path.realpath(os.path.expanduser(target))
+    for launcher in _PATH_ROUTABLE_LAUNCHERS:
+        on_path = shutil.which(launcher)
+        if on_path and os.path.realpath(on_path) == invoked:
+            return launcher
+    return None
+
+
 def main() -> None:
     # On Windows the default stdout/stderr encoding is the system ANSI codepage
     # (e.g. cp1252), which can't encode the banner's box-drawing glyphs. Force
@@ -1052,10 +1092,14 @@ def main() -> None:
     lapdog_args, remaining = _parse_command(args[1:])
     lapdog_parsed_args = _parse_lapdog_args(lapdog_args)
 
-    sub_cmd = remaining[0].lower()
+    # Resolve path-form invocations of a managed launcher (e.g.
+    # ``lapdog ~/.local/bin/claude``) to their canonical command so they route
+    # to the dedicated launcher rather than the generic cmd_exec wrapper
+    # (MLOB-7870). Unknown targets fall through to cmd_exec unchanged.
+    sub_cmd = _canonical_launcher(remaining[0]) or remaining[0].lower()
     sub_cmd_args = remaining[1:]
     command_backfill = False
-    if sub_cmd in ("claude", "pi", "codex"):
+    if sub_cmd in _PATH_ROUTABLE_LAUNCHERS:
         sub_cmd_args, command_backfill = _consume_backfill_arg(sub_cmd_args)
     backfill = lapdog_parsed_args.backfill or command_backfill
 

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -32,9 +32,7 @@ from lapdog.paths import PID_FILE
 
 LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "uninstall"]
 # Managed launchers that also exist as external binaries a user might invoke by
-# an explicit path (e.g. ``lapdog ~/.local/bin/claude``). Unlike start/stop/
-# status/uninstall, these must be recognized whether spelled as a bare name or
-# a path so they route to their dedicated launcher instead of ``cmd_exec``.
+# an explicit path (e.g. ``lapdog ~/.local/bin/claude``)
 _PATH_ROUTABLE_LAUNCHERS = ("claude", "pi", "codex")
 LAPDOG_USAGE = (
     "Usage: lapdog [OPTIONS] <command> [command-args...]\n"
@@ -1041,24 +1039,14 @@ def _canonical_launcher(target: str) -> Optional[str]:
     A managed launcher may be invoked either by bare name (``claude``) or by an
     explicit path that resolves to the same binary (``~/.local/bin/claude``,
     i.e. what ``which claude`` returns). Both must route to the dedicated
-    launcher (``cmd_claude``/``cmd_pi``/``cmd_codex``). The generic ``cmd_exec``
-    wrapper injects a ``PYTHONPATH`` pointing at ``lapdog/bootstrap`` that is
-    inherited by every Python subprocess the agent later spawns; each then
-    fails ``sitecustomize``'s ``import ddtrace`` check with
-    "[lapdog] ddtrace is not installed" (MLOB-7870).
+    launcher (``cmd_claude``/``cmd_pi``/``cmd_codex``).
 
     A bare, unknown word (e.g. ``python``) returns None so it still falls
     through to ``cmd_exec`` unchanged.
-
-    Matching is by resolved target, not basename: Claude Code installs as a
-    versioned binary (``.../versions/2.1.215``) with a ``claude`` symlink, so
-    ``realpath`` of the invoked path and of ``which claude`` both point at the
-    same versioned file even though its basename is not ``claude``.
     """
     if target.lower() in _PATH_ROUTABLE_LAUNCHERS:
         return target.lower()
 
-    # Only treat the target as a path when it looks like one.
     if not (target.startswith("~") or os.sep in target or (os.altsep and os.altsep in target)):
         return None
 
@@ -1092,10 +1080,6 @@ def main() -> None:
     lapdog_args, remaining = _parse_command(args[1:])
     lapdog_parsed_args = _parse_lapdog_args(lapdog_args)
 
-    # Resolve path-form invocations of a managed launcher (e.g.
-    # ``lapdog ~/.local/bin/claude``) to their canonical command so they route
-    # to the dedicated launcher rather than the generic cmd_exec wrapper
-    # (MLOB-7870). Unknown targets fall through to cmd_exec unchanged.
     sub_cmd = _canonical_launcher(remaining[0]) or remaining[0].lower()
     sub_cmd_args = remaining[1:]
     command_backfill = False

--- a/releasenotes/notes/lapdog-path-routing-7a3c1e9d2f4b8c60.yaml
+++ b/releasenotes/notes/lapdog-path-routing-7a3c1e9d2f4b8c60.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    lapdog: Route path-form launcher invocations (e.g.
+    ``lapdog ~/.local/bin/claude``) to the dedicated launcher instead of the
+    generic ``exec`` wrapper, which previously broke Python subprocesses with
+    ``[lapdog] ddtrace is not installed``.

--- a/tests/test_lapdog_cli.py
+++ b/tests/test_lapdog_cli.py
@@ -699,3 +699,66 @@ def test_cmd_codex_backfill_does_not_exec_codex(monkeypatch):
     run_backfill.assert_called_once_with("http://localhost:8126", cwd=expected_cwd)
     start_watcher.assert_not_called()
     run_codex.assert_not_called()
+
+
+def test_canonical_launcher_bare_name():
+    assert cli._canonical_launcher("claude") == "claude"
+    assert cli._canonical_launcher("Codex") == "codex"
+
+
+def test_canonical_launcher_path_resolving_to_launcher(monkeypatch, tmp_path):
+    # Claude installs as a versioned binary with a `claude` symlink. A path
+    # invocation that resolves to the same file as `which claude` must map to
+    # the `claude` command so it routes to cmd_claude, not cmd_exec (MLOB-7870).
+    real = tmp_path / "versions" / "2.1.215"
+    real.parent.mkdir(parents=True)
+    real.write_text("#!/bin/sh\n")
+    link = tmp_path / "bin" / "claude"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(real)
+
+    monkeypatch.setattr(cli.shutil, "which", lambda name: str(link) if name == "claude" else None)
+
+    # Invoked via the symlink or via the versioned real path — both resolve to
+    # the same target as `which claude`.
+    assert cli._canonical_launcher(str(link)) == "claude"
+    assert cli._canonical_launcher(str(real)) == "claude"
+
+
+def test_canonical_launcher_ignores_unknown_targets(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    assert cli._canonical_launcher("python") is None
+    assert cli._canonical_launcher("/usr/bin/python") is None
+
+
+def test_canonical_launcher_path_not_matching_which_falls_through(monkeypatch, tmp_path):
+    # A path whose basename is `claude` but which does not resolve to the
+    # managed claude binary must NOT be rerouted.
+    other = tmp_path / "claude"
+    other.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    assert cli._canonical_launcher(str(other)) is None
+
+
+def test_main_routes_full_path_claude_to_cmd_claude(monkeypatch, tmp_path):
+    claude = tmp_path / "claude"
+    claude.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cli.shutil, "which", lambda name: str(claude) if name == "claude" else None)
+    monkeypatch.setattr(cli.sys, "argv", ["lapdog", str(claude)])
+    with mock.patch("lapdog.cli.cmd_claude") as cmd_claude:
+        with mock.patch("lapdog.cli.cmd_exec") as cmd_exec:
+            cli.main()
+
+    cmd_claude.assert_called_once()
+    cmd_exec.assert_not_called()
+
+
+def test_main_routes_unknown_command_to_cmd_exec(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli.sys, "argv", ["lapdog", "/usr/bin/python", "app.py"])
+    with mock.patch("lapdog.cli.cmd_claude") as cmd_claude:
+        with mock.patch("lapdog.cli.cmd_exec") as cmd_exec:
+            cli.main()
+
+    cmd_exec.assert_called_once()
+    cmd_claude.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes [MLOB-7870](https://datadoghq.atlassian.net/browse/MLOB-7870).

lapdog dispatches on an exact string match of the first argument, so only the bare names `claude`, `pi`, and `codex` reach their dedicated launchers. Invoking a managed launcher by an explicit **path** (e.g. `lapdog ~/.local/bin/claude`) — the same binary `which claude` resolves to — doesn't match, so it falls through to the generic `cmd_exec` wrapper instead.

`cmd_exec` injects a `PYTHONPATH` pointing at `lapdog/bootstrap`, which is then inherited by every Python subprocess spawned for the rest of the session (hooks, Bash tool calls, MCP servers). Each fails `sitecustomize`'s `import ddtrace` check and exits with `[lapdog] ddtrace is not installed`. The result: two invocations of the *identical* binary behave differently — the bare name works, the full path silently breaks the session.

## Fix

- Add `_canonical_launcher(target)`: maps an invocation target to a managed launcher name (`claude`/`pi`/`codex`) whether it's spelled as a bare name or an explicit path.
- `main()` resolves the target before dispatch, so path-form invocations of any managed launcher route to the dedicated launcher (no `PYTHONPATH` injection). Unknown targets still fall through to `cmd_exec` unchanged.

Matching is **resolve-and-compare** (`realpath(target) == realpath(which(launcher))`), not basename. The launchers install as versioned binaries fronted by a symlink (e.g. Claude Code is `~/.local/share/claude/versions/<ver>` behind a `claude` symlink), so a basename check would see `<ver>`, not `claude`. Comparing resolved paths handles this and matches the ticket's acceptance criteria ("any path resolving to the same binary").

## Tests

6 new tests in `tests/test_lapdog_cli.py` covering bare name, path-via-symlink resolution, unknown targets, a launcher-named file that does *not* resolve to the managed binary, and `main()` routing (both the reroute and the unchanged `cmd_exec` fall-through). Full `test_lapdog_cli.py` suite passes (54 tests).

Claude session: `f2ab1d44-6581-4b2c-95e5-f546fab5abfa`
Resume: `claude --resume f2ab1d44-6581-4b2c-95e5-f546fab5abfa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MLOB-7870]: https://datadoghq.atlassian.net/browse/MLOB-7870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ