### PR TITLE
Allow Claude to add custom tags to its own Lapdog spans

### DIFF
--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -308,7 +308,7 @@ class ClaudeHooksAPI:
     def __init__(self, link_tracker: Optional[ClaudeLinkTracker] = None) -> None:
         self._sessions: Dict[str, SessionState] = {}
         self._session_ids_by_token: Dict[str, Set[str]] = {}
-        self._tags_by_token: Dict[str, Dict[str, str]] = {}
+        self._pending_tags_by_token: Dict[str, Dict[str, str]] = {}
         self._assembled_spans: List[Dict[str, Any]] = []
         self._raw_events: List[Dict[str, Any]] = []
         self._link_tracker = link_tracker
@@ -341,7 +341,7 @@ class ClaudeHooksAPI:
 
     def _register_session_token(self, session_token: str, session_id: str) -> None:
         self._session_ids_by_token.setdefault(session_token, set()).add(session_id)
-        pending_tags = self._tags_by_token.get(session_token)
+        pending_tags = self._pending_tags_by_token.pop(session_token, None)
         if pending_tags:
             self._set_session_tags(self._get_or_create_session(session_id), pending_tags)
 
@@ -1902,19 +1902,42 @@ class ClaudeHooksAPI:
                 return web.json_response({"error": "tag keys and values must be non-empty strings"}, status=400)
             normalized[key.strip()] = value.strip()
 
-        token_tags = self._tags_by_token.setdefault(session_token, {})
-        token_tags.update(normalized)
-        session_ids = sorted(self._session_ids_by_token.get(session_token, set()))
-        for session_id in session_ids:
-            session = self._sessions.get(session_id)
-            if session is not None:
+        requested_session_id = body.get("session_id")
+        if requested_session_id is not None and (
+            not isinstance(requested_session_id, str) or not requested_session_id.strip()
+        ):
+            return web.json_response({"error": "session_id must be a non-empty string"}, status=400)
+
+        if isinstance(requested_session_id, str):
+            session_id = requested_session_id.strip()
+            session = self._get_or_create_session(session_id)
+            self._set_session_tags(session, normalized)
+            session_ids = [session_id]
+            applied_tags = dict(session.custom_tags)
+        else:
+            session_ids = sorted(self._session_ids_by_token.get(session_token, set()))
+            if len(session_ids) > 1:
+                return web.json_response(
+                    {
+                        "error": "launch token matches multiple sessions; provide session_id",
+                        "session_ids": session_ids,
+                    },
+                    status=409,
+                )
+            if session_ids:
+                session = self._get_or_create_session(session_ids[0])
                 self._set_session_tags(session, normalized)
+                applied_tags = dict(session.custom_tags)
+            else:
+                pending_tags = self._pending_tags_by_token.setdefault(session_token, {})
+                pending_tags.update(normalized)
+                applied_tags = dict(pending_tags)
         return web.json_response(
             {
                 "status": "ok",
                 "session_id": session_ids[-1] if session_ids else "",
                 "session_ids": session_ids,
-                "tags": token_tags,
+                "tags": applied_tags,
             }
         )
 

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -345,14 +345,21 @@ class ClaudeHooksAPI:
         if pending_tags:
             self._set_session_tags(self._get_or_create_session(session_id), pending_tags)
 
-    def _append_span(self, span: Dict[str, Any]) -> None:
-        """Store a span, applying tags configured for its Claude session."""
+    def _apply_registered_session_tags(self, span: Dict[str, Any]) -> None:
         session_id = span.get("session_id")
-        if isinstance(session_id, str):
-            session = self._sessions.get(session_id)
-            if session is not None:
+        if not isinstance(session_id, str):
+            return
+        for raw_session_id, session in self._sessions.items():
+            if raw_session_id == session_id or session.session_id == session_id:
                 self._apply_session_tags(span, session)
-        self._assembled_spans.append(span)
+
+    def _append_span(self, span: Dict[str, Any], index: Optional[int] = None) -> None:
+        """Store a span, applying tags configured for its coding-agent session."""
+        self._apply_registered_session_tags(span)
+        if index is None:
+            self._assembled_spans.append(span)
+        else:
+            self._assembled_spans.insert(index, span)
 
     def _get_or_create_session(self, session_id: str) -> SessionState:
         """Get existing session or create a new one."""
@@ -1874,7 +1881,7 @@ class ClaudeHooksAPI:
         return web.json_response({"spans": self._assembled_spans})
 
     async def handle_session_tags(self, request: Request) -> web.Response:
-        """Add tags to the Claude session identified by its Lapdog launch token."""
+        """Add tags to coding-agent sessions identified by a Lapdog launch token."""
         session_token = request.headers.get("X-Lapdog-Session-Token", "")
         if not session_token:
             return web.json_response({"error": "missing Lapdog session token"}, status=404)
