### PR TITLE
feat(lapdog): cost tracking for latest Claude and Codex models

### DIFF
--- a/ddapm_test_agent/claude_cost_tracker.py
+++ b/ddapm_test_agent/claude_cost_tracker.py
@@ -11,7 +11,7 @@ and the metric keys expected by the web-ui LLM observability span detail view:
     estimated_cache_write_input_cost
     estimated_cache_read_input_cost
 
-Pricing data last updated 2025-11 based on:
+Pricing data last updated 2026-08 based on:
   * Anthropic public pricing: https://www.anthropic.com/pricing#api
   * pi-ai models.generated.js (the data Claude Code itself uses to compute
     the self-reported per-turn cost shown in its UI):
@@ -22,6 +22,12 @@ Note: Anthropic significantly reduced Opus prices starting with Opus 4.5
 (Nov 2025).  Opus 4.5 / 4.6 / 4.7 / 4.8 cost $5 / $25 / $0.50 / $6.25 per Mtok,
 whereas Opus 4 / 4.1 / 3 still cost $15 / $75 / $1.50 / $18.75 per Mtok.
 Using the old Opus rates for 4.5+ overcharges by exactly 3x.
+
+The Claude 5 family adds Sonnet 5 ($3 / $15 per Mtok, same tier as Sonnet 4.6)
+and Fable 5 / Mythos 5 ($10 / $50 per Mtok — the most capable tier).  Sonnet 5
+carries an introductory rate of $2 / $10 per Mtok through 2026-08-31; because
+these values are only estimates, the table uses the higher ongoing list price
+($3 / $15) as a conservative upper bound rather than the temporary intro rate.
 
 Only the popular models used with Claude Code are included.
 """
@@ -81,6 +87,17 @@ COST_METRIC_KEYS: FrozenSet[str] = frozenset(
 _ONE_TIER = 0  # sentinel: no upper bound on a single tier
 
 _PRICING: List[Tuple[str, List[_PriceTier]]] = [
+    # ---- Fable 5 / Mythos 5 (most capable tier, Claude 5 family) -------------
+    # $10 / $50 / $1.00 cache-read / $12.50 cache-write per Mtok.
+    # Mythos 5 is Project-Glasswing-only but shares Fable 5's pricing.
+    (
+        "claude-fable-5",
+        [_PriceTier(0, _ONE_TIER, 10_000, 12_500, 1_000, 50_000)],
+    ),
+    (
+        "claude-mythos-5",
+        [_PriceTier(0, _ONE_TIER, 10_000, 12_500, 1_000, 50_000)],
+    ),
     # ---- Opus 4.5+ (reduced pricing, Nov 2025) ------------------------------
     # $5 / $25 / $0.50 cache-read / $6.25 cache-write per Mtok.
     # Source: Anthropic pricing page; pi-ai models.generated.js entries
@@ -128,7 +145,14 @@ _PRICING: List[Tuple[str, List[_PriceTier]]] = [
         [_PriceTier(0, _ONE_TIER, 15_000, 18_750, 1_500, 75_000)],
     ),
     # ---- Sonnet -------------------------------------------------------------
-    # claude-sonnet-4-6 / claude-sonnet-4.6  (latest)
+    # claude-sonnet-5  (Claude 5 family; latest)
+    # $3 / $15 list per Mtok — conservative upper bound; the $2 / $10 intro rate
+    # (through 2026-08-31) is lower, so the ongoing list price is used instead.
+    (
+        "claude-sonnet-5",
+        [_PriceTier(0, _ONE_TIER, 3_000, 3_750, 300, 15_000)],
+    ),
+    # claude-sonnet-4-6 / claude-sonnet-4.6
     (
         "claude-sonnet-4-6",
         [_PriceTier(0, _ONE_TIER, 3_000, 3_750, 300, 15_000)],
@@ -214,6 +238,7 @@ def cost_from_provider_usage(
 
     Returns a dict with the same metric keys as ``compute_cost_metrics``.
     """
+
     def _to_nano(v: float) -> int:
         return int(round(v * _NANODOLLARS_PER_DOLLAR))
 

--- a/ddapm_test_agent/codex_cost_tracker.py
+++ b/ddapm_test_agent/codex_cost_tracker.py
@@ -3,8 +3,17 @@
 Pricing is in nanodollars per token (1 nanodollar = 1e-9 USD), matching the
 metric keys expected by the web-ui LLM observability span detail view.
 
