### PR TITLE
fix(proxy): recompute Content-Length on forwarded trace responses

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -257,9 +257,17 @@ async def _prepare_and_send_request(data: bytes, request: Request, headers: Mapp
     log.debug(f"Using headers: {headers}")
 
     client_response, body = await _forward_request(data, headers, full_agent_url)
+    # The body is re-serialized in _forward_request, so the agent's Content-Length no
+    # longer matches it. Drop the headers describing the original encoding and let
+    # aiohttp recompute them from the body we actually send.
+    response_headers = {
+        k: v
+        for k, v in client_response.headers.items()
+        if k.lower() not in ("content-length", "content-encoding", "transfer-encoding")
+    }
     return web.Response(
         status=client_response.status,
-        headers=client_response.headers,
+        headers=response_headers,
         body=body,
     )
 

--- a/releasenotes/notes/proxied-trace-response-truncation-8bc52fb6419a198b.yaml
+++ b/releasenotes/notes/proxied-trace-response-truncation-8bc52fb6419a198b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix truncated trace responses when proxying to a real agent via ``DD_AGENT_URL``.
+    The forwarded body is re-serialized with ``json.dumps``, making it longer than the
+    agent's compact JSON, but the agent's ``Content-Length`` was relayed verbatim. The
+    response was cut to that length and tracers failed to parse it. The headers
+    describing the original encoding are now recomputed from the body actually sent.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.request
 
 import aiohttp
+from aiohttp import web
 import msgpack
 import pytest
 
@@ -1320,3 +1321,45 @@ async def test_tcp_available_when_uds_configured(
         assert resp.status == 200
         received_traces = await resp.json()
         assert received_traces == v04_reference_http_trace_payload_data_raw
+
+
+# Enough entries that the re-serialized body is longer than the compact upstream one.
+PROXIED_RATES = {f"service:svc{i:03d},env:": 1.0 for i in range(20)}
+
+
+class TestProxiedTraceResponse:
+    """Regression: _forward_request re-serializes the upstream body with json.dumps,
+    whose default separators make it longer than the agent's compact JSON. Relaying
+    the upstream Content-Length verbatim truncated it into invalid JSON.
+    """
+
+    @pytest.fixture
+    async def agent_url(self, aiohttp_server):
+        """An upstream agent that replies with compact JSON, as the real agent does."""
+        compact = json.dumps({"rate_by_service": PROXIED_RATES}, separators=(",", ":"))
+
+        async def handler(request):
+            return web.Response(body=compact.encode(), content_type="application/json")
+
+        app = web.Application()
+        app.router.add_route("*", "/v0.4/traces", handler)
+        server = await aiohttp_server(app)
+        yield f"http://127.0.0.1:{server.port}"
+
+    async def test_response_is_not_truncated(
+        self,
+        agent,
+        v04_reference_http_trace_payload_headers,
+        v04_reference_http_trace_payload_data,
+    ):
+        resp = await agent.put(
+            "/v0.4/traces",
+            headers=v04_reference_http_trace_payload_headers,
+            data=v04_reference_http_trace_payload_data,
+        )
+
+        assert resp.status == 200
+        body = await resp.read()
+        # The declared length must describe the body sent, so it stays parseable.
+        assert int(resp.headers["Content-Length"]) == len(body)
+        assert json.loads(body) == {"rate_by_service": PROXIED_RATES}

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1335,7 +1335,7 @@ class TestProxiedTraceResponse:
 
     @pytest.fixture
     async def agent_url(self, aiohttp_server):
-        """An upstream agent that replies with compact JSON, as the real agent does."""
+        """Serve compact JSON from an upstream agent, as the real agent does."""
         compact = json.dumps({"rate_by_service": PROXIED_RATES}, separators=(",", ":"))
 
         async def handler(request):


### PR DESCRIPTION
# What Does This Do

Drops the upstream `Content-Length`, `Content-Encoding`, and `Transfer-Encoding`
headers from trace responses forwarded via `DD_AGENT_URL`, letting aiohttp
recompute them from the body actually sent. Adds regression coverage.

# Motivation

`_forward_request` re-serializes the upstream body with `json.dumps`, whose
default separators make it longer than the agent's compact JSON, but the
upstream headers were relayed verbatim. aiohttp honored the stale
`Content-Length` and truncated the body, leaving tracers with invalid JSON.

The overflow is ~2 bytes per `rate_by_service` entry, so it stays hidden until
enough services accumulate in the agent — which made it look intermittent.
Found in dd-trace-rb, which runs the test agent in proxy mode locally.

# Additional Notes

The new test fails without the fix and passes with it; the originally-failing
dd-trace-rb suite is clean through a patched image in proxy mode.