@@ -1965,6 +1972,7 @@ class ClaudeHooksAPI:
         """Return the routes for this API."""
         return [
             web.post("/claude/hooks", with_cors(self.handle_hook)),
+            web.post("/lapdog/session/tags", with_cors(self.handle_session_tags)),
             web.post("/claude/hooks/session/tags", with_cors(self.handle_session_tags)),
             web.post("/claude/hooks/backfill_session", with_cors(self.handle_backfill_session)),
             web.route("*", "/claude/hooks/sessions", with_cors(self.handle_sessions)),

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -49,6 +49,27 @@ _HOSTNAME = socket.gethostname()
 _USERNAME = os.environ.get("HOST_USER") or getpass.getuser()
 _USER_HANDLE = os.environ.get("DD_USER_HANDLE", "")
 _ML_APP = CLAUDE_CODE_ML_APP
+_RESERVED_SESSION_TAG_KEYS = frozenset(
+    {
+        "env",
+        "git.commit.sha",
+        "git.repository_url",
+        "hostname",
+        "language",
+        "lapdog_forwarded",
+        "ml_app",
+        "project_name",
+        "service",
+        "session_id",
+        "source",
+        "subagent",
+        "tool_name",
+        "topic",
+        "trajectory.semantic_type",
+        "user_handle",
+        "user_name",
+    }
+)
 
 # Models with 1M token context windows (native, no beta header needed).
 # All other models default to 200k.
@@ -147,6 +168,7 @@ class SessionState:
         self.conversation_title: str = ""
         self.cwd: str = ""
         self.custom_tags: Dict[str, str] = {}
+        self.custom_tag_sequences: Dict[str, int] = {}
         self.project_metadata = resolve_project_metadata()
         # Persists across turns so each turn's context_delta reflects growth from
         # the previous turn's final context size.
@@ -308,7 +330,9 @@ class ClaudeHooksAPI:
     def __init__(self, link_tracker: Optional[ClaudeLinkTracker] = None) -> None:
         self._sessions: Dict[str, SessionState] = {}
         self._session_ids_by_token: Dict[str, Set[str]] = {}
+        self._session_tokens_by_id: Dict[str, Set[str]] = {}
         self._pending_tags_by_token: Dict[str, Dict[str, str]] = {}
+        self._tag_update_sequence = 0
         self._assembled_spans: List[Dict[str, Any]] = []
         self._raw_events: List[Dict[str, Any]] = []
         self._link_tracker = link_tracker
@@ -334,13 +358,54 @@ class ClaudeHooksAPI:
         span["tags"] = span_tags
 
     def _set_session_tags(self, session: SessionState, tags: Dict[str, str]) -> None:
-        session.custom_tags.update(tags)
+        self._tag_update_sequence += 1
+        for candidate in self._sessions.values():
+            if candidate.session_id == session.session_id:
+                candidate.custom_tags.update(tags)
+                candidate.custom_tag_sequences.update({key: self._tag_update_sequence for key in tags})
         for span in self._assembled_spans:
             if span.get("session_id") == session.session_id:
                 self._apply_session_tags(span, session)
 
+    def _synchronize_session_tags(self, session_id: str) -> None:
+        """Reconcile custom tags after Codex groups raw sessions together.
+
+        Codex may initially report a parent thread and its child threads as
+        independent sessions. Once their relationship is discovered,
+        ``CodexHooksAPI._set_session_group`` changes those raw SessionState
+        objects to share one visible session ID and calls this method.
+
+        Before grouping, each raw session can receive its own tag updates. We
+        therefore merge tags one key at a time, using ``custom_tag_sequences``
+        to preserve the most recently set value when sessions disagree. The
+        merged result is copied to every grouped SessionState so future spans
+        cannot reintroduce a stale value, then applied to spans already held in
+        memory under the visible session ID.
+
+        Claude and Pi sessions do not use this reconciliation path because
+        they do not perform Codex-style session grouping.
+        """
+        grouped_sessions = [session for session in self._sessions.values() if session.session_id == session_id]
+        merged_tags: Dict[str, str] = {}
+        merged_sequences: Dict[str, int] = {}
+        for session in grouped_sessions:
+            for key, value in session.custom_tags.items():
+                sequence = session.custom_tag_sequences.get(key, 0)
+                if key not in merged_sequences or sequence >= merged_sequences[key]:
+                    merged_tags[key] = value
+                    merged_sequences[key] = sequence
+        if not merged_tags:
+            return
+        for session in grouped_sessions:
+            session.custom_tags.update(merged_tags)
+            session.custom_tag_sequences.update(merged_sequences)
+        for span in self._assembled_spans:
+            if span.get("session_id") == session_id:
+                self._apply_session_tags(span, grouped_sessions[0])
+
     def _register_session_token(self, session_token: str, session_id: str) -> None:
         self._session_ids_by_token.setdefault(session_token, set()).add(session_id)
+        self._session_tokens_by_id.setdefault(session_id, set()).add(session_token)
         pending_tags = self._pending_tags_by_token.pop(session_token, None)
         if pending_tags:
             self._set_session_tags(self._get_or_create_session(session_id), pending_tags)
@@ -1901,6 +1966,12 @@ class ClaudeHooksAPI:
             if not isinstance(key, str) or not key.strip() or not isinstance(value, str) or not value.strip():
                 return web.json_response({"error": "tag keys and values must be non-empty strings"}, status=400)
             normalized[key.strip()] = value.strip()
+        reserved_keys = sorted(set(normalized).intersection(_RESERVED_SESSION_TAG_KEYS))
+        if reserved_keys:
+            return web.json_response(
+                {"error": f"reserved tag keys cannot be changed: {', '.join(reserved_keys)}"},
+                status=400,
+            )
 
         requested_session_id = body.get("session_id")
         if requested_session_id is not None and (
@@ -1910,6 +1981,14 @@ class ClaudeHooksAPI:
 
         if isinstance(requested_session_id, str):
             session_id = requested_session_id.strip()
+            registered_tokens = self._session_tokens_by_id.get(session_id, set())
+            if registered_tokens and session_token not in registered_tokens:
+                return web.json_response(
+                    {"error": "session_id is associated with a different Lapdog launch token"},
+                    status=409,
+                )
+            if not registered_tokens:
+                self._register_session_token(session_token, session_id)
             session = self._get_or_create_session(session_id)
             self._set_session_tags(session, normalized)
             session_ids = [session_id]

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -103,14 +103,7 @@ def _to_json_str(value: Any) -> str:
 class PendingToolSpan:
     """Tracks a tool invocation between PreToolUse and PostToolUse."""
 
-    def __init__(
-        self,
-        span_id: str,
-        tool_name: str,
-        tool_input: Any,
-        parent_id: str,
-        start_ns: int,
-    ) -> None:
+    def __init__(self, span_id: str, tool_name: str, tool_input: Any, parent_id: str, start_ns: int) -> None:
         self.span_id = span_id
         self.tool_name = tool_name
         self.tool_input = tool_input
@@ -148,9 +141,7 @@ class ActiveStep:
 class SessionState:
     """Tracks the state of a single Claude Code session."""
 
-    def __init__(
-        self, session_id: str, trace_id: str, root_span_id: str, start_ns: int
-    ) -> None:
+    def __init__(self, session_id: str, trace_id: str, root_span_id: str, start_ns: int) -> None:
         self.session_id = session_id
         self.trace_id = trace_id
         self.root_span_id = root_span_id
@@ -362,9 +353,7 @@ class ClaudeHooksAPI:
         span_tags = [
             tag
             for tag in span_tags
-            if not isinstance(tag, str)
-            or ":" not in tag
-            or tag.split(":", 1)[0] not in custom_keys
+            if not isinstance(tag, str) or ":" not in tag or tag.split(":", 1)[0] not in custom_keys
         ]
         span_tags.extend(f"{key}:{value}" for key, value in session.custom_tags.items())
         span["tags"] = span_tags
@@ -374,9 +363,7 @@ class ClaudeHooksAPI:
         for candidate in self._sessions.values():
             if candidate.session_id == session.session_id:
                 candidate.custom_tags.update(tags)
-                candidate.custom_tag_sequences.update(
-                    {key: self._tag_update_sequence for key in tags}
-                )
+                candidate.custom_tag_sequences.update({key: self._tag_update_sequence for key in tags})
         for span in self._assembled_spans:
             if span.get("session_id") == session.session_id:
                 self._apply_session_tags(span, session)
@@ -399,11 +386,7 @@ class ClaudeHooksAPI:
         Claude and Pi sessions do not use this reconciliation path because
         they do not perform Codex-style session grouping.
         """
-        grouped_sessions = [
-            session
-            for session in self._sessions.values()
-            if session.session_id == session_id
-        ]
+        grouped_sessions = [session for session in self._sessions.values() if session.session_id == session_id]
         merged_tags: Dict[str, str] = {}
         merged_sequences: Dict[str, int] = {}
         for session in grouped_sessions:
@@ -426,9 +409,7 @@ class ClaudeHooksAPI:
         self._session_tokens_by_id.setdefault(session_id, set()).add(session_token)
         pending_tags = self._pending_tags_by_token.pop(session_token, None)
         if pending_tags:
-            self._set_session_tags(
-                self._get_or_create_session(session_id), pending_tags
-            )
+            self._set_session_tags(self._get_or_create_session(session_id), pending_tags)
 
     def _apply_registered_session_tags(self, span: Dict[str, Any]) -> None:
         session_id = span.get("session_id")
@@ -502,9 +483,7 @@ class ClaudeHooksAPI:
         """Merge key-value pairs into span['meta']['metadata']['_dd'], preserving existing values."""
         span["meta"].setdefault("metadata", {}).setdefault("_dd", {}).update(kwargs)
 
-    def update_session_project_metadata(
-        self, session: SessionState, body: Dict[str, Any]
-    ) -> None:
+    def update_session_project_metadata(self, session: SessionState, body: Dict[str, Any]) -> None:
         previous_cwd = session.cwd
         cwd = body.get("cwd")
         if isinstance(cwd, str) and cwd.strip():
@@ -516,8 +495,7 @@ class ClaudeHooksAPI:
         if session.cwd or project_name or git_repository_url:
             session.project_metadata = resolve_project_metadata(
                 cwd=session.cwd,
-                project_name=project_name
-                or ("" if cwd_changed else session.project_metadata.project_name),
+                project_name=project_name or ("" if cwd_changed else session.project_metadata.project_name),
                 git_repository_url=git_repository_url
                 or ("" if cwd_changed else session.project_metadata.git_repository_url),
             )
@@ -548,9 +526,7 @@ class ClaudeHooksAPI:
         tags.extend(git_commit_sha_tags(session.cwd))
         return tags
 
-    def _set_permission_wait_critical_evaluation(
-        self, span: Dict[str, Any], estimated_permission_wait_ms: int
-    ) -> None:
+    def _set_permission_wait_critical_evaluation(self, span: Dict[str, Any], estimated_permission_wait_ms: int) -> None:
         """Embed a permission_wait_critical boolean evaluation on a span.
         The evaluation flags whether the permission wait was > 50% of span duration.
         """
@@ -565,17 +541,12 @@ class ClaudeHooksAPI:
             "assessment": assessment,
             "status": "OK",
             "reasoning": (
-                f"Permission wait {'exceeded' if is_critical else 'did not exceed'} "
-                f"50% of span duration"
+                f"Permission wait {'exceeded' if is_critical else 'did not exceed'} " f"50% of span duration"
             ),
         }
         # Also populate legacy fields so the frontend can read them
-        span.setdefault("evaluations", {}).setdefault("custom", {})[
-            "permission_wait_critical"
-        ] = is_critical
-        span.setdefault("evaluation_assessments", {}).setdefault("custom", {})[
-            "permission_wait_critical"
-        ] = assessment
+        span.setdefault("evaluations", {}).setdefault("custom", {})["permission_wait_critical"] = is_critical
+        span.setdefault("evaluation_assessments", {}).setdefault("custom", {})["permission_wait_critical"] = assessment
 
     def _start_step_for_llm(
         self,
@@ -604,9 +575,7 @@ class ClaudeHooksAPI:
         before the proxy finishes creating the LLM span and the children
         got cached with the agent as parent instead of this step.
         """
-        agent_parent_id = session.step_agent_by_span_id.get(
-            agent_parent_id, agent_parent_id
-        )
+        agent_parent_id = session.step_agent_by_span_id.get(agent_parent_id, agent_parent_id)
 
         prior = session.active_steps_by_agent.get(agent_parent_id)
         if prior is not None:
@@ -628,8 +597,7 @@ class ClaudeHooksAPI:
             "service": _ML_APP,
             "env": "local",
             "session_id": session.session_id,
-            "tags": self.base_tags(session)
-            + ["trajectory.semantic_type:agent_message"],
+            "tags": self.base_tags(session) + ["trajectory.semantic_type:agent_message"],
             "meta": {
                 "span": {"kind": "step"},
                 "input": {},
@@ -706,23 +674,14 @@ class ClaudeHooksAPI:
             if deferred is not None and deferred.get("parent_id") == agent_parent_id:
                 deferred["parent_id"] = step_span_id
                 span_ref = deferred.get("_span_ref")
-                if (
-                    span_ref is not None
-                    and span_ref.get("parent_id") == agent_parent_id
-                ):
+                if span_ref is not None and span_ref.get("parent_id") == agent_parent_id:
                     span_ref["parent_id"] = step_span_id
 
         for entry in session.agent_span_stack:
-            if (
-                entry.get("task_tool_use_id") in tool_use_set
-                and entry.get("parent_id") == agent_parent_id
-            ):
+            if entry.get("task_tool_use_id") in tool_use_set and entry.get("parent_id") == agent_parent_id:
                 entry["parent_id"] = step_span_id
                 span_ref = entry.get("_span_ref")
-                if (
-                    span_ref is not None
-                    and span_ref.get("parent_id") == agent_parent_id
-                ):
+                if span_ref is not None and span_ref.get("parent_id") == agent_parent_id:
                     span_ref["parent_id"] = step_span_id
 
     def _finalize_step(
@@ -763,13 +722,7 @@ class ClaudeHooksAPI:
         """Finalize the open step (if any) for the given agent frame."""
         active = session.active_steps_by_agent.get(agent_span_id)
         if active is not None:
-            self._finalize_step(
-                session,
-                active,
-                end_ns=end_ns,
-                status=status,
-                error_message=error_message,
-            )
+            self._finalize_step(session, active, end_ns=end_ns, status=status, error_message=error_message)
 
     def _update_step_from_llm_response(
         self,
@@ -834,21 +787,13 @@ class ClaudeHooksAPI:
         # Discard any pending permission wait — the turn was interrupted so we don't
         # want it bleeding into the next turn's accumulated total.
         session.pending_permission_at_ns = None
-        root_span_ref: Optional[Dict[str, Any]] = getattr(
-            session, "_root_span_ref", None
-        )
+        root_span_ref: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
         if root_span_ref is not None and root_span_ref["duration"] == -1:
             root_span_ref["duration"] = 0
 
         # Finalize any in-progress step spans before tearing down their agents.
         for active in list(session.active_steps_by_agent.values()):
-            self._finalize_step(
-                session,
-                active,
-                end_ns=now_ns,
-                status="error",
-                error_message="interrupted",
-            )
+            self._finalize_step(session, active, end_ns=now_ns, status="error", error_message="interrupted")
         session.active_steps_by_agent.clear()
         session.step_index_by_agent.clear()
         session.step_agent_by_span_id.clear()
@@ -872,11 +817,7 @@ class ClaudeHooksAPI:
         root_span: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
         if not root_span:
             root_span = next(
-                (
-                    s
-                    for s in self._assembled_spans
-                    if s.get("span_id") == session.root_span_id
-                ),
+                (s for s in self._assembled_spans if s.get("span_id") == session.root_span_id),
                 None,
             )
 
@@ -896,11 +837,7 @@ class ClaudeHooksAPI:
             # rollup + each LLM span's own value).
 
         session.root_span_emitted = True
-        log.info(
-            "Finalized interrupted turn for session %s (trace %s)",
-            session.session_id,
-            session.trace_id,
-        )
+        log.info("Finalized interrupted turn for session %s (trace %s)", session.session_id, session.trace_id)
 
     def _handle_user_prompt_submit(self, session_id: str, body: Dict[str, Any]) -> None:
         """Handle UserPromptSubmit hook event — starts a new trace for each user turn.
@@ -912,10 +849,7 @@ class ClaudeHooksAPI:
 
         # If the previous turn was never finalized (Stop never fired, e.g. Ctrl+C),
         # finalize it as interrupted before starting the new turn.
-        if (
-            not session.root_span_emitted
-            and getattr(session, "_root_span_ref", None) is not None
-        ):
+        if not session.root_span_emitted and getattr(session, "_root_span_ref", None) is not None:
             self._finalize_interrupted_turn(session)
 
         # If the previous turn's root span was emitted, start a fresh trace
@@ -957,11 +891,7 @@ class ClaudeHooksAPI:
             "env": "local",
             "session_id": session.session_id,
             "tags": self.base_tags(session)
-            + (
-                [f"topic:{session.conversation_title}"]
-                if session.conversation_title
-                else []
-            ),
+            + ([f"topic:{session.conversation_title}"] if session.conversation_title else []),
             "meta": {
                 "span": {"kind": "agent"},
                 "input": {"value": prompt},
@@ -1023,14 +953,10 @@ class ClaudeHooksAPI:
             start_ns = pending.start_ns
             input_value = _to_json_str(pending.tool_input) if pending.tool_input else ""
             actual_tool_name = pending.tool_name
-            tool_input_dict = (
-                pending.tool_input if isinstance(pending.tool_input, dict) else {}
-            )
+            tool_input_dict = pending.tool_input if isinstance(pending.tool_input, dict) else {}
         else:
             span_id = _format_span_id()
-            parent_id = self._resolve_tool_parent(
-                tool_use_id, self._current_parent_id(session)
-            )
+            parent_id = self._resolve_tool_parent(tool_use_id, self._current_parent_id(session))
             start_ns = now_ns
             input_value = ""
             actual_tool_name = tool_name
@@ -1042,13 +968,9 @@ class ClaudeHooksAPI:
 
         estimated_permission_wait_ms: Optional[int] = None
         if session.pending_permission_at_ns is not None:
-            estimated_permission_wait_ms = (
-                now_ns - session.pending_permission_at_ns
-            ) // 1_000_000
+            estimated_permission_wait_ms = (now_ns - session.pending_permission_at_ns) // 1_000_000
             session.pending_permission_at_ns = None
-            root_span_ref: Optional[Dict[str, Any]] = getattr(
-                session, "_root_span_ref", None
-            )
+            root_span_ref: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
             if root_span_ref is not None and root_span_ref["duration"] == -1:
                 root_span_ref["duration"] = 0
 
@@ -1148,9 +1070,7 @@ class ClaudeHooksAPI:
             "span_links": span_links,
         }
         if estimated_permission_wait_ms is not None:
-            self._set_hidden_metadata(
-                span, estimated_permission_wait_ms=estimated_permission_wait_ms
-            )
+            self._set_hidden_metadata(span, estimated_permission_wait_ms=estimated_permission_wait_ms)
         self._append_span(span)
 
     def _handle_subagent_start(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -1188,9 +1108,7 @@ class ClaudeHooksAPI:
         # from when they were dispatched, not the stack top which may have changed.
         # Re-resolve via the link tracker in case PreToolUse raced ahead of the
         # LLM span's creation and cached a stale agent parent rather than the step.
-        fallback_parent = (
-            task_pending.parent_id if task_pending else self._current_parent_id(session)
-        )
+        fallback_parent = task_pending.parent_id if task_pending else self._current_parent_id(session)
         if task_tool_use_id:
             parent_id = self._resolve_tool_parent(task_tool_use_id, fallback_parent)
         else:
@@ -1255,9 +1173,7 @@ class ClaudeHooksAPI:
         now_ns = monotonic_wall_ns()
 
         if not session.agent_span_stack:
-            log.warning(
-                "SubagentStop with empty agent stack for session %s", session_id
-            )
+            log.warning("SubagentStop with empty agent stack for session %s", session_id)
             return
 
         # Finalize this subagent's active step (if any) before popping the frame.
@@ -1279,16 +1195,11 @@ class ClaudeHooksAPI:
             first_input_tokens=0,
         )
 
-        estimated_perm_wait = self._sum_estimated_permission_wait_ms(
-            parent_id=str(agent_info["span_id"])
-        )
+        estimated_perm_wait = self._sum_estimated_permission_wait_ms(parent_id=str(agent_info["span_id"]))
         # If SubagentStart fired before PreToolUse(Task), retry the match now.
         if not task_tool_use_id:
             for tid, pending in session.pending_tools.items():
-                if (
-                    pending.tool_name == "Task"
-                    and tid not in session.claimed_task_tools
-                ):
+                if pending.tool_name == "Task" and tid not in session.claimed_task_tools:
                     task_tool_use_id = tid
                     task_tool_input = pending.tool_input
                     session.claimed_task_tools.add(tid)
@@ -1303,9 +1214,7 @@ class ClaudeHooksAPI:
             if span_ref:
                 span_ref["duration"] = duration
                 if estimated_perm_wait > 0:
-                    self._set_hidden_metadata(
-                        span_ref, estimated_permission_wait_ms=estimated_perm_wait
-                    )
+                    self._set_hidden_metadata(span_ref, estimated_permission_wait_ms=estimated_perm_wait)
             session.deferred_agent_spans[task_tool_use_id] = {
                 "span_id": agent_info["span_id"],
                 "trace_id": session.trace_id,
@@ -1376,10 +1285,7 @@ class ClaudeHooksAPI:
             "output_tokens": total_output,
             "cache_read_input_tokens": total_cache_read,
             "cache_write_input_tokens": total_cache_write,
-            "total_tokens": total_input
-            + total_output
-            + total_cache_read
-            + total_cache_write,
+            "total_tokens": total_input + total_output + total_cache_read + total_cache_write,
         }
 
     def _aggregate_tool_usage(self, trace_id: str) -> Dict[str, Dict[str, int]]:
@@ -1398,21 +1304,11 @@ class ClaudeHooksAPI:
             tool_name = raw_name.split(" - ")[0]
             entry = result.setdefault(
                 tool_name,
-                {
-                    "call_count": 0,
-                    "total_duration_ns": 0,
-                    "permission_wait_count": 0,
-                    "permission_wait_ms": 0,
-                },
+                {"call_count": 0, "total_duration_ns": 0, "permission_wait_count": 0, "permission_wait_ms": 0},
             )
             entry["call_count"] += 1
             entry["total_duration_ns"] += span.get("duration", 0)
-            perm_wait = (
-                span.get("meta", {})
-                .get("metadata", {})
-                .get("_dd", {})
-                .get("estimated_permission_wait_ms", 0)
-            )
+            perm_wait = span.get("meta", {}).get("metadata", {}).get("_dd", {}).get("estimated_permission_wait_ms", 0)
             if perm_wait:
                 entry["permission_wait_count"] += 1
                 entry["permission_wait_ms"] += perm_wait
@@ -1450,11 +1346,7 @@ class ClaudeHooksAPI:
             key=lambda s: s.get("start_ns", 0),
         )
         last_span = next(
-            (
-                s
-                for s in reversed(llm_spans)
-                if s.get("metrics", {}).get("input_tokens", 0) > 0
-            ),
+            (s for s in reversed(llm_spans) if s.get("metrics", {}).get("input_tokens", 0) > 0),
             None,
         )
         if last_span is None:
@@ -1469,30 +1361,18 @@ class ClaudeHooksAPI:
             None,
         )
         first_breakdown = (
-            first_span.get("meta", {})
-            .get("metadata", {})
-            .get("_dd", {})
-            .get("context_breakdown")
+            first_span.get("meta", {}).get("metadata", {}).get("_dd", {}).get("context_breakdown")
             if first_span
             else None
         )
-        last_breakdown = (
-            last_span.get("meta", {})
-            .get("metadata", {})
-            .get("_dd", {})
-            .get("context_breakdown")
-        )
+        last_breakdown = last_span.get("meta", {}).get("metadata", {}).get("_dd", {}).get("context_breakdown")
         context_delta: Dict[str, Any] = {
             "first_input_tokens": first_input_tokens,
             "last_input_tokens": last_input_tokens,
             "delta_tokens": delta_tokens,
             "context_window_size": window,
-            "first_usage_pct": round(first_input_tokens / window * 100, 1)
-            if window
-            else 0.0,
-            "last_usage_pct": round(last_input_tokens / window * 100, 1)
-            if window
-            else 0.0,
+            "first_usage_pct": round(first_input_tokens / window * 100, 1) if window else 0.0,
+            "last_usage_pct": round(last_input_tokens / window * 100, 1) if window else 0.0,
         }
         if first_breakdown:
             context_delta["first_sections"] = first_breakdown.get("sections", [])
@@ -1537,11 +1417,7 @@ class ClaudeHooksAPI:
         if not root_span:
             # Fallback: search _assembled_spans
             root_span = next(
-                (
-                    s
-                    for s in self._assembled_spans
-                    if s.get("span_id") == session.root_span_id
-                ),
+                (s for s in self._assembled_spans if s.get("span_id") == session.root_span_id),
                 None,
             )
         tool_usage = self._aggregate_tool_usage(session.trace_id)
@@ -1553,18 +1429,14 @@ class ClaudeHooksAPI:
 
         root_span_name = "claude-code-request"
 
-        estimated_permission_wait_ms = self._sum_estimated_permission_wait_ms(
-            trace_id=session.trace_id
-        )
+        estimated_permission_wait_ms = self._sum_estimated_permission_wait_ms(trace_id=session.trace_id)
 
         if root_span:
             root_span["name"] = root_span_name
             if session.conversation_title:
                 topic_tag = f"topic:{session.conversation_title}"
                 # Replace existing topic tag (set from preliminary span) or append
-                root_span["tags"] = [
-                    t for t in root_span["tags"] if not t.startswith("topic:")
-                ] + [topic_tag]
+                root_span["tags"] = [t for t in root_span["tags"] if not t.startswith("topic:")] + [topic_tag]
             root_span["duration"] = duration
             root_span["meta"]["input"]["value"] = input_value
             root_span["meta"]["output"]["value"] = output_value
@@ -1583,9 +1455,7 @@ class ClaudeHooksAPI:
                 dd_fields["context_delta"] = context_delta
             if estimated_permission_wait_ms > 0:
                 dd_fields["estimated_permission_wait_ms"] = estimated_permission_wait_ms
-                self._set_permission_wait_critical_evaluation(
-                    root_span, estimated_permission_wait_ms
-                )
+                self._set_permission_wait_critical_evaluation(root_span, estimated_permission_wait_ms)
             if tool_usage:
                 dd_fields["tool_usage"] = tool_usage
             self._set_hidden_metadata(root_span, **dd_fields)
@@ -1607,11 +1477,7 @@ class ClaudeHooksAPI:
                 "session_id": session.session_id,
                 "tags": self.base_tags(session)
                 + [f"user_name:{_USERNAME}"]
-                + (
-                    [f"topic:{session.conversation_title}"]
-                    if session.conversation_title
-                    else []
-                ),
+                + ([f"topic:{session.conversation_title}"] if session.conversation_title else []),
                 "meta": {
                     "span": {"kind": "agent"},
                     "input": {"value": input_value},
@@ -1630,9 +1496,7 @@ class ClaudeHooksAPI:
                 dd_fields["context_delta"] = context_delta
             if estimated_permission_wait_ms > 0:
                 dd_fields["estimated_permission_wait_ms"] = estimated_permission_wait_ms
-                self._set_permission_wait_critical_evaluation(
-                    root_span, estimated_permission_wait_ms
-                )
+                self._set_permission_wait_critical_evaluation(root_span, estimated_permission_wait_ms)
             if tool_usage:
                 dd_fields["tool_usage"] = tool_usage
             apply_project_metadata_to_span(root_span, session.project_metadata)
@@ -1656,15 +1520,9 @@ class ClaudeHooksAPI:
 
     def _handle_notification(self, session_id: str, body: Dict[str, Any]) -> None:
         """Handle Notification hook event — logged but no span emitted."""
-        log.info(
-            "Claude notification for session %s: %s",
-            session_id,
-            body.get("message", ""),
-        )
+        log.info("Claude notification for session %s: %s", session_id, body.get("message", ""))
 
-    def _handle_post_tool_use_failure(
-        self, session_id: str, body: Dict[str, Any]
-    ) -> None:
+    def _handle_post_tool_use_failure(self, session_id: str, body: Dict[str, Any]) -> None:
         """Handle PostToolUseFailure hook event — emits a tool span with error status.
 
         Fired when a tool execution fails. The body includes an ``error`` string
@@ -1687,14 +1545,10 @@ class ClaudeHooksAPI:
             start_ns = pending.start_ns
             input_value = _to_json_str(pending.tool_input) if pending.tool_input else ""
             actual_tool_name = pending.tool_name
-            tool_input_dict = (
-                pending.tool_input if isinstance(pending.tool_input, dict) else {}
-            )
+            tool_input_dict = pending.tool_input if isinstance(pending.tool_input, dict) else {}
         else:
             span_id = _format_span_id()
-            parent_id = self._resolve_tool_parent(
-                tool_use_id, self._current_parent_id(session)
-            )
+            parent_id = self._resolve_tool_parent(tool_use_id, self._current_parent_id(session))
             start_ns = now_ns
             input_value = ""
             actual_tool_name = tool_name
@@ -1706,13 +1560,9 @@ class ClaudeHooksAPI:
         # Consume any pending permission wait
         estimated_permission_wait_ms: Optional[int] = None
         if session.pending_permission_at_ns is not None:
-            estimated_permission_wait_ms = (
-                now_ns - session.pending_permission_at_ns
-            ) // 1_000_000
+            estimated_permission_wait_ms = (now_ns - session.pending_permission_at_ns) // 1_000_000
             session.pending_permission_at_ns = None
-            root_span_ref: Optional[Dict[str, Any]] = getattr(
-                session, "_root_span_ref", None
-            )
+            root_span_ref: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
             if root_span_ref is not None and root_span_ref["duration"] == -1:
                 root_span_ref["duration"] = 0
 
@@ -1769,9 +1619,7 @@ class ClaudeHooksAPI:
         if is_interrupt:
             span["meta"]["error"]["type"] = "interrupt"
         if estimated_permission_wait_ms is not None:
-            self._set_hidden_metadata(
-                span, estimated_permission_wait_ms=estimated_permission_wait_ms
-            )
+            self._set_hidden_metadata(span, estimated_permission_wait_ms=estimated_permission_wait_ms)
         self._append_span(span)
 
     def _handle_pre_compact(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -1790,11 +1638,7 @@ class ClaudeHooksAPI:
         log.info("span_ref: %s", span_ref)
         if span_ref is None:
             return
-        dd = (
-            span_ref.setdefault("meta", {})
-            .setdefault("metadata", {})
-            .setdefault("_dd", {})
-        )
+        dd = span_ref.setdefault("meta", {}).setdefault("metadata", {}).setdefault("_dd", {})
         dd.setdefault("compactions", []).append(
             {
                 "trigger": trigger,
@@ -1819,12 +1663,7 @@ class ClaudeHooksAPI:
                 continue
             if parent_id is not None and str(s.get("parent_id")) != str(parent_id):
                 continue
-            total += (
-                s.get("meta", {})
-                .get("metadata", {})
-                .get("_dd", {})
-                .get("estimated_permission_wait_ms", 0)
-            )
+            total += s.get("meta", {}).get("metadata", {}).get("_dd", {}).get("estimated_permission_wait_ms", 0)
         return total
 
     def _handle_permission_request(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -1911,32 +1750,19 @@ class ClaudeHooksAPI:
             url = f"https://{agentless_base_url}.{dd_site}{endpoint}"
             headers["DD-API-KEY"] = dd_api_key
         else:
-            log.debug(
-                "No DD_API_KEY/DD_SITE or agent URL configured — skipping forwarding"
-            )
+            log.debug("No DD_API_KEY/DD_SITE or agent URL configured — skipping forwarding")
             return None
 
-        log.info(
-            "Resolved backend target: %s (mode=%s)",
-            url,
-            "agent" if agent_url else "agentless",
-        )
+        log.info("Resolved backend target: %s (mode=%s)", url, "agent" if agent_url else "agentless")
         return url, headers
 
-    async def _post_to_backend(
-        self, url: str, headers: Dict[str, str], data: bytes, description: str
-    ) -> None:
+    async def _post_to_backend(self, url: str, headers: Dict[str, str], data: bytes, description: str) -> None:
         """POST the given data to the url and log the outcome."""
         try:
             async with ClientSession() as http_session:
                 async with http_session.post(url, headers=headers, data=data) as resp:
                     if not resp.ok:
-                        log.warning(
-                            "Failed to %s: %s %s",
-                            description,
-                            resp.status,
-                            await resp.text(),
-                        )
+                        log.warning("Failed to %s: %s %s", description, resp.status, await resp.text())
                     else:
                         log.info("Successfully %s", description)
         except Exception as e:
@@ -1958,15 +1784,10 @@ class ClaudeHooksAPI:
             "spans": spans,
         }
         data = gzip.compress(msgpack.packb(payload))
-        await self._post_to_backend(
-            url, headers, data, f"forward {len(spans)} span updates"
-        )
+        await self._post_to_backend(url, headers, data, f"forward {len(spans)} span updates")
 
     async def _forward_trace_to_backend(
-        self,
-        session_id: str,
-        trace_id: Optional[str] = None,
-        span_source: str = "Claude hooks",
+        self, session_id: str, trace_id: Optional[str] = None, span_source: str = "Claude hooks"
     ) -> None:
         """Forward all assembled spans for a session's trace to the backend via the EVP proxy path."""
         session = self._sessions.get(session_id)
@@ -1987,14 +1808,7 @@ class ClaudeHooksAPI:
         forwarded_spans = []
         for s in spans:
             span = (
-                {
-                    **s,
-                    "metrics": {
-                        k: v
-                        for k, v in s["metrics"].items()
-                        if k not in COST_METRIC_KEYS
-                    },
-                }
+                {**s, "metrics": {k: v for k, v in s["metrics"].items() if k not in COST_METRIC_KEYS}}
                 if s.get("metrics")
                 else dict(s)
             )
@@ -2010,15 +1824,10 @@ class ClaudeHooksAPI:
         }
         data = gzip.compress(msgpack.packb(payload))
         await self._post_to_backend(
-            url,
-            headers,
-            data,
-            f"forward {len(spans)} {span_source} spans for trace {trace_id}",
+            url, headers, data, f"forward {len(spans)} {span_source} spans for trace {trace_id}"
         )
 
-    async def _forward_eval_metrics_to_backend(
-        self, session_id: str, trace_id: Optional[str] = None
-    ) -> None:
+    async def _forward_eval_metrics_to_backend(self, session_id: str, trace_id: Optional[str] = None) -> None:
         """Forward evaluation metrics for all spans in a session's trace to the Datadog backend.
 
         Collects evaluation entries from every span in the trace (not just root),
@@ -2075,14 +1884,9 @@ class ClaudeHooksAPI:
         if not metrics:
             return
 
-        payload = {
-            "data": {"type": "evaluation_metric", "attributes": {"metrics": metrics}}
-        }
+        payload = {"data": {"type": "evaluation_metric", "attributes": {"metrics": metrics}}}
         await self._post_to_backend(
-            url,
-            headers,
-            json.dumps(payload).encode(),
-            f"forward {len(metrics)} eval metric(s) for trace {trace_id}",
+            url, headers, json.dumps(payload).encode(), f"forward {len(metrics)} eval metric(s) for trace {trace_id}"
         )
 
     async def handle_hook(self, request: Request) -> web.Response:
@@ -2092,9 +1896,7 @@ class ClaudeHooksAPI:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         if not isinstance(body, dict):
-            return web.json_response(
-                {"error": "JSON body must be an object"}, status=400
-            )
+            return web.json_response({"error": "JSON body must be an object"}, status=400)
 
         session_id = body.get("session_id", "")
         if not session_id:
@@ -2148,63 +1950,42 @@ class ClaudeHooksAPI:
         """Add tags to coding-agent sessions identified by a Lapdog launch token."""
         session_token = request.headers.get("X-Lapdog-Session-Token", "")
         if not session_token:
-            return web.json_response(
-                {"error": "missing Lapdog session token"}, status=404
-            )
+            return web.json_response({"error": "missing Lapdog session token"}, status=404)
 
         try:
             body = await request.json()
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         if not isinstance(body, dict):
-            return web.json_response(
-                {"error": "JSON body must be an object"}, status=400
-            )
+            return web.json_response({"error": "JSON body must be an object"}, status=400)
         tags = body.get("tags")
         if not isinstance(tags, dict) or not tags:
-            return web.json_response(
-                {"error": "tags must be a non-empty object"}, status=400
-            )
+            return web.json_response({"error": "tags must be a non-empty object"}, status=400)
 
         normalized: Dict[str, str] = {}
         for key, value in tags.items():
-            if (
-                not isinstance(key, str)
-                or not key.strip()
-                or not isinstance(value, str)
-                or not value.strip()
-            ):
-                return web.json_response(
-                    {"error": "tag keys and values must be non-empty strings"},
-                    status=400,
-                )
+            if not isinstance(key, str) or not key.strip() or not isinstance(value, str) or not value.strip():
+                return web.json_response({"error": "tag keys and values must be non-empty strings"}, status=400)
             normalized[key.strip()] = value.strip()
         reserved_keys = sorted(set(normalized).intersection(_RESERVED_SESSION_TAG_KEYS))
         if reserved_keys:
             return web.json_response(
-                {
-                    "error": f"reserved tag keys cannot be changed: {', '.join(reserved_keys)}"
-                },
+                {"error": f"reserved tag keys cannot be changed: {', '.join(reserved_keys)}"},
                 status=400,
             )
 
         requested_session_id = body.get("session_id")
         if requested_session_id is not None and (
-            not isinstance(requested_session_id, str)
-            or not requested_session_id.strip()
+            not isinstance(requested_session_id, str) or not requested_session_id.strip()
         ):
-            return web.json_response(
-                {"error": "session_id must be a non-empty string"}, status=400
-            )
+            return web.json_response({"error": "session_id must be a non-empty string"}, status=400)
 
         if isinstance(requested_session_id, str):
             session_id = requested_session_id.strip()
             registered_tokens = self._session_tokens_by_id.get(session_id, set())
             if registered_tokens and session_token not in registered_tokens:
                 return web.json_response(
-                    {
-                        "error": "session_id is associated with a different Lapdog launch token"
-                    },
+                    {"error": "session_id is associated with a different Lapdog launch token"},
                     status=409,
                 )
             if not registered_tokens:
@@ -2266,9 +2047,7 @@ class ClaudeHooksAPI:
         entries = body.get("entries") or []
         subagents = body.get("subagents") or []
         if not session_id or not isinstance(entries, list):
-            return web.json_response(
-                {"error": "session_id and entries required"}, status=400
-            )
+            return web.json_response({"error": "session_id and entries required"}, status=400)
 
         if has_backfilled_session(self._assembled_spans, session_id):
             return web.json_response(
@@ -2281,22 +2060,16 @@ class ClaudeHooksAPI:
             )
 
         try:
-            spans = claude_backfill.session_to_spans(
-                session_id, cwd, entries, subagents=subagents
-            )
+            spans = claude_backfill.session_to_spans(session_id, cwd, entries, subagents=subagents)
         except Exception as exc:
             # A single malformed transcript shouldn't propagate as a 500 that
             # closes the connection — return a structured failure so the
             # client logs it and moves on.
             log.warning("claude backfill_session failed for %s: %r", session_id, exc)
-            return web.json_response(
-                {"status": "error", "error": repr(exc)}, status=400
-            )
+            return web.json_response({"status": "error", "error": repr(exc)}, status=400)
         self._assembled_spans.extend(spans)
         traces = len({s.get("trace_id") for s in spans})
-        return web.json_response(
-            {"status": "ok", "spans_created": len(spans), "traces_created": traces}
-        )
+        return web.json_response({"status": "ok", "spans_created": len(spans), "traces_created": traces})
 
     def get_routes(self) -> List[web.RouteDef]:
         """Return the routes for this API."""
@@ -2304,10 +2077,7 @@ class ClaudeHooksAPI:
             web.post("/claude/hooks", with_cors(self.handle_hook)),
             web.post("/lapdog/session/tags", with_cors(self.handle_session_tags)),
             web.post("/claude/hooks/session/tags", with_cors(self.handle_session_tags)),
-            web.post(
-                "/claude/hooks/backfill_session",
-                with_cors(self.handle_backfill_session),
-            ),
+            web.post("/claude/hooks/backfill_session", with_cors(self.handle_backfill_session)),
             web.route("*", "/claude/hooks/sessions", with_cors(self.handle_sessions)),
             web.route("*", "/claude/hooks/spans", with_cors(self.handle_spans)),
             web.route("*", "/claude/hooks/raw", with_cors(self.handle_raw_events)),

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -78,24 +78,6 @@ def _to_json_str(value: Any) -> str:
         return str(value)
 
 
-def _dd_tags_from_env() -> List[str]:
-    """Parse DD_TAGS atomically, returning no tags when any entry is malformed."""
-    value = os.environ.get("DD_TAGS")
-    if not value:
-        return []
-
-    tags: List[str] = []
-    for entry in value.split(","):
-        parts = entry.split(":")
-        if len(parts) != 2:
-            return []
-        key, tag_value = (part.strip() for part in parts)
-        if not key or not tag_value:
-            return []
-        tags.append(f"{key}:{tag_value}")
-    return tags
-
-
 class PendingToolSpan:
     """Tracks a tool invocation between PreToolUse and PostToolUse."""
 
@@ -164,6 +146,7 @@ class SessionState:
         self.active_agents: Dict[str, Dict[str, Any]] = {}
         self.conversation_title: str = ""
         self.cwd: str = ""
+        self.custom_tags: Dict[str, str] = {}
         self.project_metadata = resolve_project_metadata()
         # Persists across turns so each turn's context_delta reflects growth from
         # the previous turn's final context size.
@@ -324,6 +307,8 @@ class ClaudeHooksAPI:
 
     def __init__(self, link_tracker: Optional[ClaudeLinkTracker] = None) -> None:
         self._sessions: Dict[str, SessionState] = {}
+        self._session_ids_by_token: Dict[str, Set[str]] = {}
+        self._tags_by_token: Dict[str, Dict[str, str]] = {}
         self._assembled_spans: List[Dict[str, Any]] = []
         self._raw_events: List[Dict[str, Any]] = []
         self._link_tracker = link_tracker
@@ -333,24 +318,41 @@ class ClaudeHooksAPI:
         """Set the aiohttp app reference for backend forwarding."""
         self._app = app
 
-    def _append_span(self, span: Dict[str, Any], index: Optional[int] = None) -> None:
-        """Store a span with the DD_TAGS value observed at creation time."""
-        dd_tags = _dd_tags_from_env()
+    def _apply_session_tags(self, span: Dict[str, Any], session: SessionState) -> None:
+        if not session.custom_tags:
+            return
         span_tags = span.get("tags")
         if not isinstance(span_tags, list):
             span_tags = []
-            span["tags"] = span_tags
-        for tag in dd_tags:
-            if tag not in span_tags:
-                span_tags.append(tag)
-        if index is None:
-            self._assembled_spans.append(span)
-        else:
-            self._assembled_spans.insert(index, span)
+        custom_keys = set(session.custom_tags)
+        span_tags = [
+            tag
+            for tag in span_tags
+            if not isinstance(tag, str) or ":" not in tag or tag.split(":", 1)[0] not in custom_keys
+        ]
+        span_tags.extend(f"{key}:{value}" for key, value in session.custom_tags.items())
+        span["tags"] = span_tags
 
-    def _extend_spans(self, spans: List[Dict[str, Any]]) -> None:
-        for span in spans:
-            self._append_span(span)
+    def _set_session_tags(self, session: SessionState, tags: Dict[str, str]) -> None:
+        session.custom_tags.update(tags)
+        for span in self._assembled_spans:
+            if span.get("session_id") == session.session_id:
+                self._apply_session_tags(span, session)
+
+    def _register_session_token(self, session_token: str, session_id: str) -> None:
+        self._session_ids_by_token.setdefault(session_token, set()).add(session_id)
+        pending_tags = self._tags_by_token.get(session_token)
+        if pending_tags:
+            self._set_session_tags(self._get_or_create_session(session_id), pending_tags)
+
+    def _append_span(self, span: Dict[str, Any]) -> None:
+        """Store a span, applying tags configured for its Claude session."""
+        session_id = span.get("session_id")
+        if isinstance(session_id, str):
+            session = self._sessions.get(session_id)
+            if session is not None:
+                self._apply_session_tags(span, session)
+        self._assembled_spans.append(span)
 
     def _get_or_create_session(self, session_id: str) -> SessionState:
         """Get existing session or create a new one."""
@@ -1612,6 +1614,9 @@ class ClaudeHooksAPI:
         if session_id:
             session = self._get_or_create_session(session_id)
             self.update_session_project_metadata(session, body)
+            session_token = body.get("lapdog_session_token")
+            if isinstance(session_token, str) and session_token:
+                self._register_session_token(session_token, session_id)
 
         handlers: Dict[str, Any] = {
             "SessionStart": self._handle_session_start,
@@ -1817,11 +1822,16 @@ class ClaudeHooksAPI:
             body = await request.json()
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
+        if not isinstance(body, dict):
+            return web.json_response({"error": "JSON body must be an object"}, status=400)
 
         session_id = body.get("session_id", "")
         if not session_id:
             return web.json_response({"error": "missing session_id"}, status=400)
 
+        session_token = body.pop("lapdog_session_token", "")
+        if isinstance(session_token, str) and session_token:
+            self._register_session_token(session_token, session_id)
         self._raw_events.append(body)
 
         # wait for the transcript to be fully flushed before dispatching the hook
@@ -1862,6 +1872,44 @@ class ClaudeHooksAPI:
     async def handle_spans(self, request: Request) -> web.Response:
         """Handle GET /claude/hooks/spans — return all assembled spans."""
         return web.json_response({"spans": self._assembled_spans})
+
+    async def handle_session_tags(self, request: Request) -> web.Response:
+        """Add tags to the Claude session identified by its Lapdog launch token."""
+        session_token = request.headers.get("X-Lapdog-Session-Token", "")
+        if not session_token:
+            return web.json_response({"error": "missing Lapdog session token"}, status=404)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        if not isinstance(body, dict):
+            return web.json_response({"error": "JSON body must be an object"}, status=400)
+        tags = body.get("tags")
+        if not isinstance(tags, dict) or not tags:
+            return web.json_response({"error": "tags must be a non-empty object"}, status=400)
+
+        normalized: Dict[str, str] = {}
+        for key, value in tags.items():
+            if not isinstance(key, str) or not key.strip() or not isinstance(value, str) or not value.strip():
+                return web.json_response({"error": "tag keys and values must be non-empty strings"}, status=400)
+            normalized[key.strip()] = value.strip()
+
+        token_tags = self._tags_by_token.setdefault(session_token, {})
+        token_tags.update(normalized)
+        session_ids = sorted(self._session_ids_by_token.get(session_token, set()))
+        for session_id in session_ids:
+            session = self._sessions.get(session_id)
+            if session is not None:
+                self._set_session_tags(session, normalized)
+        return web.json_response(
+            {
+                "status": "ok",
+                "session_id": session_ids[-1] if session_ids else "",
+                "session_ids": session_ids,
+                "tags": token_tags,
+            }
+        )
 
     async def handle_raw_events(self, request: Request) -> web.Response:
         """Handle GET /claude/hooks/raw — return all raw received events for debugging."""
@@ -1909,7 +1957,7 @@ class ClaudeHooksAPI:
             # client logs it and moves on.
             log.warning("claude backfill_session failed for %s: %r", session_id, exc)
             return web.json_response({"status": "error", "error": repr(exc)}, status=400)
-        self._extend_spans(spans)
+        self._assembled_spans.extend(spans)
         traces = len({s.get("trace_id") for s in spans})
         return web.json_response({"status": "ok", "spans_created": len(spans), "traces_created": traces})
 
@@ -1917,6 +1965,7 @@ class ClaudeHooksAPI:
         """Return the routes for this API."""
         return [
             web.post("/claude/hooks", with_cors(self.handle_hook)),
+            web.post("/claude/hooks/session/tags", with_cors(self.handle_session_tags)),
             web.post("/claude/hooks/backfill_session", with_cors(self.handle_backfill_session)),
             web.route("*", "/claude/hooks/sessions", with_cors(self.handle_sessions)),
             web.route("*", "/claude/hooks/spans", with_cors(self.handle_spans)),

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -49,6 +49,7 @@ _HOSTNAME = socket.gethostname()
 _USERNAME = os.environ.get("HOST_USER") or getpass.getuser()
 _USER_HANDLE = os.environ.get("DD_USER_HANDLE", "")
 _ML_APP = CLAUDE_CODE_ML_APP
+# Reserved tags may not be modified by the agent via the "lapdog tags set" CLI command.
 _RESERVED_SESSION_TAG_KEYS = frozenset(
     {
         "env",
@@ -102,7 +103,14 @@ def _to_json_str(value: Any) -> str:
 class PendingToolSpan:
     """Tracks a tool invocation between PreToolUse and PostToolUse."""
 
-    def __init__(self, span_id: str, tool_name: str, tool_input: Any, parent_id: str, start_ns: int) -> None:
+    def __init__(
+        self,
+        span_id: str,
+        tool_name: str,
+        tool_input: Any,
+        parent_id: str,
+        start_ns: int,
+    ) -> None:
         self.span_id = span_id
         self.tool_name = tool_name
         self.tool_input = tool_input
@@ -140,7 +148,9 @@ class ActiveStep:
 class SessionState:
     """Tracks the state of a single Claude Code session."""
 
-    def __init__(self, session_id: str, trace_id: str, root_span_id: str, start_ns: int) -> None:
+    def __init__(
+        self, session_id: str, trace_id: str, root_span_id: str, start_ns: int
+    ) -> None:
         self.session_id = session_id
         self.trace_id = trace_id
         self.root_span_id = root_span_id
@@ -352,7 +362,9 @@ class ClaudeHooksAPI:
         span_tags = [
             tag
             for tag in span_tags
-            if not isinstance(tag, str) or ":" not in tag or tag.split(":", 1)[0] not in custom_keys
+            if not isinstance(tag, str)
+            or ":" not in tag
+            or tag.split(":", 1)[0] not in custom_keys
         ]
         span_tags.extend(f"{key}:{value}" for key, value in session.custom_tags.items())
         span["tags"] = span_tags
@@ -362,7 +374,9 @@ class ClaudeHooksAPI:
         for candidate in self._sessions.values():
             if candidate.session_id == session.session_id:
                 candidate.custom_tags.update(tags)
-                candidate.custom_tag_sequences.update({key: self._tag_update_sequence for key in tags})
+                candidate.custom_tag_sequences.update(
+                    {key: self._tag_update_sequence for key in tags}
+                )
         for span in self._assembled_spans:
             if span.get("session_id") == session.session_id:
                 self._apply_session_tags(span, session)
@@ -385,7 +399,11 @@ class ClaudeHooksAPI:
         Claude and Pi sessions do not use this reconciliation path because
         they do not perform Codex-style session grouping.
         """
-        grouped_sessions = [session for session in self._sessions.values() if session.session_id == session_id]
+        grouped_sessions = [
+            session
+            for session in self._sessions.values()
+            if session.session_id == session_id
+        ]
         merged_tags: Dict[str, str] = {}
         merged_sequences: Dict[str, int] = {}
         for session in grouped_sessions:
@@ -408,7 +426,9 @@ class ClaudeHooksAPI:
         self._session_tokens_by_id.setdefault(session_id, set()).add(session_token)
         pending_tags = self._pending_tags_by_token.pop(session_token, None)
         if pending_tags:
-            self._set_session_tags(self._get_or_create_session(session_id), pending_tags)
+            self._set_session_tags(
+                self._get_or_create_session(session_id), pending_tags
+            )
 
     def _apply_registered_session_tags(self, span: Dict[str, Any]) -> None:
         session_id = span.get("session_id")
@@ -482,7 +502,9 @@ class ClaudeHooksAPI:
         """Merge key-value pairs into span['meta']['metadata']['_dd'], preserving existing values."""
         span["meta"].setdefault("metadata", {}).setdefault("_dd", {}).update(kwargs)
 
-    def update_session_project_metadata(self, session: SessionState, body: Dict[str, Any]) -> None:
+    def update_session_project_metadata(
+        self, session: SessionState, body: Dict[str, Any]
+    ) -> None:
         previous_cwd = session.cwd
         cwd = body.get("cwd")
         if isinstance(cwd, str) and cwd.strip():
@@ -494,7 +516,8 @@ class ClaudeHooksAPI:
         if session.cwd or project_name or git_repository_url:
             session.project_metadata = resolve_project_metadata(
                 cwd=session.cwd,
-                project_name=project_name or ("" if cwd_changed else session.project_metadata.project_name),
+                project_name=project_name
+                or ("" if cwd_changed else session.project_metadata.project_name),
                 git_repository_url=git_repository_url
                 or ("" if cwd_changed else session.project_metadata.git_repository_url),
             )
@@ -525,7 +548,9 @@ class ClaudeHooksAPI:
         tags.extend(git_commit_sha_tags(session.cwd))
         return tags
 
-    def _set_permission_wait_critical_evaluation(self, span: Dict[str, Any], estimated_permission_wait_ms: int) -> None:
+    def _set_permission_wait_critical_evaluation(
+        self, span: Dict[str, Any], estimated_permission_wait_ms: int
+    ) -> None:
         """Embed a permission_wait_critical boolean evaluation on a span.
         The evaluation flags whether the permission wait was > 50% of span duration.
         """
@@ -540,12 +565,17 @@ class ClaudeHooksAPI:
             "assessment": assessment,
             "status": "OK",
             "reasoning": (
-                f"Permission wait {'exceeded' if is_critical else 'did not exceed'} " f"50% of span duration"
+                f"Permission wait {'exceeded' if is_critical else 'did not exceed'} "
+                f"50% of span duration"
             ),
         }
         # Also populate legacy fields so the frontend can read them
-        span.setdefault("evaluations", {}).setdefault("custom", {})["permission_wait_critical"] = is_critical
-        span.setdefault("evaluation_assessments", {}).setdefault("custom", {})["permission_wait_critical"] = assessment
+        span.setdefault("evaluations", {}).setdefault("custom", {})[
+            "permission_wait_critical"
+        ] = is_critical
+        span.setdefault("evaluation_assessments", {}).setdefault("custom", {})[
+            "permission_wait_critical"
+        ] = assessment
 
     def _start_step_for_llm(
         self,
@@ -574,7 +604,9 @@ class ClaudeHooksAPI:
         before the proxy finishes creating the LLM span and the children
         got cached with the agent as parent instead of this step.
         """
-        agent_parent_id = session.step_agent_by_span_id.get(agent_parent_id, agent_parent_id)
+        agent_parent_id = session.step_agent_by_span_id.get(
+            agent_parent_id, agent_parent_id
+        )
 
         prior = session.active_steps_by_agent.get(agent_parent_id)
         if prior is not None:
@@ -596,7 +628,8 @@ class ClaudeHooksAPI:
             "service": _ML_APP,
             "env": "local",
             "session_id": session.session_id,
-            "tags": self.base_tags(session) + ["trajectory.semantic_type:agent_message"],
+            "tags": self.base_tags(session)
+            + ["trajectory.semantic_type:agent_message"],
             "meta": {
                 "span": {"kind": "step"},
                 "input": {},
@@ -673,14 +706,23 @@ class ClaudeHooksAPI:
             if deferred is not None and deferred.get("parent_id") == agent_parent_id:
                 deferred["parent_id"] = step_span_id
                 span_ref = deferred.get("_span_ref")
-                if span_ref is not None and span_ref.get("parent_id") == agent_parent_id:
+                if (
+                    span_ref is not None
+                    and span_ref.get("parent_id") == agent_parent_id
+                ):
                     span_ref["parent_id"] = step_span_id
 
         for entry in session.agent_span_stack:
-            if entry.get("task_tool_use_id") in tool_use_set and entry.get("parent_id") == agent_parent_id:
+            if (
+                entry.get("task_tool_use_id") in tool_use_set
+                and entry.get("parent_id") == agent_parent_id
+            ):
                 entry["parent_id"] = step_span_id
                 span_ref = entry.get("_span_ref")
-                if span_ref is not None and span_ref.get("parent_id") == agent_parent_id:
+                if (
+                    span_ref is not None
+                    and span_ref.get("parent_id") == agent_parent_id
+                ):
                     span_ref["parent_id"] = step_span_id
 
     def _finalize_step(
@@ -721,7 +763,13 @@ class ClaudeHooksAPI:
         """Finalize the open step (if any) for the given agent frame."""
         active = session.active_steps_by_agent.get(agent_span_id)
         if active is not None:
-            self._finalize_step(session, active, end_ns=end_ns, status=status, error_message=error_message)
+            self._finalize_step(
+                session,
+                active,
+                end_ns=end_ns,
+                status=status,
+                error_message=error_message,
+            )
 
     def _update_step_from_llm_response(
         self,
@@ -786,13 +834,21 @@ class ClaudeHooksAPI:
         # Discard any pending permission wait — the turn was interrupted so we don't
         # want it bleeding into the next turn's accumulated total.
         session.pending_permission_at_ns = None
-        root_span_ref: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
+        root_span_ref: Optional[Dict[str, Any]] = getattr(
+            session, "_root_span_ref", None
+        )
         if root_span_ref is not None and root_span_ref["duration"] == -1:
             root_span_ref["duration"] = 0
 
         # Finalize any in-progress step spans before tearing down their agents.
         for active in list(session.active_steps_by_agent.values()):
-            self._finalize_step(session, active, end_ns=now_ns, status="error", error_message="interrupted")
+            self._finalize_step(
+                session,
+                active,
+                end_ns=now_ns,
+                status="error",
+                error_message="interrupted",
+            )
         session.active_steps_by_agent.clear()
         session.step_index_by_agent.clear()
         session.step_agent_by_span_id.clear()
@@ -816,7 +872,11 @@ class ClaudeHooksAPI:
         root_span: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
         if not root_span:
             root_span = next(
-                (s for s in self._assembled_spans if s.get("span_id") == session.root_span_id),
+                (
+                    s
+                    for s in self._assembled_spans
+                    if s.get("span_id") == session.root_span_id
+                ),
                 None,
             )
 
@@ -836,7 +896,11 @@ class ClaudeHooksAPI:
             # rollup + each LLM span's own value).
 
         session.root_span_emitted = True
-        log.info("Finalized interrupted turn for session %s (trace %s)", session.session_id, session.trace_id)
+        log.info(
+            "Finalized interrupted turn for session %s (trace %s)",
+            session.session_id,
+            session.trace_id,
+        )
 
     def _handle_user_prompt_submit(self, session_id: str, body: Dict[str, Any]) -> None:
         """Handle UserPromptSubmit hook event — starts a new trace for each user turn.
@@ -848,7 +912,10 @@ class ClaudeHooksAPI:
 
         # If the previous turn was never finalized (Stop never fired, e.g. Ctrl+C),
         # finalize it as interrupted before starting the new turn.
-        if not session.root_span_emitted and getattr(session, "_root_span_ref", None) is not None:
+        if (
+            not session.root_span_emitted
+            and getattr(session, "_root_span_ref", None) is not None
+        ):
             self._finalize_interrupted_turn(session)
 
         # If the previous turn's root span was emitted, start a fresh trace
@@ -890,7 +957,11 @@ class ClaudeHooksAPI:
             "env": "local",
             "session_id": session.session_id,
             "tags": self.base_tags(session)
-            + ([f"topic:{session.conversation_title}"] if session.conversation_title else []),
+            + (
+                [f"topic:{session.conversation_title}"]
+                if session.conversation_title
+                else []
+            ),
             "meta": {
                 "span": {"kind": "agent"},
                 "input": {"value": prompt},
@@ -952,10 +1023,14 @@ class ClaudeHooksAPI:
             start_ns = pending.start_ns
             input_value = _to_json_str(pending.tool_input) if pending.tool_input else ""
             actual_tool_name = pending.tool_name
-            tool_input_dict = pending.tool_input if isinstance(pending.tool_input, dict) else {}
+            tool_input_dict = (
+                pending.tool_input if isinstance(pending.tool_input, dict) else {}
+            )
         else:
             span_id = _format_span_id()
-            parent_id = self._resolve_tool_parent(tool_use_id, self._current_parent_id(session))
+            parent_id = self._resolve_tool_parent(
+                tool_use_id, self._current_parent_id(session)
+            )
             start_ns = now_ns
             input_value = ""
             actual_tool_name = tool_name
@@ -967,9 +1042,13 @@ class ClaudeHooksAPI:
 
         estimated_permission_wait_ms: Optional[int] = None
         if session.pending_permission_at_ns is not None:
-            estimated_permission_wait_ms = (now_ns - session.pending_permission_at_ns) // 1_000_000
+            estimated_permission_wait_ms = (
+                now_ns - session.pending_permission_at_ns
+            ) // 1_000_000
             session.pending_permission_at_ns = None
-            root_span_ref: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
+            root_span_ref: Optional[Dict[str, Any]] = getattr(
+                session, "_root_span_ref", None
+            )
             if root_span_ref is not None and root_span_ref["duration"] == -1:
                 root_span_ref["duration"] = 0
 
@@ -1069,7 +1148,9 @@ class ClaudeHooksAPI:
             "span_links": span_links,
         }
         if estimated_permission_wait_ms is not None:
-            self._set_hidden_metadata(span, estimated_permission_wait_ms=estimated_permission_wait_ms)
+            self._set_hidden_metadata(
+                span, estimated_permission_wait_ms=estimated_permission_wait_ms
+            )
         self._append_span(span)
 
     def _handle_subagent_start(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -1107,7 +1188,9 @@ class ClaudeHooksAPI:
         # from when they were dispatched, not the stack top which may have changed.
         # Re-resolve via the link tracker in case PreToolUse raced ahead of the
         # LLM span's creation and cached a stale agent parent rather than the step.
-        fallback_parent = task_pending.parent_id if task_pending else self._current_parent_id(session)
+        fallback_parent = (
+            task_pending.parent_id if task_pending else self._current_parent_id(session)
+        )
         if task_tool_use_id:
             parent_id = self._resolve_tool_parent(task_tool_use_id, fallback_parent)
         else:
@@ -1172,7 +1255,9 @@ class ClaudeHooksAPI:
         now_ns = monotonic_wall_ns()
 
         if not session.agent_span_stack:
-            log.warning("SubagentStop with empty agent stack for session %s", session_id)
+            log.warning(
+                "SubagentStop with empty agent stack for session %s", session_id
+            )
             return
 
         # Finalize this subagent's active step (if any) before popping the frame.
@@ -1194,11 +1279,16 @@ class ClaudeHooksAPI:
             first_input_tokens=0,
         )
 
-        estimated_perm_wait = self._sum_estimated_permission_wait_ms(parent_id=str(agent_info["span_id"]))
+        estimated_perm_wait = self._sum_estimated_permission_wait_ms(
+            parent_id=str(agent_info["span_id"])
+        )
         # If SubagentStart fired before PreToolUse(Task), retry the match now.
         if not task_tool_use_id:
             for tid, pending in session.pending_tools.items():
-                if pending.tool_name == "Task" and tid not in session.claimed_task_tools:
+                if (
+                    pending.tool_name == "Task"
+                    and tid not in session.claimed_task_tools
+                ):
                     task_tool_use_id = tid
                     task_tool_input = pending.tool_input
                     session.claimed_task_tools.add(tid)
@@ -1213,7 +1303,9 @@ class ClaudeHooksAPI:
             if span_ref:
                 span_ref["duration"] = duration
                 if estimated_perm_wait > 0:
-                    self._set_hidden_metadata(span_ref, estimated_permission_wait_ms=estimated_perm_wait)
+                    self._set_hidden_metadata(
+                        span_ref, estimated_permission_wait_ms=estimated_perm_wait
+                    )
             session.deferred_agent_spans[task_tool_use_id] = {
                 "span_id": agent_info["span_id"],
                 "trace_id": session.trace_id,
@@ -1284,7 +1376,10 @@ class ClaudeHooksAPI:
             "output_tokens": total_output,
             "cache_read_input_tokens": total_cache_read,
             "cache_write_input_tokens": total_cache_write,
-            "total_tokens": total_input + total_output + total_cache_read + total_cache_write,
+            "total_tokens": total_input
+            + total_output
+            + total_cache_read
+            + total_cache_write,
         }
 
     def _aggregate_tool_usage(self, trace_id: str) -> Dict[str, Dict[str, int]]:
@@ -1303,11 +1398,21 @@ class ClaudeHooksAPI:
             tool_name = raw_name.split(" - ")[0]
             entry = result.setdefault(
                 tool_name,
-                {"call_count": 0, "total_duration_ns": 0, "permission_wait_count": 0, "permission_wait_ms": 0},
+                {
+                    "call_count": 0,
+                    "total_duration_ns": 0,
+                    "permission_wait_count": 0,
+                    "permission_wait_ms": 0,
+                },
             )
             entry["call_count"] += 1
             entry["total_duration_ns"] += span.get("duration", 0)
-            perm_wait = span.get("meta", {}).get("metadata", {}).get("_dd", {}).get("estimated_permission_wait_ms", 0)
+            perm_wait = (
+                span.get("meta", {})
+                .get("metadata", {})
+                .get("_dd", {})
+                .get("estimated_permission_wait_ms", 0)
+            )
             if perm_wait:
                 entry["permission_wait_count"] += 1
                 entry["permission_wait_ms"] += perm_wait
@@ -1345,7 +1450,11 @@ class ClaudeHooksAPI:
             key=lambda s: s.get("start_ns", 0),
         )
         last_span = next(
-            (s for s in reversed(llm_spans) if s.get("metrics", {}).get("input_tokens", 0) > 0),
+            (
+                s
+                for s in reversed(llm_spans)
+                if s.get("metrics", {}).get("input_tokens", 0) > 0
+            ),
             None,
         )
         if last_span is None:
@@ -1360,18 +1469,30 @@ class ClaudeHooksAPI:
             None,
         )
         first_breakdown = (
-            first_span.get("meta", {}).get("metadata", {}).get("_dd", {}).get("context_breakdown")
+            first_span.get("meta", {})
+            .get("metadata", {})
+            .get("_dd", {})
+            .get("context_breakdown")
             if first_span
             else None
         )
-        last_breakdown = last_span.get("meta", {}).get("metadata", {}).get("_dd", {}).get("context_breakdown")
+        last_breakdown = (
+            last_span.get("meta", {})
+            .get("metadata", {})
+            .get("_dd", {})
+            .get("context_breakdown")
+        )
         context_delta: Dict[str, Any] = {
             "first_input_tokens": first_input_tokens,
             "last_input_tokens": last_input_tokens,
             "delta_tokens": delta_tokens,
             "context_window_size": window,
-            "first_usage_pct": round(first_input_tokens / window * 100, 1) if window else 0.0,
-            "last_usage_pct": round(last_input_tokens / window * 100, 1) if window else 0.0,
+            "first_usage_pct": round(first_input_tokens / window * 100, 1)
+            if window
+            else 0.0,
+            "last_usage_pct": round(last_input_tokens / window * 100, 1)
+            if window
+            else 0.0,
         }
         if first_breakdown:
             context_delta["first_sections"] = first_breakdown.get("sections", [])
@@ -1416,7 +1537,11 @@ class ClaudeHooksAPI:
         if not root_span:
             # Fallback: search _assembled_spans
             root_span = next(
-                (s for s in self._assembled_spans if s.get("span_id") == session.root_span_id),
+                (
+                    s
+                    for s in self._assembled_spans
+                    if s.get("span_id") == session.root_span_id
+                ),
                 None,
             )
         tool_usage = self._aggregate_tool_usage(session.trace_id)
@@ -1428,14 +1553,18 @@ class ClaudeHooksAPI:
 
         root_span_name = "claude-code-request"
 
-        estimated_permission_wait_ms = self._sum_estimated_permission_wait_ms(trace_id=session.trace_id)
+        estimated_permission_wait_ms = self._sum_estimated_permission_wait_ms(
+            trace_id=session.trace_id
+        )
 
         if root_span:
             root_span["name"] = root_span_name
             if session.conversation_title:
                 topic_tag = f"topic:{session.conversation_title}"
                 # Replace existing topic tag (set from preliminary span) or append
-                root_span["tags"] = [t for t in root_span["tags"] if not t.startswith("topic:")] + [topic_tag]
+                root_span["tags"] = [
+                    t for t in root_span["tags"] if not t.startswith("topic:")
+                ] + [topic_tag]
             root_span["duration"] = duration
             root_span["meta"]["input"]["value"] = input_value
             root_span["meta"]["output"]["value"] = output_value
@@ -1454,7 +1583,9 @@ class ClaudeHooksAPI:
                 dd_fields["context_delta"] = context_delta
             if estimated_permission_wait_ms > 0:
                 dd_fields["estimated_permission_wait_ms"] = estimated_permission_wait_ms
-                self._set_permission_wait_critical_evaluation(root_span, estimated_permission_wait_ms)
+                self._set_permission_wait_critical_evaluation(
+                    root_span, estimated_permission_wait_ms
+                )
             if tool_usage:
                 dd_fields["tool_usage"] = tool_usage
             self._set_hidden_metadata(root_span, **dd_fields)
@@ -1476,7 +1607,11 @@ class ClaudeHooksAPI:
                 "session_id": session.session_id,
                 "tags": self.base_tags(session)
                 + [f"user_name:{_USERNAME}"]
-                + ([f"topic:{session.conversation_title}"] if session.conversation_title else []),
+                + (
+                    [f"topic:{session.conversation_title}"]
+                    if session.conversation_title
+                    else []
+                ),
                 "meta": {
                     "span": {"kind": "agent"},
                     "input": {"value": input_value},
@@ -1495,7 +1630,9 @@ class ClaudeHooksAPI:
                 dd_fields["context_delta"] = context_delta
             if estimated_permission_wait_ms > 0:
                 dd_fields["estimated_permission_wait_ms"] = estimated_permission_wait_ms
-                self._set_permission_wait_critical_evaluation(root_span, estimated_permission_wait_ms)
+                self._set_permission_wait_critical_evaluation(
+                    root_span, estimated_permission_wait_ms
+                )
             if tool_usage:
                 dd_fields["tool_usage"] = tool_usage
             apply_project_metadata_to_span(root_span, session.project_metadata)
@@ -1519,9 +1656,15 @@ class ClaudeHooksAPI:
 
     def _handle_notification(self, session_id: str, body: Dict[str, Any]) -> None:
         """Handle Notification hook event — logged but no span emitted."""
-        log.info("Claude notification for session %s: %s", session_id, body.get("message", ""))
+        log.info(
+            "Claude notification for session %s: %s",
+            session_id,
+            body.get("message", ""),
+        )
 
-    def _handle_post_tool_use_failure(self, session_id: str, body: Dict[str, Any]) -> None:
+    def _handle_post_tool_use_failure(
+        self, session_id: str, body: Dict[str, Any]
+    ) -> None:
         """Handle PostToolUseFailure hook event — emits a tool span with error status.
 
         Fired when a tool execution fails. The body includes an ``error`` string
@@ -1544,10 +1687,14 @@ class ClaudeHooksAPI:
             start_ns = pending.start_ns
             input_value = _to_json_str(pending.tool_input) if pending.tool_input else ""
             actual_tool_name = pending.tool_name
-            tool_input_dict = pending.tool_input if isinstance(pending.tool_input, dict) else {}
+            tool_input_dict = (
+                pending.tool_input if isinstance(pending.tool_input, dict) else {}
+            )
         else:
             span_id = _format_span_id()
-            parent_id = self._resolve_tool_parent(tool_use_id, self._current_parent_id(session))
+            parent_id = self._resolve_tool_parent(
+                tool_use_id, self._current_parent_id(session)
+            )
             start_ns = now_ns
             input_value = ""
             actual_tool_name = tool_name
@@ -1559,9 +1706,13 @@ class ClaudeHooksAPI:
         # Consume any pending permission wait
         estimated_permission_wait_ms: Optional[int] = None
         if session.pending_permission_at_ns is not None:
-            estimated_permission_wait_ms = (now_ns - session.pending_permission_at_ns) // 1_000_000
+            estimated_permission_wait_ms = (
+                now_ns - session.pending_permission_at_ns
+            ) // 1_000_000
             session.pending_permission_at_ns = None
-            root_span_ref: Optional[Dict[str, Any]] = getattr(session, "_root_span_ref", None)
+            root_span_ref: Optional[Dict[str, Any]] = getattr(
+                session, "_root_span_ref", None
+            )
             if root_span_ref is not None and root_span_ref["duration"] == -1:
                 root_span_ref["duration"] = 0
 
@@ -1618,7 +1769,9 @@ class ClaudeHooksAPI:
         if is_interrupt:
             span["meta"]["error"]["type"] = "interrupt"
         if estimated_permission_wait_ms is not None:
-            self._set_hidden_metadata(span, estimated_permission_wait_ms=estimated_permission_wait_ms)
+            self._set_hidden_metadata(
+                span, estimated_permission_wait_ms=estimated_permission_wait_ms
+            )
         self._append_span(span)
 
     def _handle_pre_compact(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -1637,7 +1790,11 @@ class ClaudeHooksAPI:
         log.info("span_ref: %s", span_ref)
         if span_ref is None:
             return
-        dd = span_ref.setdefault("meta", {}).setdefault("metadata", {}).setdefault("_dd", {})
+        dd = (
+            span_ref.setdefault("meta", {})
+            .setdefault("metadata", {})
+            .setdefault("_dd", {})
+        )
         dd.setdefault("compactions", []).append(
             {
                 "trigger": trigger,
@@ -1662,7 +1819,12 @@ class ClaudeHooksAPI:
                 continue
             if parent_id is not None and str(s.get("parent_id")) != str(parent_id):
                 continue
-            total += s.get("meta", {}).get("metadata", {}).get("_dd", {}).get("estimated_permission_wait_ms", 0)
+            total += (
+                s.get("meta", {})
+                .get("metadata", {})
+                .get("_dd", {})
+                .get("estimated_permission_wait_ms", 0)
+            )
         return total
 
     def _handle_permission_request(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -1749,19 +1911,32 @@ class ClaudeHooksAPI:
             url = f"https://{agentless_base_url}.{dd_site}{endpoint}"
             headers["DD-API-KEY"] = dd_api_key
         else:
-            log.debug("No DD_API_KEY/DD_SITE or agent URL configured — skipping forwarding")
+            log.debug(
+                "No DD_API_KEY/DD_SITE or agent URL configured — skipping forwarding"
+            )
             return None
 
-        log.info("Resolved backend target: %s (mode=%s)", url, "agent" if agent_url else "agentless")
+        log.info(
+            "Resolved backend target: %s (mode=%s)",
+            url,
+            "agent" if agent_url else "agentless",
+        )
         return url, headers
 
-    async def _post_to_backend(self, url: str, headers: Dict[str, str], data: bytes, description: str) -> None:
+    async def _post_to_backend(
+        self, url: str, headers: Dict[str, str], data: bytes, description: str
+    ) -> None:
         """POST the given data to the url and log the outcome."""
         try:
             async with ClientSession() as http_session:
                 async with http_session.post(url, headers=headers, data=data) as resp:
                     if not resp.ok:
-                        log.warning("Failed to %s: %s %s", description, resp.status, await resp.text())
+                        log.warning(
+                            "Failed to %s: %s %s",
+                            description,
+                            resp.status,
+                            await resp.text(),
+                        )
                     else:
                         log.info("Successfully %s", description)
         except Exception as e:
@@ -1783,10 +1958,15 @@ class ClaudeHooksAPI:
             "spans": spans,
         }
         data = gzip.compress(msgpack.packb(payload))
-        await self._post_to_backend(url, headers, data, f"forward {len(spans)} span updates")
+        await self._post_to_backend(
+            url, headers, data, f"forward {len(spans)} span updates"
+        )
 
     async def _forward_trace_to_backend(
-        self, session_id: str, trace_id: Optional[str] = None, span_source: str = "Claude hooks"
+        self,
+        session_id: str,
+        trace_id: Optional[str] = None,
+        span_source: str = "Claude hooks",
     ) -> None:
         """Forward all assembled spans for a session's trace to the backend via the EVP proxy path."""
         session = self._sessions.get(session_id)
@@ -1807,7 +1987,14 @@ class ClaudeHooksAPI:
         forwarded_spans = []
         for s in spans:
             span = (
-                {**s, "metrics": {k: v for k, v in s["metrics"].items() if k not in COST_METRIC_KEYS}}
+                {
+                    **s,
+                    "metrics": {
+                        k: v
+                        for k, v in s["metrics"].items()
+                        if k not in COST_METRIC_KEYS
+                    },
+                }
                 if s.get("metrics")
                 else dict(s)
             )
@@ -1823,10 +2010,15 @@ class ClaudeHooksAPI:
         }
         data = gzip.compress(msgpack.packb(payload))
         await self._post_to_backend(
-            url, headers, data, f"forward {len(spans)} {span_source} spans for trace {trace_id}"
+            url,
+            headers,
+            data,
+            f"forward {len(spans)} {span_source} spans for trace {trace_id}",
         )
 
-    async def _forward_eval_metrics_to_backend(self, session_id: str, trace_id: Optional[str] = None) -> None:
+    async def _forward_eval_metrics_to_backend(
+        self, session_id: str, trace_id: Optional[str] = None
+    ) -> None:
         """Forward evaluation metrics for all spans in a session's trace to the Datadog backend.
 
         Collects evaluation entries from every span in the trace (not just root),
@@ -1883,9 +2075,14 @@ class ClaudeHooksAPI:
         if not metrics:
             return
 
-        payload = {"data": {"type": "evaluation_metric", "attributes": {"metrics": metrics}}}
+        payload = {
+            "data": {"type": "evaluation_metric", "attributes": {"metrics": metrics}}
+        }
         await self._post_to_backend(
-            url, headers, json.dumps(payload).encode(), f"forward {len(metrics)} eval metric(s) for trace {trace_id}"
+            url,
+            headers,
+            json.dumps(payload).encode(),
+            f"forward {len(metrics)} eval metric(s) for trace {trace_id}",
         )
 
     async def handle_hook(self, request: Request) -> web.Response:
@@ -1895,7 +2092,9 @@ class ClaudeHooksAPI:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         if not isinstance(body, dict):
-            return web.json_response({"error": "JSON body must be an object"}, status=400)
+            return web.json_response(
+                {"error": "JSON body must be an object"}, status=400
+            )
 
         session_id = body.get("session_id", "")
         if not session_id:
@@ -1949,42 +2148,63 @@ class ClaudeHooksAPI:
         """Add tags to coding-agent sessions identified by a Lapdog launch token."""
         session_token = request.headers.get("X-Lapdog-Session-Token", "")
         if not session_token:
-            return web.json_response({"error": "missing Lapdog session token"}, status=404)
+            return web.json_response(
+                {"error": "missing Lapdog session token"}, status=404
+            )
 
         try:
             body = await request.json()
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         if not isinstance(body, dict):
-            return web.json_response({"error": "JSON body must be an object"}, status=400)
+            return web.json_response(
+                {"error": "JSON body must be an object"}, status=400
+            )
         tags = body.get("tags")
         if not isinstance(tags, dict) or not tags:
-            return web.json_response({"error": "tags must be a non-empty object"}, status=400)
+            return web.json_response(
+                {"error": "tags must be a non-empty object"}, status=400
+            )
 
         normalized: Dict[str, str] = {}
         for key, value in tags.items():
-            if not isinstance(key, str) or not key.strip() or not isinstance(value, str) or not value.strip():
-                return web.json_response({"error": "tag keys and values must be non-empty strings"}, status=400)
+            if (
+                not isinstance(key, str)
+                or not key.strip()
+                or not isinstance(value, str)
+                or not value.strip()
+            ):
+                return web.json_response(
+                    {"error": "tag keys and values must be non-empty strings"},
+                    status=400,
+                )
             normalized[key.strip()] = value.strip()
         reserved_keys = sorted(set(normalized).intersection(_RESERVED_SESSION_TAG_KEYS))
         if reserved_keys:
             return web.json_response(
-                {"error": f"reserved tag keys cannot be changed: {', '.join(reserved_keys)}"},
+                {
+                    "error": f"reserved tag keys cannot be changed: {', '.join(reserved_keys)}"
+                },
                 status=400,
             )
 
         requested_session_id = body.get("session_id")
         if requested_session_id is not None and (
-            not isinstance(requested_session_id, str) or not requested_session_id.strip()
+            not isinstance(requested_session_id, str)
+            or not requested_session_id.strip()
         ):
-            return web.json_response({"error": "session_id must be a non-empty string"}, status=400)
+            return web.json_response(
+                {"error": "session_id must be a non-empty string"}, status=400
+            )
 
         if isinstance(requested_session_id, str):
             session_id = requested_session_id.strip()
             registered_tokens = self._session_tokens_by_id.get(session_id, set())
             if registered_tokens and session_token not in registered_tokens:
                 return web.json_response(
-                    {"error": "session_id is associated with a different Lapdog launch token"},
+                    {
+                        "error": "session_id is associated with a different Lapdog launch token"
+                    },
                     status=409,
                 )
             if not registered_tokens:
@@ -2046,7 +2266,9 @@ class ClaudeHooksAPI:
         entries = body.get("entries") or []
         subagents = body.get("subagents") or []
         if not session_id or not isinstance(entries, list):
-            return web.json_response({"error": "session_id and entries required"}, status=400)
+            return web.json_response(
+                {"error": "session_id and entries required"}, status=400
+            )
 
         if has_backfilled_session(self._assembled_spans, session_id):
             return web.json_response(
@@ -2059,16 +2281,22 @@ class ClaudeHooksAPI:
             )
 
         try:
-            spans = claude_backfill.session_to_spans(session_id, cwd, entries, subagents=subagents)
+            spans = claude_backfill.session_to_spans(
+                session_id, cwd, entries, subagents=subagents
+            )
         except Exception as exc:
             # A single malformed transcript shouldn't propagate as a 500 that
             # closes the connection — return a structured failure so the
             # client logs it and moves on.
             log.warning("claude backfill_session failed for %s: %r", session_id, exc)
-            return web.json_response({"status": "error", "error": repr(exc)}, status=400)
+            return web.json_response(
+                {"status": "error", "error": repr(exc)}, status=400
+            )
         self._assembled_spans.extend(spans)
         traces = len({s.get("trace_id") for s in spans})
-        return web.json_response({"status": "ok", "spans_created": len(spans), "traces_created": traces})
+        return web.json_response(
+            {"status": "ok", "spans_created": len(spans), "traces_created": traces}
+        )
 
     def get_routes(self) -> List[web.RouteDef]:
         """Return the routes for this API."""
@@ -2076,7 +2304,10 @@ class ClaudeHooksAPI:
             web.post("/claude/hooks", with_cors(self.handle_hook)),
             web.post("/lapdog/session/tags", with_cors(self.handle_session_tags)),
             web.post("/claude/hooks/session/tags", with_cors(self.handle_session_tags)),
-            web.post("/claude/hooks/backfill_session", with_cors(self.handle_backfill_session)),
+            web.post(
+                "/claude/hooks/backfill_session",
+                with_cors(self.handle_backfill_session),
+            ),
             web.route("*", "/claude/hooks/sessions", with_cors(self.handle_sessions)),
             web.route("*", "/claude/hooks/spans", with_cors(self.handle_spans)),
             web.route("*", "/claude/hooks/raw", with_cors(self.handle_raw_events)),

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -78,6 +78,24 @@ def _to_json_str(value: Any) -> str:
         return str(value)
 
 
+def _dd_tags_from_env() -> List[str]:
+    """Parse DD_TAGS atomically, returning no tags when any entry is malformed."""
+    value = os.environ.get("DD_TAGS")
+    if not value:
+        return []
+
+    tags: List[str] = []
+    for entry in value.split(","):
+        parts = entry.split(":")
+        if len(parts) != 2:
+            return []
+        key, tag_value = (part.strip() for part in parts)
+        if not key or not tag_value:
+            return []
+        tags.append(f"{key}:{tag_value}")
+    return tags
+
+
 class PendingToolSpan:
     """Tracks a tool invocation between PreToolUse and PostToolUse."""
 
@@ -315,6 +333,25 @@ class ClaudeHooksAPI:
         """Set the aiohttp app reference for backend forwarding."""
         self._app = app
 
+    def _append_span(self, span: Dict[str, Any], index: Optional[int] = None) -> None:
+        """Store a span with the DD_TAGS value observed at creation time."""
+        dd_tags = _dd_tags_from_env()
+        span_tags = span.get("tags")
+        if not isinstance(span_tags, list):
+            span_tags = []
+            span["tags"] = span_tags
+        for tag in dd_tags:
+            if tag not in span_tags:
+                span_tags.append(tag)
+        if index is None:
+            self._assembled_spans.append(span)
+        else:
+            self._assembled_spans.insert(index, span)
+
+    def _extend_spans(self, spans: List[Dict[str, Any]]) -> None:
+        for span in spans:
+            self._append_span(span)
+
     def _get_or_create_session(self, session_id: str) -> SessionState:
         """Get existing session or create a new one."""
         if session_id not in self._sessions:
@@ -494,7 +531,7 @@ class ClaudeHooksAPI:
             },
             "metrics": {},
         }
-        self._assembled_spans.append(step_span)
+        self._append_span(step_span)
 
         active = ActiveStep(
             span_id=step_span_id,
@@ -789,7 +826,7 @@ class ClaudeHooksAPI:
             "metrics": {},
         }
         apply_project_metadata_to_span(root_span, session.project_metadata)
-        self._assembled_spans.append(root_span)
+        self._append_span(root_span)
         session._root_span_ref = root_span  # type: ignore[attr-defined]
 
     def _handle_pre_tool_use(self, session_id: str, body: Dict[str, Any]) -> None:
@@ -916,7 +953,7 @@ class ClaudeHooksAPI:
                 }
                 if context_delta:
                     self._set_hidden_metadata(span, context_delta=context_delta)
-                self._assembled_spans.append(span)
+                self._append_span(span)
             return
 
         # Normal tool span
@@ -959,7 +996,7 @@ class ClaudeHooksAPI:
         }
         if estimated_permission_wait_ms is not None:
             self._set_hidden_metadata(span, estimated_permission_wait_ms=estimated_permission_wait_ms)
-        self._assembled_spans.append(span)
+        self._append_span(span)
 
     def _handle_subagent_start(self, session_id: str, body: Dict[str, Any]) -> None:
         """Handle SubagentStart hook event — pushes a new agent onto the stack.
@@ -1031,7 +1068,7 @@ class ClaudeHooksAPI:
             },
             "metrics": {},
         }
-        self._assembled_spans.append(preliminary_span)
+        self._append_span(preliminary_span)
 
         task_prompt = ""
         if isinstance(task_tool_input, dict):
@@ -1150,7 +1187,7 @@ class ClaudeHooksAPI:
                 }
                 if context_delta:
                     self._set_hidden_metadata(span, context_delta=context_delta)
-                self._assembled_spans.append(span)
+                self._append_span(span)
 
     def _compute_token_usage(self, trace_id: str) -> Dict[str, int]:
         """Sum token metrics from all LLM spans in the given trace."""
@@ -1389,7 +1426,7 @@ class ClaudeHooksAPI:
                 dd_fields["tool_usage"] = tool_usage
             apply_project_metadata_to_span(root_span, session.project_metadata)
             self._set_hidden_metadata(root_span, **dd_fields)
-            self._assembled_spans.append(root_span)
+            self._append_span(root_span)
 
         session.root_span_emitted = True
 
@@ -1508,7 +1545,7 @@ class ClaudeHooksAPI:
             span["meta"]["error"]["type"] = "interrupt"
         if estimated_permission_wait_ms is not None:
             self._set_hidden_metadata(span, estimated_permission_wait_ms=estimated_permission_wait_ms)
-        self._assembled_spans.append(span)
+        self._append_span(span)
 
     def _handle_pre_compact(self, session_id: str, body: Dict[str, Any]) -> None:
         """Handle PreCompact hook event — marks the current active span with compaction metadata.
@@ -1872,7 +1909,7 @@ class ClaudeHooksAPI:
             # client logs it and moves on.
             log.warning("claude backfill_session failed for %s: %r", session_id, exc)
             return web.json_response({"status": "error", "error": repr(exc)}, status=400)
-        self._assembled_spans.extend(spans)
+        self._extend_spans(spans)
         traces = len({s.get("trace_id") for s in spans})
         return web.json_response({"status": "ok", "spans_created": len(spans), "traces_created": traces})
 

--- a/ddapm_test_agent/claude_proxy.py
+++ b/ddapm_test_agent/claude_proxy.py
@@ -728,10 +728,10 @@ class ClaudeProxyAPI:
                 if span.get("parent_id") == "undefined":
                     # No session yet — buffer for later re-parenting
                     self._orphan_spans.append(span)
-                    self._hooks_api._assembled_spans.append(span)
+                    self._hooks_api._append_span(span)
                     log.info("Buffered orphan LLM span %s (no session yet)", span["span_id"])
                 else:
-                    self._hooks_api._assembled_spans.append(span)
+                    self._hooks_api._append_span(span)
                 log.info(
                     "LLM span %s: model=%s tokens=%d+%d duration=%.1fs",
                     span["span_id"],
@@ -763,10 +763,10 @@ class ClaudeProxyAPI:
                 span = self._create_llm_span(session, request_body, response_data, start_ns, duration_ns)
                 if span.get("parent_id") == "undefined":
                     self._orphan_spans.append(span)
-                    self._hooks_api._assembled_spans.append(span)
+                    self._hooks_api._append_span(span)
                     log.info("Buffered orphan LLM span %s (no session yet)", span["span_id"])
                 else:
-                    self._hooks_api._assembled_spans.append(span)
+                    self._hooks_api._append_span(span)
                 log.info(
                     "LLM span %s: model=%s tokens=%d+%d duration=%.1fs",
                     span["span_id"],

--- a/ddapm_test_agent/claude_proxy.py
+++ b/ddapm_test_agent/claude_proxy.py
@@ -407,6 +407,7 @@ class ClaudeProxyAPI:
                     existing_tags.append(tag)
             span["tags"] = existing_tags
             apply_project_metadata_to_span(span, session.project_metadata)
+            self._hooks_api._apply_session_tags(span, session)
         log.info("Re-parented %d orphan LLM spans into trace %s", len(self._orphan_spans), session.trace_id)
         self._orphan_spans.clear()
 

--- a/ddapm_test_agent/codex_hooks.py
+++ b/ddapm_test_agent/codex_hooks.py
@@ -389,6 +389,7 @@ class CodexHooksAPI:
         shared_session = self._hooks_api._sessions.get(raw_session_id)
         if shared_session is not None:
             shared_session.session_id = group_session_id
+            self._hooks_api._synchronize_session_tags(group_session_id)
 
     def _get_or_create_session(self, session_id: str, start_ns: int) -> CodexSession:
         if session_id not in self._sessions:
@@ -1946,7 +1947,9 @@ class CodexHooksAPI:
         if not session_id:
             return web.json_response({"error": "missing session_id"}, status=400)
 
-        self._raw_events.append(body)
+        raw_body = dict(body)
+        raw_body.pop("proxy_session_key", None)
+        self._raw_events.append(raw_body)
         self._last_session_id = session_id
         is_backfill = body.get("backfill") is True
         completed = self._dispatch(session_id, record, proxy_session_key=proxy_session_key)

--- a/ddapm_test_agent/codex_hooks.py
+++ b/ddapm_test_agent/codex_hooks.py
@@ -362,7 +362,7 @@ class CodexHooksAPI:
         self._ignored_session_ids: Set[str] = set()
 
     def _append_span(self, span: Dict[str, Any]) -> None:
-        self._hooks_api._assembled_spans.append(span)
+        self._hooks_api._append_span(span)
 
     def _replace_session_id_tag(self, span: Dict[str, Any], old_session_id: str, new_session_id: str) -> None:
         tags = span.get("tags", [])
@@ -385,6 +385,7 @@ class CodexHooksAPI:
                     continue
                 span["session_id"] = group_session_id
                 self._replace_session_id_tag(span, old_session_id, group_session_id)
+                self._hooks_api._apply_registered_session_tags(span)
         shared_session = self._hooks_api._sessions.get(raw_session_id)
         if shared_session is not None:
             shared_session.session_id = group_session_id
@@ -695,7 +696,7 @@ class CodexHooksAPI:
         if insert_at is None:
             self._append_span(span)
         else:
-            self._hooks_api._assembled_spans.insert(insert_at, span)
+            self._hooks_api._append_span(span, index=insert_at)
         turn.last_llm_span_ref = span
 
     def _apply_turn_context(self, session: CodexSession, record: Dict[str, Any]) -> None:
@@ -1324,6 +1325,7 @@ class CodexHooksAPI:
             ml_app=self._config.ml_app,
             user_handle=self._config.user_handle,
         )
+        self._hooks_api._apply_registered_session_tags(span)
         tool_call_ids = self._normalize_proxy_tool_call_ids(session, span)
         if append:
             self._append_llm_span(turn, span)
@@ -1876,7 +1878,10 @@ class CodexHooksAPI:
         )
 
     def _dispatch(
-        self, session_id: str, record: Dict[str, Any], proxy_session_key: Optional[str] = None
+        self,
+        session_id: str,
+        record: Dict[str, Any],
+        proxy_session_key: Optional[str] = None,
     ) -> List[CompletedTrace]:
         start_ns = _timestamp_to_ns(record.get("timestamp", ""))
         if session_id in self._ignored_session_ids:
@@ -1884,6 +1889,7 @@ class CodexHooksAPI:
         session = self._get_or_create_session(session_id, start_ns=start_ns)
         if proxy_session_key:
             session.proxy_session_keys.add(proxy_session_key)
+            self._hooks_api._register_session_token(proxy_session_key, session_id)
         if session.raw_session_id in self._ignored_session_ids:
             return []
         try:
@@ -1949,7 +1955,9 @@ class CodexHooksAPI:
                 await self._hooks_api._forward_trace_to_backend(
                     completed_session_id, trace_id=completed_trace_id, span_source="Codex"
                 )
-                await self._hooks_api._forward_eval_metrics_to_backend(completed_session_id, trace_id=completed_trace_id)
+                await self._hooks_api._forward_eval_metrics_to_backend(
+                    completed_session_id, trace_id=completed_trace_id
+                )
         return web.json_response({"status": "ok"})
 
     async def handle_raw_events(self, request: Request) -> web.Response:

--- a/ddapm_test_agent/codex_hooks.py
+++ b/ddapm_test_agent/codex_hooks.py
@@ -362,7 +362,7 @@ class CodexHooksAPI:
         self._ignored_session_ids: Set[str] = set()
 
     def _append_span(self, span: Dict[str, Any]) -> None:
-        self._hooks_api._assembled_spans.append(span)
+        self._hooks_api._append_span(span)
 
     def _replace_session_id_tag(self, span: Dict[str, Any], old_session_id: str, new_session_id: str) -> None:
         tags = span.get("tags", [])
@@ -695,7 +695,7 @@ class CodexHooksAPI:
         if insert_at is None:
             self._append_span(span)
         else:
-            self._hooks_api._assembled_spans.insert(insert_at, span)
+            self._hooks_api._append_span(span, index=insert_at)
         turn.last_llm_span_ref = span
 
     def _apply_turn_context(self, session: CodexSession, record: Dict[str, Any]) -> None:

--- a/ddapm_test_agent/codex_hooks.py
+++ b/ddapm_test_agent/codex_hooks.py
@@ -362,7 +362,7 @@ class CodexHooksAPI:
         self._ignored_session_ids: Set[str] = set()
 
     def _append_span(self, span: Dict[str, Any]) -> None:
-        self._hooks_api._append_span(span)
+        self._hooks_api._assembled_spans.append(span)
 
     def _replace_session_id_tag(self, span: Dict[str, Any], old_session_id: str, new_session_id: str) -> None:
         tags = span.get("tags", [])
@@ -695,7 +695,7 @@ class CodexHooksAPI:
         if insert_at is None:
             self._append_span(span)
         else:
-            self._hooks_api._append_span(span, index=insert_at)
+            self._hooks_api._assembled_spans.insert(insert_at, span)
         turn.last_llm_span_ref = span
 
     def _apply_turn_context(self, session: CodexSession, record: Dict[str, Any]) -> None:

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -311,7 +311,7 @@ class PiHooksAPI:
         return self._hooks_api._current_parent_id(session)
 
     def _append_span(self, span: Dict[str, Any]) -> None:
-        self._hooks_api._assembled_spans.append(span)
+        self._hooks_api._append_span(span)
 
     def _active_step_parent_id(self, session: SessionState) -> str:
         """Return active step span_id if one exists, else fall back to root/agent parent."""
@@ -1069,11 +1069,16 @@ class PiHooksAPI:
             body = await request.json()
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
+        if not isinstance(body, dict):
+            return web.json_response({"error": "JSON body must be an object"}, status=400)
 
         session_id = body.get("session_id", "")
         if not session_id:
             return web.json_response({"error": "missing session_id"}, status=400)
 
+        session_token = body.pop("lapdog_session_token", "")
+        if isinstance(session_token, str) and session_token:
+            self._hooks_api._register_session_token(session_token, session_id)
         self._raw_events.append(body)
         self._dispatch(body)
 

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -311,7 +311,7 @@ class PiHooksAPI:
         return self._hooks_api._current_parent_id(session)
 
     def _append_span(self, span: Dict[str, Any]) -> None:
-        self._hooks_api._append_span(span)
+        self._hooks_api._assembled_spans.append(span)
 
     def _active_step_parent_id(self, session: SessionState) -> str:
         """Return active step span_id if one exists, else fall back to root/agent parent."""
@@ -1128,7 +1128,7 @@ class PiHooksAPI:
         except Exception as exc:
             log.warning("pi backfill_session failed for %s: %r", session_id, exc)
             return web.json_response({"status": "error", "error": repr(exc)}, status=400)
-        self._hooks_api._extend_spans(spans)
+        self._hooks_api._assembled_spans.extend(spans)
         traces = len({s.get("trace_id") for s in spans})
         return web.json_response({"status": "ok", "spans_created": len(spans), "traces_created": traces})
 

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -311,7 +311,7 @@ class PiHooksAPI:
         return self._hooks_api._current_parent_id(session)
 
     def _append_span(self, span: Dict[str, Any]) -> None:
-        self._hooks_api._assembled_spans.append(span)
+        self._hooks_api._append_span(span)
 
     def _active_step_parent_id(self, session: SessionState) -> str:
         """Return active step span_id if one exists, else fall back to root/agent parent."""
@@ -1128,7 +1128,7 @@ class PiHooksAPI:
         except Exception as exc:
             log.warning("pi backfill_session failed for %s: %r", session_id, exc)
             return web.json_response({"status": "error", "error": repr(exc)}, status=400)
-        self._hooks_api._assembled_spans.extend(spans)
+        self._hooks_api._extend_spans(spans)
         traces = len({s.get("trace_id") for s in spans})
         return web.json_response({"status": "ok", "spans_created": len(spans), "traces_created": traces})
 

--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -194,6 +194,17 @@ lapdog status
 lapdog stop
 ```
 
+Claude can tag its current session by running this command from one of its shell
+tool calls:
+
+```bash
+lapdog tags set dd_auto_experiment_id:c0817213-61d4-43d6-8261-050d7560011a iteration:2
+```
+
+The tags are applied to spans already captured for that Claude session and to
+all spans captured afterward. The command only works inside a Claude process
+started with `lapdog claude`.
+
 Open <https://lapdog.datadoghq.com> while a session is running to see traces,
 sessions, costs, and permission friction in real time. The page reads directly
 from your local agent on `localhost:8126` — no Datadog account or login

--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -194,16 +194,16 @@ lapdog status
 lapdog stop
 ```
 
-Claude can tag its current session by running this command from one of its shell
-tool calls:
+Claude or Codex can tag its current session by running this command from one of
+its shell tool calls:
 
 ```bash
 lapdog tags set dd_auto_experiment_id:c0817213-61d4-43d6-8261-050d7560011a iteration:2
 ```
 
-The tags are applied to spans already captured for that Claude session and to
-all spans captured afterward. The command only works inside a Claude process
-started with `lapdog claude`.
+The tags are applied to spans already captured for that coding-agent session and
+to all spans captured afterward. The command only works inside a process
+started with `lapdog claude` or `lapdog codex`.
 
 Open <https://lapdog.datadoghq.com> while a session is running to see traces,
 sessions, costs, and permission friction in real time. The page reads directly

--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -194,16 +194,18 @@ lapdog status
 lapdog stop
 ```
 
-Claude or Codex can tag its current session by running this command from one of
-its shell tool calls:
+Claude, Codex, or Pi can tag its current session by running this command from
+one of its shell tool calls:
 
 ```bash
 lapdog tags set dd_auto_experiment_id:c0817213-61d4-43d6-8261-050d7560011a iteration:2
 ```
 
-The tags are applied to spans already captured for that coding-agent session and
-to all spans captured afterward. The command only works inside a process
-started with `lapdog claude` or `lapdog codex`.
+The tags are applied to spans still retained by the local agent for that
+coding-agent session and to all spans captured afterward. Spans already
+forwarded to Datadog are not resent. The command only works inside a process
+started with `lapdog claude`, `lapdog codex`, or `lapdog pi`. Intrinsic identity
+tags such as `session_id`, `service`, and `env` cannot be overridden.
 
 Open <https://lapdog.datadoghq.com> while a session is running to see traces,
 sessions, costs, and permission friction in real time. The page reads directly

--- a/lapdog/claude_intercept.mjs
+++ b/lapdog/claude_intercept.mjs
@@ -10,13 +10,17 @@
  * Environment variables:
  *   DDAPM_GATEWAY_URL       - Gateway URL (default: http://localhost:8126/claude/proxy)
  *   DDAPM_INTERCEPT_DEBUG   - "true" to enable stderr log messages
+ *   LAPDOG_SESSION_TOKEN    - Correlates hook events with this instrumented Claude process
  */
 
 const proc = typeof process !== 'undefined' ? process : undefined;
 const GATEWAY_URL = (proc?.env?.DDAPM_GATEWAY_URL) || 'http://localhost:8126/claude/proxy';
 const TEST_AGENT_URL = (proc?.env?.TEST_AGENT_URL) || 'http://localhost:8126/info';
+const LAPDOG_URL = (proc?.env?.LAPDOG_URL) || 'http://localhost:8126';
+const DEFAULT_HOOK_URL = 'http://localhost:8126/claude/hooks';
 const TEST_AGENT_CHECK_MS = 500; // low timeout since it should all be local
 const DEBUG = ((proc?.env?.DDAPM_INTERCEPT_DEBUG) || '').toLowerCase() === 'true';
+const LAPDOG_SESSION_TOKEN = (proc?.env?.LAPDOG_SESSION_TOKEN) || '';
 
 // Match URLs that look like Anthropic API calls (Messages API, token counting, etc.)
 // This catches api.anthropic.com, ai-gateway.*.ddbuild.io, and custom ANTHROPIC_BASE_URL hosts.
@@ -93,13 +97,22 @@ if (!child_process.spawn?.[CP_SPAWN_PATCH_MARKER]) {
   const origSpawn = child_process.spawn;
 
   function patchedSpawn (cmd, args, opts) {
+    if (Array.isArray(args)) {
+      const hookUrl = `${LAPDOG_URL.replace(/\/$/, '')}/claude/hooks`;
+      args = args.map(arg => typeof arg === 'string' ? arg.replace(DEFAULT_HOOK_URL, hookUrl) : arg);
+    }
     const child = origSpawn(cmd, args, opts);
     const origWrite = child.stdin.write.bind(child.stdin);
     child.stdin.write = function(data, ...rest) {
       try {
         const parsed = JSON.parse(typeof data === 'string' ? data.trim() : data);
-        if (parsed?.hook_event_name === 'SessionStart') {
-          parsed.lapdog_instrumented = true;
+        if (parsed?.hook_event_name) {
+          if (parsed.hook_event_name === 'SessionStart') {
+            parsed.lapdog_instrumented = true;
+          }
+          if (LAPDOG_SESSION_TOKEN) {
+            parsed.lapdog_session_token = LAPDOG_SESSION_TOKEN;
+          }
           data = JSON.stringify(parsed);
         }
       } catch {}

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -30,7 +30,7 @@ from lapdog.paths import LAPDOG_DIR
 from lapdog.paths import LOG_FILE
 from lapdog.paths import PID_FILE
 
-LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "uninstall"]
+LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "tags", "uninstall"]
 # Managed launchers that also exist as external binaries a user might invoke by
 # an explicit path (e.g. ``lapdog ~/.local/bin/claude``)
 _PATH_ROUTABLE_LAUNCHERS = ("claude", "pi", "codex")
@@ -43,6 +43,7 @@ LAPDOG_USAGE = (
     "  claude     Start lapdog in background if needed, then launch Claude with intercept\n"
     "  pi         Start lapdog in background if needed, install extension, then launch pi\n"
     "  codex      Start lapdog in background if needed, then launch Codex with tracing\n"
+    "  tags       Add tags to the current instrumented Claude session\n"
     "  uninstall  Stop lapdog and remove all state it wrote (~/.lapdog, Claude hooks, pi extension, Codex watchers)\n"
     "\n"
     "Any other command is treated as an app to run with tracing instrumentation:\n"
@@ -306,7 +307,9 @@ def _wait_for_lapdog(proc: "subprocess.Popen[bytes]", log_path: Optional[str] = 
     sys.exit(1)
 
 
-def _run_claude(args: Optional[List[str]] = None) -> None:
+def _run_claude(
+    args: Optional[List[str]] = None, port: Optional[int] = None, session_token: Optional[str] = None
+) -> None:
     """Set BUN_OPTIONS with claude_intercept.mjs and exec the claude binary. Never returns."""
     if args is None:
         args = sys.argv[1:]
@@ -320,9 +323,17 @@ def _run_claude(args: Optional[List[str]] = None) -> None:
     if not claude_bin:
         print("[ddapm] 'claude' not found in PATH", file=sys.stderr)
         sys.exit(1)
-    existing = os.environ.get("BUN_OPTIONS", "")
-    os.environ["BUN_OPTIONS"] = f"--preload {mjs_path} {existing}".strip()
-    os.execv(claude_bin, [claude_bin] + args)
+    env = os.environ.copy()
+    existing = env.get("BUN_OPTIONS", "")
+    env["BUN_OPTIONS"] = f"--preload {mjs_path} {existing}".strip()
+    if port is not None:
+        lapdog_url = f"http://localhost:{port}"
+        env["LAPDOG_URL"] = lapdog_url
+        env["DDAPM_GATEWAY_URL"] = f"{lapdog_url}/claude/proxy"
+        env["TEST_AGENT_URL"] = f"{lapdog_url}/info"
+    if session_token:
+        env["LAPDOG_SESSION_TOKEN"] = session_token
+    os.execve(claude_bin, [claude_bin] + args, env)
 
 
 def cmd_start(sub_cmd_args: List[str], forward_data: bool) -> None:
@@ -468,10 +479,74 @@ def cmd_claude(
 
     if install_plugin:
         _ensure_lapdog_claude_code_plugin_installed()
-    _ensure_lapdog_running(forward_data, detached=True)
+    port = _ensure_lapdog_running(forward_data, detached=True)
+    if port is None:
+        print("[lapdog] Could not determine lapdog port.", file=sys.stderr)
+        sys.exit(1)
     print(build_running_banner(data_type="coding session", warning_lines=_PROXY_SESSION_WARNING_LINES))
 
-    _run_claude(sub_cmd_args)
+    _run_claude(sub_cmd_args, port=port, session_token=uuid.uuid4().hex)
+
+
+def _post_session_tags(lapdog_url: str, session_token: str, tags: Dict[str, str]) -> Dict[str, Any]:
+    request = urllib.request.Request(
+        f"{lapdog_url.rstrip('/')}/claude/hooks/session/tags",
+        data=json.dumps({"tags": tags}).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "X-Lapdog-Session-Token": session_token,
+        },
+        method="POST",
+    )
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    with opener.open(request, timeout=2) as response:
+        result = json.loads(response.read())
+    if not isinstance(result, dict):
+        raise ValueError("Lapdog returned an invalid response")
+    return result
+
+
+def cmd_tags(sub_cmd_args: List[str]) -> None:
+    """Add key:value tags to the current instrumented Claude session."""
+    if len(sub_cmd_args) < 2 or sub_cmd_args[0] != "set":
+        print("Usage: lapdog tags set <key:value> [key:value ...]", file=sys.stderr)
+        sys.exit(1)
+
+    tags: Dict[str, str] = {}
+    for raw_tag in sub_cmd_args[1:]:
+        key, separator, value = raw_tag.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if not separator or not key or not value:
+            print(f"[lapdog] Invalid tag {raw_tag!r}; expected key:value.", file=sys.stderr)
+            sys.exit(1)
+        tags[key] = value
+
+    session_token = os.environ.get("LAPDOG_SESSION_TOKEN", "")
+    lapdog_url = os.environ.get("LAPDOG_URL", "")
+    if not session_token or not lapdog_url:
+        print(
+            "[lapdog] No instrumented Claude session found. Run this command from inside 'lapdog claude'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        result = _post_session_tags(lapdog_url, session_token, tags)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace").strip()
+        print(f"[lapdog] Failed to set session tags: HTTP {exc.code}: {detail}", file=sys.stderr)
+        sys.exit(1)
+    except (OSError, ValueError) as exc:
+        print(f"[lapdog] Failed to set session tags: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    formatted_tags = ", ".join(f"{key}:{value}" for key, value in tags.items())
+    session_id = result.get("session_id")
+    if session_id:
+        print(f"[lapdog] Tagged Claude session {session_id}: {formatted_tags}")
+    else:
+        print(f"[lapdog] Queued tags for the current Claude session: {formatted_tags}")
 
 
 # ---------------------------------------------------------------------------
@@ -1120,6 +1195,8 @@ def main() -> None:
             forward_data=lapdog_parsed_args.forward,
             backfill=backfill,
         )
+    elif sub_cmd == "tags":
+        cmd_tags(sub_cmd_args)
     elif sub_cmd == "uninstall":
         cmd_uninstall()
 

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -488,10 +488,18 @@ def cmd_claude(
     _run_claude(sub_cmd_args, port=port, session_token=uuid.uuid4().hex)
 
 
-def _post_session_tags(lapdog_url: str, session_token: str, tags: Dict[str, str]) -> Dict[str, Any]:
+def _post_session_tags(
+    lapdog_url: str,
+    session_token: str,
+    tags: Dict[str, str],
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    body: Dict[str, Any] = {"tags": tags}
+    if session_id:
+        body["session_id"] = session_id
     request = urllib.request.Request(
         f"{lapdog_url.rstrip('/')}/lapdog/session/tags",
-        data=json.dumps({"tags": tags}).encode(),
+        data=json.dumps(body).encode(),
         headers={
             "Content-Type": "application/json",
             "X-Lapdog-Session-Token": session_token,
@@ -507,7 +515,7 @@ def _post_session_tags(lapdog_url: str, session_token: str, tags: Dict[str, str]
 
 
 def cmd_tags(sub_cmd_args: List[str]) -> None:
-    """Add key:value tags to the current instrumented Claude session."""
+    """Add key:value tags to the current instrumented coding-agent session."""
     if len(sub_cmd_args) < 2 or sub_cmd_args[0] != "set":
         print("Usage: lapdog tags set <key:value> [key:value ...]", file=sys.stderr)
         sys.exit(1)
@@ -524,15 +532,17 @@ def cmd_tags(sub_cmd_args: List[str]) -> None:
 
     session_token = os.environ.get("LAPDOG_SESSION_TOKEN", "")
     lapdog_url = os.environ.get("LAPDOG_URL", "")
+    target_session_id = os.environ.get("CODEX_THREAD_ID") or None
     if not session_token or not lapdog_url:
         print(
-            "[lapdog] No instrumented Claude session found. Run this command from inside 'lapdog claude'.",
+            "[lapdog] No instrumented coding-agent session found. "
+            "Run this command from inside a session started with 'lapdog claude' or 'lapdog codex'.",
             file=sys.stderr,
         )
         sys.exit(1)
 
     try:
-        result = _post_session_tags(lapdog_url, session_token, tags)
+        result = _post_session_tags(lapdog_url, session_token, tags, session_id=target_session_id)
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace").strip()
         print(f"[lapdog] Failed to set session tags: HTTP {exc.code}: {detail}", file=sys.stderr)
@@ -542,11 +552,11 @@ def cmd_tags(sub_cmd_args: List[str]) -> None:
         sys.exit(1)
 
     formatted_tags = ", ".join(f"{key}:{value}" for key, value in tags.items())
-    session_id = result.get("session_id")
-    if session_id:
-        print(f"[lapdog] Tagged Claude session {session_id}: {formatted_tags}")
+    tagged_session_id = result.get("session_id")
+    if tagged_session_id:
+        print(f"[lapdog] Tagged coding-agent session {tagged_session_id}: {formatted_tags}")
     else:
-        print(f"[lapdog] Queued tags for the current Claude session: {formatted_tags}")
+        print(f"[lapdog] Queued tags for the current coding-agent session: {formatted_tags}")
 
 
 # ---------------------------------------------------------------------------
@@ -693,8 +703,13 @@ def _codex_watcher_matches(
         return False
     if include_all_cwds is not None and ("--include-all-cwds" in parts) is not include_all_cwds:
         return False
-    if proxy_session_key is not None and _arg_value(parts, "--proxy-session-key") != proxy_session_key:
-        return False
+    if proxy_session_key is not None:
+        actual_proxy_session_key = _arg_value(parts, "--proxy-session-key")
+        if proxy_session_key:
+            if actual_proxy_session_key != proxy_session_key:
+                return False
+        elif actual_proxy_session_key is not None:
+            return False
     return True
 
 
@@ -851,6 +866,7 @@ def _start_codex_watcher(
     log_dir = os.path.dirname(log_path)
     os.makedirs(log_dir, exist_ok=True)
     lapdog_url = f"http://localhost:{port}"
+    expected_proxy_session_key = "" if include_all_cwds and proxy_session_key is None else proxy_session_key
     if singleton_key:
         pid_path = _codex_watcher_pid_file(log_dir, singleton_key)
         existing_pid, _ = _read_pid_file(path=pid_path)
@@ -859,7 +875,7 @@ def _start_codex_watcher(
             watcher_parent_pid,
             lapdog_url=lapdog_url,
             include_all_cwds=include_all_cwds,
-            proxy_session_key=proxy_session_key,
+            proxy_session_key=expected_proxy_session_key,
         ):
             print(
                 f"[lapdog] Codex watcher already running for this app workspace (PID {existing_pid}).",
@@ -996,7 +1012,7 @@ def cmd_codex(sub_cmd_args: List[str], forward_data: bool, backfill: bool = Fals
         _stop_legacy_codex_app_watchers(port, parent_pid, codex_args.app_watcher_key(port))
     _start_codex_watcher(
         port,
-        proxy_session_key=session_token,
+        proxy_session_key=proxy_session_key,
         cwd=codex_cwd,
         parent_pid=parent_pid,
         singleton_key=codex_args.app_watcher_key(port) if app_mode else None,

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -490,7 +490,7 @@ def cmd_claude(
 
 def _post_session_tags(lapdog_url: str, session_token: str, tags: Dict[str, str]) -> Dict[str, Any]:
     request = urllib.request.Request(
-        f"{lapdog_url.rstrip('/')}/claude/hooks/session/tags",
+        f"{lapdog_url.rstrip('/')}/lapdog/session/tags",
         data=json.dumps({"tags": tags}).encode(),
         headers={
             "Content-Type": "application/json",
@@ -673,6 +673,7 @@ def _codex_watcher_matches(
     parent_pid: Optional[int] = None,
     lapdog_url: Optional[str] = None,
     include_all_cwds: Optional[bool] = None,
+    proxy_session_key: Optional[str] = None,
 ) -> bool:
     """Return True when a live process matches the expected watcher metadata."""
     if not _process_exists(pid):
@@ -692,6 +693,8 @@ def _codex_watcher_matches(
         return False
     if include_all_cwds is not None and ("--include-all-cwds" in parts) is not include_all_cwds:
         return False
+    if proxy_session_key is not None and _arg_value(parts, "--proxy-session-key") != proxy_session_key:
+        return False
     return True
 
 
@@ -700,6 +703,7 @@ def _codex_watcher_reusable(
     parent_pid: int,
     lapdog_url: Optional[str] = None,
     include_all_cwds: Optional[bool] = None,
+    proxy_session_key: Optional[str] = None,
 ) -> bool:
     """Return True only when a pid file points at the expected watcher process.
 
@@ -712,6 +716,7 @@ def _codex_watcher_reusable(
         parent_pid=parent_pid,
         lapdog_url=lapdog_url,
         include_all_cwds=include_all_cwds,
+        proxy_session_key=proxy_session_key,
     )
 
 
@@ -854,6 +859,7 @@ def _start_codex_watcher(
             watcher_parent_pid,
             lapdog_url=lapdog_url,
             include_all_cwds=include_all_cwds,
+            proxy_session_key=proxy_session_key,
         ):
             print(
                 f"[lapdog] Codex watcher already running for this app workspace (PID {existing_pid}).",
@@ -918,7 +924,10 @@ def _start_codex_watcher(
 
 
 def _run_codex(
-    args: Optional[List[str]] = None, port: Optional[int] = None, proxy_session_key: Optional[str] = None
+    args: Optional[List[str]] = None,
+    port: Optional[int] = None,
+    proxy_session_key: Optional[str] = None,
+    session_token: Optional[str] = None,
 ) -> None:
     """Exec the codex binary, forwarding arguments. Never returns."""
     if args is None:
@@ -933,6 +942,7 @@ def _run_codex(
         proxy_path = f"/codex/proxy/{proxy_session_key}/v1" if proxy_session_key else "/codex/proxy/v1"
         base_url = f"http://localhost:{port}{proxy_path}"
         env["OPENAI_BASE_URL"] = base_url
+        env["LAPDOG_URL"] = f"http://localhost:{port}"
         if env.get("OPENAI_API_KEY"):
             proxy_args = [
                 "-c",
@@ -948,6 +958,8 @@ def _run_codex(
                 "[lapdog] Codex proxy capture requires OPENAI_API_KEY; continuing with JSONL-only tracing.",
                 file=sys.stderr,
             )
+    if session_token:
+        env["LAPDOG_SESSION_TOKEN"] = session_token
     os.execve(codex_bin, [codex_bin] + proxy_args + args, env)
 
 
@@ -973,7 +985,8 @@ def cmd_codex(sub_cmd_args: List[str], forward_data: bool, backfill: bool = Fals
         print("[lapdog] Could not determine lapdog port.", file=sys.stderr)
         sys.exit(1)
     app_mode = codex_args.is_app_command(sub_cmd_args)
-    proxy_session_key = None if app_mode else uuid.uuid4().hex
+    session_token = uuid.uuid4().hex
+    proxy_session_key = None if app_mode else session_token
     parent_pid = os.getpid()
     if app_mode:
         lapdog_pid, _ = _read_pid_file()
@@ -983,7 +996,7 @@ def cmd_codex(sub_cmd_args: List[str], forward_data: bool, backfill: bool = Fals
         _stop_legacy_codex_app_watchers(port, parent_pid, codex_args.app_watcher_key(port))
     _start_codex_watcher(
         port,
-        proxy_session_key=proxy_session_key,
+        proxy_session_key=session_token,
         cwd=codex_cwd,
         parent_pid=parent_pid,
         singleton_key=codex_args.app_watcher_key(port) if app_mode else None,
@@ -991,7 +1004,12 @@ def cmd_codex(sub_cmd_args: List[str], forward_data: bool, backfill: bool = Fals
     )
 
     print(build_running_banner(data_type="coding session", warning_lines=_PROXY_SESSION_WARNING_LINES))
-    _run_codex(args=sub_cmd_args, port=port, proxy_session_key=proxy_session_key)
+    _run_codex(
+        args=sub_cmd_args,
+        port=port,
+        proxy_session_key=proxy_session_key,
+        session_token=session_token,
+    )
 
 
 def cmd_uninstall() -> None:

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -43,7 +43,7 @@ LAPDOG_USAGE = (
     "  claude     Start lapdog in background if needed, then launch Claude with intercept\n"
     "  pi         Start lapdog in background if needed, install extension, then launch pi\n"
     "  codex      Start lapdog in background if needed, then launch Codex with tracing\n"
-    "  tags       Add tags to the current instrumented Claude session\n"
+    "  tags       Add tags to the current instrumented coding-agent session\n"
     "  uninstall  Stop lapdog and remove all state it wrote (~/.lapdog, Claude hooks, pi extension, Codex watchers)\n"
     "\n"
     "Any other command is treated as an app to run with tracing instrumentation:\n"
@@ -324,6 +324,8 @@ def _run_claude(
         print("[ddapm] 'claude' not found in PATH", file=sys.stderr)
         sys.exit(1)
     env = os.environ.copy()
+    for variable in ("CODEX_THREAD_ID", "PI_SESSION_ID", "LAPDOG_SESSION_TOKEN"):
+        env.pop(variable, None)
     existing = env.get("BUN_OPTIONS", "")
     env["BUN_OPTIONS"] = f"--preload {mjs_path} {existing}".strip()
     if port is not None:
@@ -532,11 +534,11 @@ def cmd_tags(sub_cmd_args: List[str]) -> None:
 
     session_token = os.environ.get("LAPDOG_SESSION_TOKEN", "")
     lapdog_url = os.environ.get("LAPDOG_URL", "")
-    target_session_id = os.environ.get("CODEX_THREAD_ID") or None
+    target_session_id = os.environ.get("CODEX_THREAD_ID") or os.environ.get("PI_SESSION_ID") or None
     if not session_token or not lapdog_url:
         print(
             "[lapdog] No instrumented coding-agent session found. "
-            "Run this command from inside a session started with 'lapdog claude' or 'lapdog codex'.",
+            "Run this command from inside a session started with 'lapdog claude', 'lapdog codex', or 'lapdog pi'.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -572,7 +574,7 @@ def _install_pi_extension() -> None:
     """Copy the bundled lapdog extension into pi's global extensions directory.
 
     If the extension is already installed and identical, skip the copy.
-    LAPDOG_URL is injected at runtime via environment variable when pi is launched.
+    Lapdog URL and session context are injected via environment variables when pi is launched.
     """
     if not os.path.isfile(_PI_EXT_SOURCE):
         print(f"[lapdog] Extension source not found: {_PI_EXT_SOURCE}", file=sys.stderr)
@@ -604,7 +606,11 @@ def _install_pi_extension() -> None:
         print(f"[lapdog] Installed pi extension → {_PI_EXT_DEST}")
 
 
-def _run_pi(args: Optional[List[str]] = None, port: Optional[int] = 8126) -> None:
+def _run_pi(
+    args: Optional[List[str]] = None,
+    port: Optional[int] = 8126,
+    session_token: Optional[str] = None,
+) -> None:
     """Exec the pi binary, forwarding arguments.  Never returns."""
     if args is None:
         args = []
@@ -613,6 +619,10 @@ def _run_pi(args: Optional[List[str]] = None, port: Optional[int] = 8126) -> Non
         print("[lapdog] 'pi' not found in PATH", file=sys.stderr)
         sys.exit(1)
     env = {**os.environ, "LAPDOG_URL": f"http://localhost:{port}"}
+    for variable in ("CODEX_THREAD_ID", "PI_SESSION_ID", "LAPDOG_SESSION_TOKEN"):
+        env.pop(variable, None)
+    if session_token:
+        env["LAPDOG_SESSION_TOKEN"] = session_token
     os.execve(pi_bin, [pi_bin] + args, env)
 
 
@@ -636,7 +646,7 @@ def cmd_pi(sub_cmd_args: List[str], forward_data: bool, backfill: bool = False) 
     _install_pi_extension()
 
     print(build_running_banner(data_type="coding session"))
-    _run_pi(args=sub_cmd_args, port=port)
+    _run_pi(args=sub_cmd_args, port=port, session_token=uuid.uuid4().hex)
 
 
 def _codex_watcher_pid_file(log_dir: str, singleton_key: str) -> str:
@@ -953,6 +963,8 @@ def _run_codex(
         print("[lapdog] 'codex' not found in PATH", file=sys.stderr)
         sys.exit(1)
     env = os.environ.copy()
+    for variable in ("CODEX_THREAD_ID", "PI_SESSION_ID", "LAPDOG_SESSION_TOKEN"):
+        env.pop(variable, None)
     proxy_args: List[str] = []
     if port is not None:
         proxy_path = f"/codex/proxy/{proxy_session_key}/v1" if proxy_session_key else "/codex/proxy/v1"

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -536,9 +536,10 @@ def cmd_tags(sub_cmd_args: List[str]) -> None:
     lapdog_url = os.environ.get("LAPDOG_URL", "")
     target_session_id = os.environ.get("CODEX_THREAD_ID") or os.environ.get("PI_SESSION_ID") or None
     if not session_token or not lapdog_url:
+        supported_launchers = ", ".join(f"'lapdog {launcher}'" for launcher in _PATH_ROUTABLE_LAUNCHERS)
         print(
             "[lapdog] No instrumented coding-agent session found. "
-            "Run this command from inside a session started with 'lapdog claude', 'lapdog codex', or 'lapdog pi'.",
+            f"Run this command from inside a session started with one of: {supported_launchers}.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/lapdog/pi_lapdog_extension.ts
+++ b/lapdog/pi_lapdog_extension.ts
@@ -17,6 +17,7 @@
 import { convertToLlm, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 const LAPDOG_URL = process.env.LAPDOG_URL || "http://localhost:8126";
+const LAPDOG_SESSION_TOKEN = process.env.LAPDOG_SESSION_TOKEN || "";
 const HOOKS_ENDPOINT = `${LAPDOG_URL}/pi/hooks`;
 
 // ---------------------------------------------------------------------------
@@ -45,7 +46,13 @@ function post(event: string, sessionId: string, data: Record<string, unknown>, c
 		fetch(HOOKS_ENDPOINT, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ hook_event_name: event, session_id: sessionId, cwd: getCwd(ctx), ...data }),
+			body: JSON.stringify({
+				hook_event_name: event,
+				session_id: sessionId,
+				lapdog_session_token: LAPDOG_SESSION_TOKEN || undefined,
+				cwd: getCwd(ctx),
+				...data,
+			}),
 			signal: AbortSignal.timeout(2000),
 		}).catch(() => {});
 	} catch {
@@ -109,6 +116,7 @@ export default function lapdog(pi: ExtensionAPI): void {
 
 	pi.on("session_start", (_event, ctx) => {
 		sessionId = ctx.sessionManager.getSessionId();
+		process.env.PI_SESSION_ID = sessionId;
 		const model = ctx.model;
 		if (model) {
 			currentModel = model.id;

--- a/releasenotes/notes/lapdog-tags-set-command-36c0c615db86b557.yaml
+++ b/releasenotes/notes/lapdog-tags-set-command-36c0c615db86b557.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add a ``lapdog tags set`` command to allow agents to add custom tags
+    to their own Lapdog spans.

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -195,6 +195,76 @@ async def test_session_tags_reject_ambiguous_launch_token(agent):
     assert all("iteration:2" not in span["tags"] for span in spans)
 
 
+async def test_session_tags_reject_session_registered_to_another_launch_token(agent):
+    session_id = "session-owned-by-another-token"
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "SessionStart",
+            "lapdog_session_token": "owner-token",
+        },
+    )
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "keep this session isolated",
+        },
+    )
+
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": "unrelated-token"},
+        json={
+            "session_id": session_id,
+            "tags": {"iteration": "2"},
+        },
+    )
+    assert response.status == 409
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = [span for span in (await response.json())["spans"] if span.get("session_id") == session_id]
+    assert spans
+    assert all("iteration:2" not in span["tags"] for span in spans)
+
+
+async def test_session_tags_reject_reserved_identity_keys(agent):
+    session_id = "session-reserved-tags"
+    session_token = "reserved-tags-token"
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "SessionStart",
+            "lapdog_session_token": session_token,
+        },
+    )
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "preserve identity tags",
+        },
+    )
+
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"tags": {"service": "wrong-service", "session_id": "wrong-session"}},
+    )
+    assert response.status == 400
+    assert "reserved tag keys" in (await response.json())["error"]
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = [span for span in (await response.json())["spans"] if span.get("session_id") == session_id]
+    assert spans
+    assert all("service:wrong-service" not in span["tags"] for span in spans)
+    assert all("session_id:wrong-session" not in span["tags"] for span in spans)
+
+
 async def test_session_tags_require_launch_token(agent):
     response = await agent.post(
         "/claude/hooks/session/tags",

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -131,9 +131,68 @@ async def test_session_tags_queue_until_hook_registers_launch_token(agent):
     assert spans
     assert all("iteration:2" in span["tags"] for span in spans)
 
+    second_session_id = "sess-after-queued-tags"
+    await _post_hook(
+        agent,
+        {
+            "session_id": second_session_id,
+            "hook_event_name": "SessionStart",
+            "lapdog_session_token": session_token,
+        },
+    )
+    await _post_hook(
+        agent,
+        {
+            "session_id": second_session_id,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "do not reuse consumed queued tags",
+        },
+    )
+    response = await agent.get("/claude/hooks/spans")
+    second_session_spans = [
+        span for span in (await response.json())["spans"] if span.get("session_id") == second_session_id
+    ]
+    assert second_session_spans
+    assert all("iteration:2" not in span["tags"] for span in second_session_spans)
+
     response = await agent.get("/claude/hooks/raw")
     raw_events = (await response.json())["events"]
     assert all("lapdog_session_token" not in event for event in raw_events)
+
+
+async def test_session_tags_reject_ambiguous_launch_token(agent):
+    session_token = "shared-launch-token"
+    session_ids = ["shared-session-a", "shared-session-b"]
+    for session_id in session_ids:
+        await _post_hook(
+            agent,
+            {
+                "session_id": session_id,
+                "hook_event_name": "SessionStart",
+                "lapdog_session_token": session_token,
+            },
+        )
+        await _post_hook(
+            agent,
+            {
+                "session_id": session_id,
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": session_id,
+            },
+        )
+
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"tags": {"iteration": "2"}},
+    )
+    assert response.status == 409
+    assert (await response.json())["session_ids"] == session_ids
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = [span for span in (await response.json())["spans"] if span.get("session_id") in session_ids]
+    assert spans
+    assert all("iteration:2" not in span["tags"] for span in spans)
 
 
 async def test_session_tags_require_launch_token(agent):

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -37,36 +37,111 @@ async def test_hook_missing_session_id(agent):
     assert "session_id" in body["error"]
 
 
-def test_dd_tags_are_read_when_each_span_is_created(monkeypatch):
-    hooks = ClaudeHooksAPI()
+async def test_session_tags_apply_to_existing_and_future_spans(agent):
+    session_id = "sess-custom-tags"
+    session_token = "launch-token"
+    custom_tags = {
+        "dd_auto_experiment_id": "c0817213-61d4-43d6-8261-050d7560011a",
+        "iteration": "2",
+    }
 
-    monkeypatch.delenv("DD_TAGS", raising=False)
-    without_tags = {"tags": ["existing:value"]}
-    hooks._append_span(without_tags)
-
-    monkeypatch.setenv(
-        "DD_TAGS",
-        "dd_auto_experiment_id:c0817213-61d4-43d6-8261-050d7560011a,iteration:2",
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "SessionStart",
+            "lapdog_session_token": session_token,
+        },
     )
-    with_tags = {"tags": ["existing:value"]}
-    hooks._append_span(with_tags)
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "tag this session",
+        },
+    )
 
-    assert without_tags["tags"] == ["existing:value"]
-    assert with_tags["tags"] == [
-        "existing:value",
-        "dd_auto_experiment_id:c0817213-61d4-43d6-8261-050d7560011a",
-        "iteration:2",
-    ]
+    response = await agent.post(
+        "/claude/hooks/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"tags": custom_tags},
+    )
+    assert response.status == 200, await response.text()
+
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "tool-after-tags",
+            "tool_input": {"command": "pwd"},
+        },
+    )
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "tool-after-tags",
+            "tool_response": "/tmp",
+        },
+    )
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = [span for span in (await response.json())["spans"] if span.get("session_id") == session_id]
+    assert len(spans) >= 2
+    for span in spans:
+        assert "dd_auto_experiment_id:c0817213-61d4-43d6-8261-050d7560011a" in span["tags"]
+        assert "iteration:2" in span["tags"]
 
 
-def test_malformed_dd_tags_are_rejected_atomically(monkeypatch):
-    hooks = ClaudeHooksAPI()
+async def test_session_tags_queue_until_hook_registers_launch_token(agent):
+    session_id = "sess-queued-tags"
+    session_token = "queued-launch-token"
+    response = await agent.post(
+        "/claude/hooks/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"tags": {"iteration": "2"}},
+    )
+    assert response.status == 200
+    assert (await response.json())["session_ids"] == []
 