-Pricing data last updated 2026-05 from OpenAI API pricing pages. GPT-5.5
-standard rates are documented for context lengths under 270K tokens.
+Pricing data last updated 2026-08 from OpenAI API pricing pages. Standard
+rates are documented for context lengths under 270K tokens.
+
+Latest models added 2026-08:
+  * gpt-5.6 family (Sol $5 / $30, Terra $2 / $12 per Mtok, 90% cached-input
+    discount). The nano-tier "Luna" variant is deliberately left out so it
+    resolves to the higher "gpt-5.6" (Sol) rate via prefix match — a
+    conservative upper bound, since its own rate was inconsistent across
+    sources.
+  * gpt-5.3-codex — the current Codex CLI default ($1.75 / $14 per Mtok),
+    superseding gpt-5.2-codex at the same rates.
 """
 
 from dataclasses import dataclass
@@ -23,9 +32,13 @@ class _OpenAIPrice:
 
 
 _PRICING: List[_OpenAIPrice] = [
+    # gpt-5.6 family (Terra listed before the Sol catch-all so it isn't shadowed).
+    _OpenAIPrice("gpt-5.6-terra", input_price=2_000, cached_input=200, output=12_000),
+    _OpenAIPrice("gpt-5.6", input_price=5_000, cached_input=500, output=30_000),
     _OpenAIPrice("gpt-5.5", input_price=5_000, cached_input=500, output=30_000),
     _OpenAIPrice("gpt-5.4-mini", input_price=750, cached_input=75, output=4_500),
     _OpenAIPrice("gpt-5.4", input_price=2_500, cached_input=250, output=15_000),
+    _OpenAIPrice("gpt-5.3-codex", input_price=1_750, cached_input=175, output=14_000),
     _OpenAIPrice("gpt-5.2-codex", input_price=1_750, cached_input=175, output=14_000),
     _OpenAIPrice("gpt-5.2", input_price=1_750, cached_input=175, output=14_000),
     _OpenAIPrice("gpt-5.1-codex-max", input_price=1_250, cached_input=125, output=10_000),

--- a/releasenotes/notes/latest-claude-codex-model-pricing-9c2f1a4e6b8d0357.yaml
+++ b/releasenotes/notes/latest-claude-codex-model-pricing-9c2f1a4e6b8d0357.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Add cost tracking for more of the latest Claude and Codex models. Claude:
+    ``claude-sonnet-5`` ($3 / $15 per Mtok) and ``claude-fable-5`` /
+    ``claude-mythos-5`` ($10 / $50). Codex/OpenAI: ``gpt-5.6`` and
+    ``gpt-5.6-terra``, plus ``gpt-5.3-codex`` (the current Codex CLI default).
+    Without these entries, spans for the newest models fell through and were
+    reported with no estimated cost. Where a rate was ambiguous (Sonnet 5's
+    introductory price, the disputed gpt-5.6 "Luna" tier) the higher estimate
+    is used, since these costs are only estimates.

--- a/tests/test_claude_cost_tracker.py
+++ b/tests/test_claude_cost_tracker.py
@@ -20,6 +20,17 @@ class TestModelLookup:
         result = compute_cost_metrics("claude-haiku-4-5-20251001", 1000, 0, 0, 0)
         assert result is not None
 
+    def test_opus_4_8(self) -> None:
+        assert compute_cost_metrics("claude-opus-4-8", 1000, 0, 0, 0) is not None
+        assert compute_cost_metrics("claude-opus-4-8-20260101", 1000, 0, 0, 0) is not None
+
+    def test_sonnet_5(self) -> None:
+        assert compute_cost_metrics("claude-sonnet-5", 1000, 0, 0, 0) is not None
+
+    def test_fable_and_mythos_5(self) -> None:
+        assert compute_cost_metrics("claude-fable-5", 1000, 0, 0, 0) is not None
+        assert compute_cost_metrics("claude-mythos-5", 1000, 0, 0, 0) is not None
+
     def test_unknown_model_returns_none(self) -> None:
         assert compute_cost_metrics("gpt-4o", 1000, 0, 0, 0) is None
 
@@ -96,6 +107,32 @@ class TestCostCalculation:
             assert result["estimated_cache_write_input_cost"] == 200 * 6_250, model
             assert result["estimated_cache_read_input_cost"] == 500 * 500, model
             assert result["estimated_output_cost"] == 50 * 25_000, model
+
+    def test_opus_4_8_not_shadowed_by_legacy_opus_4(self) -> None:
+        # "claude-opus-4-8" must match the reduced tier, not the legacy
+        # "claude-opus-4" prefix (which would triple the cost).
+        result = compute_cost_metrics("claude-opus-4-8", 100, 0, 0, 0)
+        assert result is not None
+        assert result["estimated_non_cached_input_cost"] == 100 * 5_000
+
+    def test_sonnet_5_pricing(self) -> None:
+        # claude-sonnet-5: list rates match the Sonnet 4.6 tier.
+        result = compute_cost_metrics("claude-sonnet-5", 100, 200, 500, 50)
+        assert result is not None
+        assert result["estimated_non_cached_input_cost"] == 100 * 3_000
+        assert result["estimated_cache_write_input_cost"] == 200 * 3_750
+        assert result["estimated_cache_read_input_cost"] == 500 * 300
+        assert result["estimated_output_cost"] == 50 * 15_000
+
+    def test_fable_and_mythos_5_pricing(self) -> None:
+        # Fable 5 / Mythos 5: $10 / $50 per Mtok, cache write $12.50, cache read $1.00.
+        for model in ("claude-fable-5", "claude-mythos-5"):
+            result = compute_cost_metrics(model, 100, 200, 500, 50)
+            assert result is not None, model
+            assert result["estimated_non_cached_input_cost"] == 100 * 10_000, model
+            assert result["estimated_cache_write_input_cost"] == 200 * 12_500, model
+            assert result["estimated_cache_read_input_cost"] == 500 * 1_000, model
+            assert result["estimated_output_cost"] == 50 * 50_000, model
 
     def test_zero_tokens_returns_all_zeros(self) -> None:
         result = compute_cost_metrics("claude-sonnet-4-6", 0, 0, 0, 0)

--- a/tests/test_codex_cost_tracker.py
+++ b/tests/test_codex_cost_tracker.py
@@ -1,0 +1,38 @@
+from ddapm_test_agent.codex_cost_tracker import compute_openai_cost_metrics
+
+
+class TestModelLookup:
+    def test_gpt_5_6(self) -> None:
+        assert compute_openai_cost_metrics("gpt-5.6", 1000, 0, 0) != {}
+
+    def test_gpt_5_6_terra(self) -> None:
+        assert compute_openai_cost_metrics("gpt-5.6-terra", 1000, 0, 0) != {}
+
+    def test_gpt_5_3_codex(self) -> None:
+        assert compute_openai_cost_metrics("gpt-5.3-codex", 1000, 0, 0) != {}
+
+    def test_unknown_model_returns_empty(self) -> None:
+        assert compute_openai_cost_metrics("claude-opus-4-8", 1000, 0, 0) == {}
+
+
+class TestCostCalculation:
+    def test_gpt_5_6_sol_pricing(self) -> None:
+        # gpt-5.6 (Sol): $5 input / $0.50 cached / $30 output per Mtok.
+        result = compute_openai_cost_metrics("gpt-5.6", 100, 20, 50)
+        assert result["estimated_non_cached_input_cost"] == 100 * 5_000
+        assert result["estimated_cache_read_input_cost"] == 20 * 500
+        assert result["estimated_output_cost"] == 50 * 30_000
+        assert result["estimated_input_cost"] == 100 * 5_000 + 20 * 500
+        assert result["estimated_total_cost"] == 100 * 5_000 + 20 * 500 + 50 * 30_000
+
+    def test_gpt_5_6_terra_not_shadowed_by_sol(self) -> None:
+        # "gpt-5.6-terra" must match the Terra tier, not the "gpt-5.6" catch-all.
+        result = compute_openai_cost_metrics("gpt-5.6-terra", 100, 0, 0)
+        assert result["estimated_non_cached_input_cost"] == 100 * 2_000
+
+    def test_gpt_5_3_codex_pricing(self) -> None:
+        # gpt-5.3-codex: $1.75 input / $0.175 cached / $14 output per Mtok.
+        result = compute_openai_cost_metrics("gpt-5.3-codex", 100, 20, 50)
+        assert result["estimated_non_cached_input_cost"] == 100 * 1_750
+        assert result["estimated_cache_read_input_cost"] == 20 * 175
+        assert result["estimated_output_cost"] == 50 * 14_000


### PR DESCRIPTION
## What

Adds LLMObs cost-tracking pricing for the newest Claude and Codex/OpenAI models so lapdog spans get an estimated cost instead of falling through to nothing.

| Provider | Added | Rate (per Mtok) |
|---|---|---|
| Claude | `claude-sonnet-5` | $3 in / $15 out |
| Claude | `claude-fable-5`, `claude-mythos-5` | $10 in / $50 out |
| Codex/OpenAI | `gpt-5.6`, `gpt-5.6-terra` | $5/$30, $2/$12 |
| Codex/OpenAI | `gpt-5.3-codex` | $1.75/$14 (current Codex CLI default) |

`claude-opus-4-8` already landed in #379; this builds on top of it.

## Notes on ambiguous rates

Costs are estimates, so where a rate was ambiguous the **higher** value is used:
- **Sonnet 5** carries a temporary intro rate ($2/$10 through 2026-08-31); the table uses the ongoing **list** price ($3/$15) as a conservative upper bound (the table isn't date-aware).
- The nano-tier **gpt-5.6 "Luna"** rate was inconsistent across sources, so it's intentionally left out — it resolves to the higher `gpt-5.6` (Sol) rate via prefix match.

Everything else is a single authoritative published rate.

## Test plan

- New/updated unit tests in `tests/test_claude_cost_tracker.py` and new `tests/test_codex_cost_tracker.py`, including shadowing guards (`claude-opus-4-8` not priced as legacy `claude-opus-4`; `gpt-5.6-terra` not priced as `gpt-5.6` Sol).
- `pytest tests/test_claude_cost_tracker.py tests/test_codex_cost_tracker.py tests/test_codex_hooks.py tests/test_pi_hooks.py` → 106 passed.
- `black --check` and `flake8` clean.

Claude session: \`c1b09a23-7f31-4275-bdc6-de2a62ee7427\`
Resume: \`claude --resume c1b09a23-7f31-4275-bdc6-de2a62ee7427\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)