### PR TITLE
fix(trace): expose v1 traces in session requests

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -1564,6 +1564,7 @@ class Agent:
                 self.handle_v04_traces,
                 self.handle_v05_traces,
                 self.handle_v07_traces,
+                self.handle_v1_traces,
                 self.handle_v06_tracestats,
                 self.handle_v01_pipelinestats,
                 self.handle_v2_apmtelemetry,

--- a/releasenotes/notes/expose-v1-session-requests-4c731e9a.yaml
+++ b/releasenotes/notes/expose-v1-session-requests-4c731e9a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Include native v1 trace requests in the `/test/session/requests` response.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -848,6 +848,13 @@ async def test_trace_v1(
     assert result[0][0]["meta"]["_dd.p.tid"] == "0000000000000055"
     assert result[0][0]["service"] == "my-service"
 
+    requests_resp = await agent.get("/test/session/requests")
+    assert requests_resp.status == 200
+    requests = await requests_resp.json()
+    v1_requests = [request for request in requests if request["url"].endswith("/v1.0/traces")]
+    assert len(v1_requests) == 1
+    assert v1_requests[0]["headers"]["X-Datadog-Trace-Count"] == "1"
+
 
 async def test_trace_v1_basic():
     data = msgpack.packb(


### PR DESCRIPTION
# What Does This Do

Includes native `/v1.0/traces` requests in the `/test/session/requests` response, preserving their headers and body. Adds regression coverage for the v1 request and `X-Datadog-Trace-Count` header.

# Motivation

System tests that validate trace-request headers could not inspect native `v1` requests because the test agent filtered them out. This caused three trace-metrics tests to fail when Java used the `v1` trace protocol.

# Additional Notes

Validated with the focused test-agent unit test and the three affected Java parametric tests using a locally built image. All four tests passed.