-    for value in ("key", "key:", ":value", "key:value,", "key:value,broken", "key:value:extra"):
-        monkeypatch.setenv("DD_TAGS", value)
-        span = {"tags": ["existing:value"]}
-        hooks._append_span(span)
-        assert span["tags"] == ["existing:value"]
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "SessionStart",
+            "lapdog_session_token": session_token,
+        },
+    )
+    await _post_hook(
+        agent,
+        {
+            "session_id": session_id,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "use queued tags",
+        },
+    )
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = [span for span in (await response.json())["spans"] if span.get("session_id") == session_id]
+    assert spans
+    assert all("iteration:2" in span["tags"] for span in spans)
+
+    response = await agent.get("/claude/hooks/raw")
+    raw_events = (await response.json())["events"]
+    assert all("lapdog_session_token" not in event for event in raw_events)
+
+
+async def test_session_tags_require_launch_token(agent):
+    response = await agent.post(
+        "/claude/hooks/session/tags",
+        json={"tags": {"iteration": "2"}},
+    )
+    assert response.status == 404
 
 
 async def test_hook_session_creates_agent_span(agent):

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -37,6 +37,38 @@ async def test_hook_missing_session_id(agent):
     assert "session_id" in body["error"]
 
 
+def test_dd_tags_are_read_when_each_span_is_created(monkeypatch):
+    hooks = ClaudeHooksAPI()
+
+    monkeypatch.delenv("DD_TAGS", raising=False)
+    without_tags = {"tags": ["existing:value"]}
+    hooks._append_span(without_tags)
+
+    monkeypatch.setenv(
+        "DD_TAGS",
+        "dd_auto_experiment_id:c0817213-61d4-43d6-8261-050d7560011a,iteration:2",
+    )
+    with_tags = {"tags": ["existing:value"]}
+    hooks._append_span(with_tags)
+
+    assert without_tags["tags"] == ["existing:value"]
+    assert with_tags["tags"] == [
+        "existing:value",
+        "dd_auto_experiment_id:c0817213-61d4-43d6-8261-050d7560011a",
+        "iteration:2",
+    ]
+
+
+def test_malformed_dd_tags_are_rejected_atomically(monkeypatch):
+    hooks = ClaudeHooksAPI()
+
+    for value in ("key", "key:", ":value", "key:value,", "key:value,broken", "key:value:extra"):
+        monkeypatch.setenv("DD_TAGS", value)
+        span = {"tags": ["existing:value"]}
+        hooks._append_span(span)
+        assert span["tags"] == ["existing:value"]
+
+
 async def test_hook_session_creates_agent_span(agent):
     session_id = "sess-agent-span"
 

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -227,6 +227,23 @@ async def test_codex_session_tags_apply_to_existing_and_future_spans(agent):
         assert "iteration:2" in span["tags"]
 
 
