### PR TITLE
fix(trace): project v1 boolean span attributes as meta strings

### DIFF
--- a/ddapm_test_agent/trace.py
+++ b/ddapm_test_agent/trace.py
@@ -1144,8 +1144,8 @@ def _convert_v1_attributes(
         if value_type == V1AnyValueKeys.STRING:
             meta[key] = _get_and_add_string(string_table, value)
         elif value_type == V1AnyValueKeys.BOOL:
-            # Treat v1 boolean attributes as metrics with a value of 1 or 0
-            metrics[key] = 1 if value else 0
+            # Project typed v1 booleans into the legacy string meta representation.
+            meta[key] = "true" if value else "false"
         elif value_type == V1AnyValueKeys.DOUBLE:
             metrics[key] = value
         elif value_type == V1AnyValueKeys.INT:

--- a/releasenotes/notes/v1-boolean-span-attributes-9c3f6a1b2d4e7f80.yaml
+++ b/releasenotes/notes/v1-boolean-span-attributes-9c3f6a1b2d4e7f80.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Preserve boolean span attributes from ``v1`` trace payloads as ``"true"`` or ``"false"``
+    strings in the legacy ``meta`` projection instead of converting them to numeric metrics.

--- a/tests/test_trace_v1_attributes.py
+++ b/tests/test_trace_v1_attributes.py
@@ -1,0 +1,33 @@
+import msgpack
+
+from ddapm_test_agent.trace import V1AnyValueKeys
+from ddapm_test_agent.trace import V1ChunkKeys
+from ddapm_test_agent.trace import V1SpanKeys
+from ddapm_test_agent.trace import decode_v1
+
+
+def test_v1_boolean_span_attributes_are_projected_as_meta_strings():
+    span = {
+        V1SpanKeys.SPAN_ID: 1234,
+        V1SpanKeys.ATTRIBUTES: [
+            "true_attr",
+            V1AnyValueKeys.BOOL,
+            True,
+            "false_attr",
+            V1AnyValueKeys.BOOL,
+            False,
+            "int_attr",
+            V1AnyValueKeys.INT,
+            7,
+            "double_attr",
+            V1AnyValueKeys.DOUBLE,
+            1.5,
+        ],
+    }
+    chunk = {V1ChunkKeys.SPANS: [span]}
+
+    result = decode_v1(msgpack.packb({11: [chunk]}))
+    decoded_span = result[0][0]
+
+    assert decoded_span["meta"] == {"true_attr": "true", "false_attr": "false"}
+    assert decoded_span["metrics"] == {"int_attr": 7, "double_attr": 1.5}


### PR DESCRIPTION
# What Does This Do

Projects typed `v1` boolean span attributes into the legacy `meta` map as the strings `"true"`/`"false"` instead of converting them to numeric `metrics` (`1`/`0`).

# Motivation

Datadog's convention stores boolean tags in `meta` as `"true"`/`"false"` strings. The previous `metrics[key] = 1/0` behavior made booleans indistinguishable from real numeric metrics, breaking snapshot comparisons and tag-based filtering in system tests.

# Additional Notes

- Only affects the span-level `_convert_v1_attributes` projection; the span *event* attribute path (typed `bool_value`) is unchanged.
- Adds `tests/test_trace_v1_attributes.py` as a regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)