+async def test_codex_raw_events_redact_launch_token(agent):
+    session_id = "codex-redacted-launch-token"
+    await _post(
+        agent,
+        session_id,
+        _session_meta(session_id),
+        proxy_session_key="codex-secret-launch-token",
+    )
+
+    response = await agent.get("/codex/hooks/raw")
+    assert response.status == 200
+    raw_events = (await response.json())["events"]
+    assert raw_events
+    assert all("proxy_session_key" not in event for event in raw_events)
+    assert "codex-secret-launch-token" not in json.dumps(raw_events)
+
+
 async def test_codex_session_tags_target_only_requested_thread(agent):
     session_token = "shared-codex-app-token"
     targeted_sid = "codex-app-targeted"
@@ -1633,6 +1650,100 @@ async def test_codex_child_thread_spans_are_grouped_with_parent_session(agent):
     assert f"session_id:{sid}" in child_turn["tags"]
     assert f"session_id:{child_sid}" not in child_turn["tags"]
     assert [s for s in spans if s.get("session_id") == child_sid] == []
+
+
+async def test_codex_grouped_sessions_keep_latest_tags_on_future_child_spans(agent):
+    parent_sid = "codex-tagged-parent"
+    child_sid = "codex-tagged-child"
+    session_token = "codex-grouped-token"
+    await _post(agent, parent_sid, _session_meta(parent_sid), proxy_session_key=session_token)
+    await _post(agent, parent_sid, _turn_context())
+    await _post(agent, parent_sid, _event("user_message", message="delegate"))
+    await _post(
+        agent,
+        parent_sid,
+        _event(
+            "collab_agent_spawn_begin",
+            timestamp="2026-05-11T17:00:02.500Z",
+            call_id="spawn-tagged-child",
+            sender_thread_id=parent_sid,
+            prompt="do the thing",
+        ),
+    )
+
+    await _post(agent, child_sid, _session_meta(child_sid), proxy_session_key=session_token)
+    await _post(agent, child_sid, _turn_context("child-turn"))
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"session_id": child_sid, "tags": {"iteration": "child"}},
+    )
+    assert response.status == 200, await response.text()
+
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"session_id": parent_sid, "tags": {"iteration": "parent"}},
+    )
+    assert response.status == 200, await response.text()
+
+    await _post(
+        agent,
+        parent_sid,
+        _event(
+            "collab_agent_spawn_end",
+            timestamp="2026-05-11T17:00:04.000Z",
+            call_id="spawn-tagged-child",
+            new_thread_id=child_sid,
+            new_agent_nickname="researcher",
+            status="ok",
+        ),
+    )
+
+    await _post(
+        agent,
+        child_sid,
+        _event(
+            "user_message",
+            timestamp="2026-05-11T17:00:05.000Z",
+            message="child work after parent tag update",
+        ),
+    )
+    await _post(
+        agent,
+        child_sid,
+        _response_item(
+            "function_call",
+            timestamp="2026-05-11T17:00:06.000Z",
+            name="exec_command",
+            call_id="child-call-after-tag-update",
+            arguments='{"cmd": "pwd"}',
+        ),
+    )
+    await _post(
+        agent,
+        child_sid,
+        _response_item(
+            "function_call_output",
+            timestamp="2026-05-11T17:00:07.000Z",
+            call_id="child-call-after-tag-update",
+            output="/tmp/project",
+        ),
+    )
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = _spans(await response.json())
+    child_turn = next(span for span in spans if span.get("meta", {}).get("metadata", {}).get("turn_id") == "child-turn")
+    child_tool = next(
+        span
+        for span in _by_kind(spans, "tool")
+        if span.get("meta", {}).get("metadata", {}).get("tool_id") == "child-call-after-tag-update"
+    )
+    assert child_turn["session_id"] == parent_sid
+    assert "iteration:parent" in child_turn["tags"]
+    assert "iteration:child" not in child_turn["tags"]
+    assert "iteration:parent" in child_tool["tags"]
+    assert "iteration:child" not in child_tool["tags"]
 
 
 async def test_codex_compaction_event_msg_annotates_active_span(agent):

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -22,10 +22,12 @@ def codex_env_overrides(monkeypatch):
     monkeypatch.setenv("DD_USER_HANDLE", "shared-user")
 
 
-async def _post(agent, session_id, record, *, backfill=False):
+async def _post(agent, session_id, record, *, backfill=False, proxy_session_key=None):
     body = {"session_id": session_id, "record": record}
     if backfill:
         body["backfill"] = True
+    if proxy_session_key:
+        body["proxy_session_key"] = proxy_session_key
     return await agent.post(
         "/codex/hooks",
         headers={"Content-Type": "application/json"},
@@ -177,6 +179,49 @@ async def test_codex_turn_llm_and_tool_spans(agent):
     assert llms[0]["metrics"]["estimated_input_cost"] == 410_000
     assert llms[0]["metrics"]["estimated_output_cost"] == 900_000
     assert llms[0]["metrics"]["estimated_total_cost"] == 1_310_000
+
+
+async def test_codex_session_tags_apply_to_existing_and_future_spans(agent):
+    sid = "codex-custom-tags"
+    session_token = "codex-launch-token"
+    await _post(agent, sid, _session_meta(sid), proxy_session_key=session_token)
+    await _post(agent, sid, _turn_context())
+    await _post(agent, sid, _event("user_message", message="tag this Codex session"))
+
+    response = await agent.get("/claude/hooks/spans")
+    spans_before_tags = [span for span in _spans(await response.json()) if span.get("session_id") == sid]
+    assert spans_before_tags
+
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"tags": {"dd_auto_experiment_id": "experiment-id", "iteration": "2"}},
+    )
+    assert response.status == 200, await response.text()
+
+    await _post(
+        agent,
+        sid,
+        _response_item(
+            "function_call",
+            name="exec_command",
+            call_id="call-after-tags",
+            arguments='{"cmd": "pwd"}',
+        ),
+    )
+    await _post(
+        agent,
+        sid,
+        _response_item("function_call_output", call_id="call-after-tags", output="/repo"),
+    )
+    await _post(agent, sid, _event("agent_message", message="done"))
+
+    response = await agent.get("/claude/hooks/spans")
+    session_spans = [span for span in _spans(await response.json()) if span.get("session_id") == sid]
+    assert len(session_spans) > len(spans_before_tags)
+    for span in session_spans:
+        assert "dd_auto_experiment_id:experiment-id" in span["tags"]
+        assert "iteration:2" in span["tags"]
 
 
 async def test_codex_project_metadata_from_session_git(agent):

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -195,7 +195,10 @@ async def test_codex_session_tags_apply_to_existing_and_future_spans(agent):
     response = await agent.post(
         "/lapdog/session/tags",
         headers={"X-Lapdog-Session-Token": session_token},
-        json={"tags": {"dd_auto_experiment_id": "experiment-id", "iteration": "2"}},
+        json={
+            "session_id": sid,
+            "tags": {"dd_auto_experiment_id": "experiment-id", "iteration": "2"},
+        },
     )
     assert response.status == 200, await response.text()
 
@@ -222,6 +225,70 @@ async def test_codex_session_tags_apply_to_existing_and_future_spans(agent):
     for span in session_spans:
         assert "dd_auto_experiment_id:experiment-id" in span["tags"]
         assert "iteration:2" in span["tags"]
+
+
+async def test_codex_session_tags_target_only_requested_thread(agent):
+    session_token = "shared-codex-app-token"
+    targeted_sid = "codex-app-targeted"
+    unrelated_sid = "codex-app-unrelated"
+    for sid in (targeted_sid, unrelated_sid):
+        await _post(agent, sid, _session_meta(sid), proxy_session_key=session_token)
+        await _post(agent, sid, _turn_context(f"{sid}-turn"))
+        await _post(agent, sid, _event("user_message", message=sid))
+
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"session_id": targeted_sid, "tags": {"iteration": "2"}},
+    )
+    assert response.status == 200, await response.text()
+    assert (await response.json())["session_ids"] == [targeted_sid]
+
+    for sid in (targeted_sid, unrelated_sid):
+        await _post(
+            agent,
+            sid,
+            _response_item(
+                "function_call",
+                name="exec_command",
+                call_id=f"{sid}-call",
+                arguments='{"cmd": "pwd"}',
+            ),
+        )
+        await _post(
+            agent,
+            sid,
+            _response_item("function_call_output", call_id=f"{sid}-call", output="/repo"),
+        )
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = _spans(await response.json())
+    targeted_spans = [span for span in spans if span.get("session_id") == targeted_sid]
+    unrelated_spans = [span for span in spans if span.get("session_id") == unrelated_sid]
+    assert targeted_spans
+    assert unrelated_spans
+    assert all("iteration:2" in span["tags"] for span in targeted_spans)
+    assert all("iteration:2" not in span["tags"] for span in unrelated_spans)
+
+
+async def test_codex_session_tags_can_target_thread_before_watcher_posts(agent):
+    sid = "codex-app-watcher-race"
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": "app-launch-token"},
+        json={"session_id": sid, "tags": {"iteration": "2"}},
+    )
+    assert response.status == 200, await response.text()
+    assert (await response.json())["session_id"] == sid
+
+    await _post(agent, sid, _session_meta(sid))
+    await _post(agent, sid, _turn_context())
+    await _post(agent, sid, _event("user_message", message="watcher arrived"))
+
+    response = await agent.get("/claude/hooks/spans")
+    session_spans = [span for span in _spans(await response.json()) if span.get("session_id") == sid]
+    assert session_spans
+    assert all("iteration:2" in span["tags"] for span in session_spans)
 
 
 async def test_codex_project_metadata_from_session_git(agent):

--- a/tests/test_lapdog_cli.py
+++ b/tests/test_lapdog_cli.py
@@ -11,6 +11,11 @@ def test_codex_command_is_registered():
     assert "codex" in cli.LAPDOG_USAGE
 
 
+def test_tags_command_is_registered():
+    assert "tags" in cli.LAPDOG_COMMANDS
+    assert "tags" in cli.LAPDOG_USAGE
+
+
 def test_cmd_codex_starts_watcher_and_execs_codex():
     with mock.patch("lapdog.cli._ensure_lapdog_running", return_value=8126) as ensure:
         with mock.patch("lapdog.cli._start_codex_watcher") as start_watcher:
@@ -595,9 +600,10 @@ def test_cmd_claude_auto_installs_plugin_by_default():
         with mock.patch("lapdog.cli._ensure_lapdog_running", return_value=8126):
             with mock.patch("lapdog.cli.build_running_banner", return_value="banner"):
                 with mock.patch("lapdog.cli._run_claude") as run_claude:
-                    cli.cmd_claude(["--model", "opus"], forward_data=False, install_plugin=True)
+                    with mock.patch("lapdog.cli.uuid.uuid4", return_value=mock.Mock(hex="launch-token")):
+                        cli.cmd_claude(["--model", "opus"], forward_data=False, install_plugin=True)
     install.assert_called_once_with()
-    run_claude.assert_called_once_with(["--model", "opus"])
+    run_claude.assert_called_once_with(["--model", "opus"], port=8126, session_token="launch-token")
 
 
 def test_cmd_claude_skips_plugin_install_when_opted_out():
@@ -607,6 +613,47 @@ def test_cmd_claude_skips_plugin_install_when_opted_out():
                 with mock.patch("lapdog.cli._run_claude"):
                     cli.cmd_claude([], forward_data=False, install_plugin=False)
     install.assert_not_called()
+
+
+def test_cmd_tags_posts_tags_for_instrumented_session(monkeypatch, capsys):
+    monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "launch-token")
+    monkeypatch.setenv("LAPDOG_URL", "http://localhost:8126")
+
+    with mock.patch(
+        "lapdog.cli._post_session_tags",
+        return_value={"status": "ok", "session_id": "claude-session"},
+    ) as post_tags:
+        cli.cmd_tags(["set", "dd_auto_experiment_id:experiment-id", "iteration:2"])
+
+    post_tags.assert_called_once_with(
+        "http://localhost:8126",
+        "launch-token",
+        {"dd_auto_experiment_id": "experiment-id", "iteration": "2"},
+    )
+    assert "Tagged Claude session claude-session" in capsys.readouterr().out
+
+
+def test_main_routes_tags_command(monkeypatch):
+    monkeypatch.setattr(cli.sys, "argv", ["lapdog", "tags", "set", "iteration:2"])
+    with mock.patch("lapdog.cli.cmd_tags") as cmd_tags:
+        cli.main()
+    cmd_tags.assert_called_once_with(["set", "iteration:2"])
+
+
+def test_run_claude_injects_lapdog_session_context(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/local/bin/claude")
+    execve = mock.Mock()
+    monkeypatch.setattr(cli.os, "execve", execve)
+
+    cli._run_claude(["--model", "opus"], port=9126, session_token="launch-token")
+
+    binary, args, env = execve.call_args.args
+    assert binary == "/usr/local/bin/claude"
+    assert args == ["/usr/local/bin/claude", "--model", "opus"]
+    assert env["LAPDOG_URL"] == "http://localhost:9126"
+    assert env["DDAPM_GATEWAY_URL"] == "http://localhost:9126/claude/proxy"
+    assert env["TEST_AGENT_URL"] == "http://localhost:9126/info"
+    assert env["LAPDOG_SESSION_TOKEN"] == "launch-token"
 
 
 def test_run_codex_falls_back_without_openai_api_key(monkeypatch):

--- a/tests/test_lapdog_cli.py
+++ b/tests/test_lapdog_cli.py
@@ -33,7 +33,12 @@ def test_cmd_codex_starts_watcher_and_execs_codex():
         singleton_key=None,
         include_all_cwds=False,
     )
-    run_codex.assert_called_once_with(args=["--model", "gpt-5.5"], port=8126, proxy_session_key="proxy-key")
+    run_codex.assert_called_once_with(
+        args=["--model", "gpt-5.5"],
+        port=8126,
+        proxy_session_key="proxy-key",
+        session_token="proxy-key",
+    )
 
 
 def test_cmd_codex_starts_watcher_with_forwarded_cd(monkeypatch, tmp_path):
@@ -68,19 +73,25 @@ def test_cmd_codex_app_starts_watcher_with_app_path_and_lapdog_pid(monkeypatch, 
             with mock.patch("lapdog.cli._stop_legacy_codex_app_watchers") as stop_legacy:
                 with mock.patch("lapdog.cli._start_codex_watcher") as start_watcher:
                     with mock.patch("lapdog.cli._run_codex") as run_codex:
-                        with mock.patch("lapdog.cli.build_running_banner", return_value="banner"):
-                            cli.cmd_codex(["app", str(target_cwd)], forward_data=True)
+                        with mock.patch("lapdog.cli.uuid.uuid4", return_value=mock.Mock(hex="app-token")):
+                            with mock.patch("lapdog.cli.build_running_banner", return_value="banner"):
+                                cli.cmd_codex(["app", str(target_cwd)], forward_data=True)
 
     stop_legacy.assert_called_once_with(8126, 4242, codex_args.app_watcher_key(8126))
     start_watcher.assert_called_once_with(
         8126,
-        proxy_session_key=None,
+        proxy_session_key="app-token",
         cwd=str(target_cwd),
         parent_pid=4242,
         singleton_key=codex_args.app_watcher_key(8126),
         include_all_cwds=True,
     )
-    run_codex.assert_called_once_with(args=["app", str(target_cwd)], port=8126, proxy_session_key=None)
+    run_codex.assert_called_once_with(
+        args=["app", str(target_cwd)],
+        port=8126,
+        proxy_session_key=None,
+        session_token="app-token",
+    )
 
 
 def test_resolve_codex_cwd_handles_relative_cd(monkeypatch, tmp_path):
@@ -253,7 +264,15 @@ def test_start_codex_watcher_skips_live_singleton(tmp_path, monkeypatch):
 
     popen.assert_not_called()
     assert reusable_calls == [
-        (4242, cli.os.getpid(), {"lapdog_url": "http://localhost:8126", "include_all_cwds": True})
+        (
+            4242,
+            cli.os.getpid(),
+            {
+                "lapdog_url": "http://localhost:8126",
+                "include_all_cwds": True,
+                "proxy_session_key": None,
+            },
+        )
     ]
 
 
@@ -315,7 +334,8 @@ def test_codex_watcher_reusable_requires_current_parent(monkeypatch):
         result = mock.Mock()
         result.returncode = 0
         result.stdout = (
-            "python -m lapdog.codex_watcher --lapdog-url http://localhost:8126 " "--parent-pid 1111 --cwd /repo"
+            "python -m lapdog.codex_watcher --lapdog-url http://localhost:8126 "
+            "--parent-pid 1111 --proxy-session-key proxy-key --cwd /repo"
         )
         return result
 
@@ -331,6 +351,8 @@ def test_codex_watcher_reusable_requires_current_parent(monkeypatch):
     assert not cli._codex_watcher_reusable(4242, 2222)
     assert not cli._codex_watcher_reusable(4242, 1111, lapdog_url="http://localhost:8127")
     assert not cli._codex_watcher_reusable(4242, 1111, include_all_cwds=True)
+    assert cli._codex_watcher_reusable(4242, 1111, proxy_session_key="proxy-key")
+    assert not cli._codex_watcher_reusable(4242, 1111, proxy_session_key="other-key")
 
 
 def test_codex_watcher_reusable_checks_windows_command(monkeypatch):
@@ -511,12 +533,19 @@ def test_run_codex_injects_lapdog_provider(monkeypatch):
     monkeypatch.setattr(cli.os, "execve", fake_execve)
 
     try:
-        cli._run_codex(args=["exec", "hello"], port=8126, proxy_session_key="proxy-key")
+        cli._run_codex(
+            args=["exec", "hello"],
+            port=8126,
+            proxy_session_key="proxy-key",
+            session_token="session-token",
+        )
     except SystemExit:
         pass
 
     assert exec_call["binary"] == "/usr/local/bin/codex"
     assert exec_call["env"]["OPENAI_BASE_URL"] == "http://localhost:8126/codex/proxy/proxy-key/v1"
+    assert exec_call["env"]["LAPDOG_URL"] == "http://localhost:8126"
+    assert exec_call["env"]["LAPDOG_SESSION_TOKEN"] == "session-token"
     assert exec_call["argv"][:5] == [
         "/usr/local/bin/codex",
         "-c",

--- a/tests/test_lapdog_cli.py
+++ b/tests/test_lapdog_cli.py
@@ -2,6 +2,8 @@ import json
 import subprocess
 from unittest import mock
 
+import pytest
+
 from lapdog import codex_args
 from lapdog import cli
 
@@ -14,6 +16,7 @@ def test_codex_command_is_registered():
 def test_tags_command_is_registered():
     assert "tags" in cli.LAPDOG_COMMANDS
     assert "tags" in cli.LAPDOG_USAGE
+    assert "current instrumented coding-agent session" in cli.LAPDOG_USAGE
 
 
 def test_cmd_codex_starts_watcher_and_execs_codex():
@@ -567,6 +570,9 @@ def test_run_codex_injects_lapdog_provider(monkeypatch):
 
     monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/local/bin/codex")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("CODEX_THREAD_ID", "outer-codex-thread")
+    monkeypatch.setenv("PI_SESSION_ID", "outer-pi-session")
+    monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "outer-launch-token")
 
     def fake_execve(binary, argv, env):
         exec_call["binary"] = binary
@@ -590,6 +596,8 @@ def test_run_codex_injects_lapdog_provider(monkeypatch):
     assert exec_call["env"]["OPENAI_BASE_URL"] == "http://localhost:8126/codex/proxy/proxy-key/v1"
     assert exec_call["env"]["LAPDOG_URL"] == "http://localhost:8126"
     assert exec_call["env"]["LAPDOG_SESSION_TOKEN"] == "session-token"
+    assert "CODEX_THREAD_ID" not in exec_call["env"]
+    assert "PI_SESSION_ID" not in exec_call["env"]
     assert exec_call["argv"][:5] == [
         "/usr/local/bin/codex",
         "-c",
@@ -692,6 +700,7 @@ def test_cmd_tags_posts_tags_for_instrumented_session(monkeypatch, capsys):
     monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "launch-token")
     monkeypatch.setenv("LAPDOG_URL", "http://localhost:8126")
     monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+    monkeypatch.delenv("PI_SESSION_ID", raising=False)
 
     with mock.patch(
         "lapdog.cli._post_session_tags",
@@ -706,6 +715,19 @@ def test_cmd_tags_posts_tags_for_instrumented_session(monkeypatch, capsys):
         session_id=None,
     )
     assert "Tagged coding-agent session claude-session" in capsys.readouterr().out
+
+
+def test_cmd_tags_missing_session_message_lists_supported_agents(monkeypatch, capsys):
+    monkeypatch.delenv("LAPDOG_SESSION_TOKEN", raising=False)
+    monkeypatch.delenv("LAPDOG_URL", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.cmd_tags(["set", "iteration:2"])
+
+    assert exc_info.value.code == 1
+    error = capsys.readouterr().err
+    assert "No instrumented coding-agent session found" in error
+    assert "'lapdog claude', 'lapdog codex', or 'lapdog pi'" in error
 
 
 def test_post_session_tags_serializes_target_session_id():
@@ -734,6 +756,7 @@ def test_cmd_tags_targets_current_codex_thread(monkeypatch, capsys):
     monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "app-launch-token")
     monkeypatch.setenv("LAPDOG_URL", "http://localhost:8126")
     monkeypatch.setenv("CODEX_THREAD_ID", "codex-thread-id")
+    monkeypatch.delenv("PI_SESSION_ID", raising=False)
 
     with mock.patch(
         "lapdog.cli._post_session_tags",
@@ -750,6 +773,27 @@ def test_cmd_tags_targets_current_codex_thread(monkeypatch, capsys):
     assert "Tagged coding-agent session codex-thread-id" in capsys.readouterr().out
 
 
+def test_cmd_tags_targets_current_pi_session(monkeypatch, capsys):
+    monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "pi-launch-token")
+    monkeypatch.setenv("LAPDOG_URL", "http://localhost:8126")
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+    monkeypatch.setenv("PI_SESSION_ID", "pi-session-id")
+
+    with mock.patch(
+        "lapdog.cli._post_session_tags",
+        return_value={"status": "ok", "session_id": "pi-session-id"},
+    ) as post_tags:
+        cli.cmd_tags(["set", "iteration:2"])
+
+    post_tags.assert_called_once_with(
+        "http://localhost:8126",
+        "pi-launch-token",
+        {"iteration": "2"},
+        session_id="pi-session-id",
+    )
+    assert "Tagged coding-agent session pi-session-id" in capsys.readouterr().out
+
+
 def test_main_routes_tags_command(monkeypatch):
     monkeypatch.setattr(cli.sys, "argv", ["lapdog", "tags", "set", "iteration:2"])
     with mock.patch("lapdog.cli.cmd_tags") as cmd_tags:
@@ -759,6 +803,9 @@ def test_main_routes_tags_command(monkeypatch):
 
 def test_run_claude_injects_lapdog_session_context(monkeypatch):
     monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/local/bin/claude")
+    monkeypatch.setenv("CODEX_THREAD_ID", "outer-codex-thread")
+    monkeypatch.setenv("PI_SESSION_ID", "outer-pi-session")
+    monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "outer-launch-token")
     execve = mock.Mock()
     monkeypatch.setattr(cli.os, "execve", execve)
 
@@ -771,6 +818,44 @@ def test_run_claude_injects_lapdog_session_context(monkeypatch):
     assert env["DDAPM_GATEWAY_URL"] == "http://localhost:9126/claude/proxy"
     assert env["TEST_AGENT_URL"] == "http://localhost:9126/info"
     assert env["LAPDOG_SESSION_TOKEN"] == "launch-token"
+    assert "CODEX_THREAD_ID" not in env
+    assert "PI_SESSION_ID" not in env
+
+
+def test_run_pi_injects_lapdog_session_context(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/local/bin/pi")
+    monkeypatch.setenv("CODEX_THREAD_ID", "outer-codex-thread")
+    monkeypatch.setenv("PI_SESSION_ID", "outer-pi-session")
+    monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "outer-launch-token")
+    execve = mock.Mock()
+    monkeypatch.setattr(cli.os, "execve", execve)
+
+    cli._run_pi(["--model", "anthropic/claude-opus-4-1"], port=9126, session_token="pi-launch-token")
+
+    binary, args, env = execve.call_args.args
+    assert binary == "/usr/local/bin/pi"
+    assert args == ["/usr/local/bin/pi", "--model", "anthropic/claude-opus-4-1"]
+    assert env["LAPDOG_URL"] == "http://localhost:9126"
+    assert env["LAPDOG_SESSION_TOKEN"] == "pi-launch-token"
+    assert "CODEX_THREAD_ID" not in env
+    assert "PI_SESSION_ID" not in env
+
+
+def test_cmd_pi_injects_unique_session_token():
+    with mock.patch("lapdog.cli._ensure_lapdog_running", return_value=8126) as ensure:
+        with mock.patch("lapdog.cli._install_pi_extension") as install_ext:
+            with mock.patch("lapdog.cli._run_pi") as run_pi:
+                with mock.patch("lapdog.cli.uuid.uuid4", return_value=mock.Mock(hex="pi-launch-token")):
+                    with mock.patch("lapdog.cli.build_running_banner", return_value="banner"):
+                        cli.cmd_pi(["--model", "anthropic/claude-opus-4-1"], forward_data=True)
+
+    ensure.assert_called_once_with(True, detached=True)
+    install_ext.assert_called_once_with()
+    run_pi.assert_called_once_with(
+        args=["--model", "anthropic/claude-opus-4-1"],
+        port=8126,
+        session_token="pi-launch-token",
+    )
 
 
 def test_run_codex_falls_back_without_openai_api_key(monkeypatch):

--- a/tests/test_lapdog_cli.py
+++ b/tests/test_lapdog_cli.py
@@ -727,7 +727,8 @@ def test_cmd_tags_missing_session_message_lists_supported_agents(monkeypatch, ca
     assert exc_info.value.code == 1
     error = capsys.readouterr().err
     assert "No instrumented coding-agent session found" in error
-    assert "'lapdog claude', 'lapdog codex', or 'lapdog pi'" in error
+    for launcher in cli._PATH_ROUTABLE_LAUNCHERS:
+        assert f"'lapdog {launcher}'" in error
 
 
 def test_post_session_tags_serializes_target_session_id():

--- a/tests/test_lapdog_cli.py
+++ b/tests/test_lapdog_cli.py
@@ -80,7 +80,7 @@ def test_cmd_codex_app_starts_watcher_with_app_path_and_lapdog_pid(monkeypatch, 
     stop_legacy.assert_called_once_with(8126, 4242, codex_args.app_watcher_key(8126))
     start_watcher.assert_called_once_with(
         8126,
-        proxy_session_key="app-token",
+        proxy_session_key=None,
         cwd=str(target_cwd),
         parent_pid=4242,
         singleton_key=codex_args.app_watcher_key(8126),
@@ -270,7 +270,7 @@ def test_start_codex_watcher_skips_live_singleton(tmp_path, monkeypatch):
             {
                 "lapdog_url": "http://localhost:8126",
                 "include_all_cwds": True,
-                "proxy_session_key": None,
+                "proxy_session_key": "",
             },
         )
     ]
@@ -329,6 +329,49 @@ def test_start_codex_watcher_terminates_verified_stale_singleton(tmp_path, monke
     assert pid_path.read_text() == "4343\n"
 
 
+def test_start_codex_app_watcher_replaces_legacy_tokenized_watcher(tmp_path, monkeypatch):
+    pid_path = tmp_path / "codex-watcher-app-key.pid"
+    pid_path.write_text("4242\n")
+    kills = []
+    popen_args = []
+
+    def fake_popen(args, **kwargs):
+        popen_args.append(args)
+        ready_path = args[args.index("--ready-file") + 1]
+        with open(ready_path, "w") as f:
+            f.write("ready\n")
+        process = mock.Mock()
+        process.pid = 4343
+        process.poll.return_value = None
+        return process
+
+    monkeypatch.setattr(cli, "_log_file_path", lambda: str(tmp_path / "lapdog.log"))
+    monkeypatch.setattr(cli, "_process_exists", lambda pid: pid == 4242)
+    monkeypatch.setattr(
+        cli,
+        "_codex_watcher_command",
+        lambda pid: (
+            "python -m lapdog.codex_watcher --lapdog-url http://localhost:8126 "
+            "--parent-pid 5252 --include-all-cwds --proxy-session-key old-token --cwd /repo"
+        ),
+    )
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+    monkeypatch.setattr(cli.subprocess, "Popen", fake_popen)
+
+    cli._start_codex_watcher(
+        8126,
+        proxy_session_key=None,
+        cwd=str(tmp_path),
+        parent_pid=5252,
+        singleton_key="app-key",
+        include_all_cwds=True,
+    )
+
+    assert kills == [(4242, cli.signal.SIGTERM)]
+    assert len(popen_args) == 1
+    assert "--proxy-session-key" not in popen_args[0]
+
+
 def test_codex_watcher_reusable_requires_current_parent(monkeypatch):
     def fake_run(args, **kwargs):
         result = mock.Mock()
@@ -353,6 +396,7 @@ def test_codex_watcher_reusable_requires_current_parent(monkeypatch):
     assert not cli._codex_watcher_reusable(4242, 1111, include_all_cwds=True)
     assert cli._codex_watcher_reusable(4242, 1111, proxy_session_key="proxy-key")
     assert not cli._codex_watcher_reusable(4242, 1111, proxy_session_key="other-key")
+    assert not cli._codex_watcher_reusable(4242, 1111, proxy_session_key="")
 
 
 def test_codex_watcher_reusable_checks_windows_command(monkeypatch):
@@ -647,6 +691,7 @@ def test_cmd_claude_skips_plugin_install_when_opted_out():
 def test_cmd_tags_posts_tags_for_instrumented_session(monkeypatch, capsys):
     monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "launch-token")
     monkeypatch.setenv("LAPDOG_URL", "http://localhost:8126")
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
 
     with mock.patch(
         "lapdog.cli._post_session_tags",
@@ -658,8 +703,51 @@ def test_cmd_tags_posts_tags_for_instrumented_session(monkeypatch, capsys):
         "http://localhost:8126",
         "launch-token",
         {"dd_auto_experiment_id": "experiment-id", "iteration": "2"},
+        session_id=None,
     )
-    assert "Tagged Claude session claude-session" in capsys.readouterr().out
+    assert "Tagged coding-agent session claude-session" in capsys.readouterr().out
+
+
+def test_post_session_tags_serializes_target_session_id():
+    opener = mock.MagicMock()
+    response = mock.MagicMock()
+    response.__enter__.return_value.read.return_value = b'{"status": "ok", "session_id": "codex-thread-id"}'
+    opener.open.return_value = response
+
+    with mock.patch("lapdog.cli.urllib.request.build_opener", return_value=opener):
+        result = cli._post_session_tags(
+            "http://localhost:8126",
+            "app-launch-token",
+            {"iteration": "2"},
+            session_id="codex-thread-id",
+        )
+
+    request = opener.open.call_args.args[0]
+    assert json.loads(request.data) == {
+        "session_id": "codex-thread-id",
+        "tags": {"iteration": "2"},
+    }
+    assert result["session_id"] == "codex-thread-id"
+
+
+def test_cmd_tags_targets_current_codex_thread(monkeypatch, capsys):
+    monkeypatch.setenv("LAPDOG_SESSION_TOKEN", "app-launch-token")
+    monkeypatch.setenv("LAPDOG_URL", "http://localhost:8126")
+    monkeypatch.setenv("CODEX_THREAD_ID", "codex-thread-id")
+
+    with mock.patch(
+        "lapdog.cli._post_session_tags",
+        return_value={"status": "ok", "session_id": "codex-thread-id"},
+    ) as post_tags:
+        cli.cmd_tags(["set", "iteration:2"])
+
+    post_tags.assert_called_once_with(
+        "http://localhost:8126",
+        "app-launch-token",
+        {"iteration": "2"},
+        session_id="codex-thread-id",
+    )
+    assert "Tagged coding-agent session codex-thread-id" in capsys.readouterr().out
 
 
 def test_main_routes_tags_command(monkeypatch):

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -202,6 +202,80 @@ def _session_shutdown(session_id=SESSION):
 # ------------------------------------------------------------------
 
 
+async def test_pi_session_tags_apply_to_existing_and_future_spans(agent):
+    sid = "pi-custom-tags"
+    session_token = "pi-launch-token"
+    await _post(
+        agent,
+        {
+            **_session_start(sid),
+            "lapdog_session_token": session_token,
+        },
+    )
+    await _post(agent, _agent_start(sid))
+
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={"tags": {"dd_auto_experiment_id": "experiment-id", "iteration": "2"}},
+    )
+    assert response.status == 200, await response.text()
+    assert (await response.json())["session_id"] == sid
+
+    await _post(agent, _turn_start(sid))
+    await _post(agent, _message_start(sid))
+    await _post(agent, _message_end(sid))
+    await _post(agent, _turn_end(sid))
+    await _post(agent, _agent_end(sid))
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = [span for span in _spans(await response.json()) if span.get("session_id") == sid]
+    assert spans
+    assert all("dd_auto_experiment_id:experiment-id" in span["tags"] for span in spans)
+    assert all("iteration:2" in span["tags"] for span in spans)
+
+    response = await agent.get("/pi/hooks/raw")
+    raw_events = (await response.json())["events"]
+    assert all("lapdog_session_token" not in event for event in raw_events)
+
+
+async def test_pi_session_tags_do_not_leak_between_sessions_from_one_launch(agent):
+    session_token = "shared-pi-launch-token"
+    target_session_id = "pi-target-session"
+    other_session_id = "pi-other-session"
+    for session_id in (target_session_id, other_session_id):
+        await _post(
+            agent,
+            {
+                **_session_start(session_id),
+                "lapdog_session_token": session_token,
+            },
+        )
+        await _post(agent, _agent_start(session_id))
+
+    response = await agent.post(
+        "/lapdog/session/tags",
+        headers={"X-Lapdog-Session-Token": session_token},
+        json={
+            "session_id": target_session_id,
+            "tags": {"iteration": "2"},
+        },
+    )
+    assert response.status == 200, await response.text()
+
+    for session_id in (target_session_id, other_session_id):
+        await _post(agent, _turn_start(session_id))
+
+    response = await agent.get("/claude/hooks/spans")
+    spans = _spans(await response.json())
+    target_spans = [span for span in spans if span.get("session_id") == target_session_id]
+    other_spans = [span for span in spans if span.get("session_id") == other_session_id]
+    assert target_spans
+    assert other_spans
+    assert all("iteration:2" in span["tags"] for span in target_spans)
+    assert all("iteration:2" not in span["tags"] for span in other_spans)
+
+
 async def test_single_step_with_llm_no_tools(agent):
     """One turn_start/turn_end cycle produces: agent → step → llm."""
     sid = "pi-single-step"


### PR DESCRIPTION
Background
----------------------
The intent of this PR is to create a way to integrate Lapdog with skill-based auto-experiments. The way that skill-based auto experiments work, we basically write a skill that says:

"Look around the codebase, try to create your own eval metric, make one improvement to the codebase, and compare eval metrics values before and after the improvement. Repeat five times. After each iteration, submit the eval metric score back to Datadog using its MCP server".

This allows the users to run the experiment without having to share their code with Datadog. Our UI for auto experiments is built on top of the eval metrics events that Claude will submit with this skill.

If the user happens to also have Lapdog installed, then we want to show the Lapdog traces in a separate tab in the auto experiment UI. This means we need some way to tag those traces with a specific auto experiment ID.

Changes
----------------------
My initial idea was to store the experiment ID in an environment variable. But that's a pain in the neck for several reasons:
- The Lapdog agent is a separate process that does not share environment with Claude
- Claude has no way of updating its own environment. It can only control the environment of the terminal shells that it creates
- By the time we tell Claude to set the environment variable and get around to it, the turn has already started and the initial root span has been created

So after conferring with Codex, I am going the route of adding a new `tags set` command to the Lapdog CLI:

```
lapdog tags set dd_auto_experiment_id:b5f657b1-7ed8-4bb7-92d4-f92e790c997c
```

Lapdog will internally store a mapping of session IDs to tags. The tags for a session ID will apply to all spans for that session that have not already been emitted by the time the tag is set, including the root span.

The only possible problem is that, over time, the mapping of sessions to tags may grow. But since I expect the cardinality of tags per session to be very low (for auto experiment, we just need the experiment_id and iteration), I do not think this will cause the agent to run out of memory.

Automated Tests
----------------------
```
cd /Users/$USER/go/src/github.com/DataDog/dd-apm-test-agent

python3.12 -m venv .venv
source .venv/bin/activate
pip install -e ".[testing]"

python -m pytest tests/test_claude_hooks.py tests/test_claude_steps.py tests/test_lapdog_cli.py tests/test_codex_hooks.py tests/test_pi_hooks.py
```

Manual Verification
-----------------------
To run a version of Lapdog that includes these changes, I used the following commands
```
cd /Users/$USER/go/src/github.com/DataDog/dd-apm-test-agent

python3.12 -m venv .venv
source .venv/bin/activate
python -m pip install -e .

which lapdog
# The above should output a path that ends with dd-apm-test-agent/.venv/bin/lapdog, not one in /opt
lapdog stop
lapdog start

lapdog claude --dangerously-skip-permissions
```

I then pasted the following prompts into Claude, one and then the other:

I want you to check if you have access to the lapdog CLI (for example, by running the command `which lapdog`). If you do have access to the CLI, please use it to add a new tag to the Lapdog telemetry with the following command: `lapdog tags set payload:test`. After adding that tag to the telemetry, check the current status of the following PR and tell me what it is: `https://github.com/DataDog/dd-apm-test-agent/pull/403`

Now I want you to update the telemetry tag by running `lapdog tags set payload:shmoduction` and, after doing so, pull up the description of the same PR, `https://github.com/DataDog/dd-apm-test-agent/pull/403`, and summarize for me what it does

I confirmed that for both of them, all spans get tagged with the `payload` tag, [which becomes searchable in our UI](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Aclaude-code%20%40event_type%3Aspan%20payload%3Ashmoduction%20%40is_root_span%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&is_llm_session=false&refresh_mode=paused&selectedTab=overview&spanId=11521154653168241800&start=1784645069374&end=1784648669374&paused=true). For the first trace, I did not yet have my Lapdog forward spans to our backend, so only the second trace is visible in production. I inspected the first one on the Lapdog that was running on my laptop, and confirmed that it also has the `payload` tags on each span.

I repeated the same test for the Codex CLI as well and confirmed that [the tags also become attached to spans](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Acodex%20%40event_type%3Aspan%20payload%3Atry_codex%20%40is_root_span%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&is_llm_session=false&refresh_mode=paused&selectedTab=overview&sidepanelContextScope=14218801265911369967&sidepanelContextScopeKind=agent&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ-FdEwgeA2ykQAAABhBWi1GZEV3Z0FBRFpVUExqd0R0NkFBQUEAAAAkZjE5Zjg1NzUtNDczNC00NTk3LTg3MmItODliNmViMGUzY2NlAAATzA%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=14218801265911369967&start=1784649595772&end=1784650495772&paused=true) as intended.

For the latest version of the PR I reran the same test steps for Pi as well.