### PR TITLE
Publish completed tool spans early when their parent is already final

### DIFF
--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -1075,6 +1075,12 @@ class ClaudeHooksAPI:
         if estimated_permission_wait_ms is not None:
             self._set_hidden_metadata(span, estimated_permission_wait_ms=estimated_permission_wait_ms)
         self._append_span(span)
+        # Only publish early when the tree position is final. A parent that is
+        # not a registered step may still be re-parented when the proxy opens
+        # the inference step for this tool use; the closing flush remains the
+        # first and only forward for that provisional position.
+        if parent_id not in session.step_agent_by_span_id:
+            return None
         return span
 
     def _handle_subagent_start(self, session_id: str, body: Dict[str, Any]) -> None:

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -5,6 +5,7 @@ into LLMObs-format spans that can be queried through the Event Platform APIs.
 """
 
 import asyncio
+import copy
 import getpass
 import gzip
 import json
@@ -72,6 +73,7 @@ _RESERVED_SESSION_TAG_KEYS = frozenset(
     }
 )
 _MAX_SPANS_PER_BACKEND_REQUEST = 20
+_INCREMENTAL_FORWARD_TIMEOUT_SECONDS = 1.0
 
 # Models with 1M token context windows (native, no beta header needed).
 # All other models default to 200k.
@@ -931,7 +933,7 @@ class ClaudeHooksAPI:
             start_ns=now_ns,
         )
 
-    def _handle_post_tool_use(self, session_id: str, body: Dict[str, Any]) -> None:
+    def _handle_post_tool_use(self, session_id: str, body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Handle PostToolUse hook event.
 
         If this is PostToolUse for a "Task" tool with a deferred agent span,
@@ -1030,7 +1032,7 @@ class ClaudeHooksAPI:
                 if context_delta:
                     self._set_hidden_metadata(span, context_delta=context_delta)
                 self._append_span(span)
-            return
+            return None
 
         # Normal tool span
         duration = now_ns - start_ns
@@ -1073,6 +1075,7 @@ class ClaudeHooksAPI:
         if estimated_permission_wait_ms is not None:
             self._set_hidden_metadata(span, estimated_permission_wait_ms=estimated_permission_wait_ms)
         self._append_span(span)
+        return span
 
     def _handle_subagent_start(self, session_id: str, body: Dict[str, Any]) -> None:
         """Handle SubagentStart hook event — pushes a new agent onto the stack.
@@ -1681,8 +1684,8 @@ class ClaudeHooksAPI:
         if root_span is not None:
             root_span["duration"] = -1
 
-    def _dispatch_hook(self, body: Dict[str, Any]) -> None:
-        """Dispatch a hook event to the appropriate handler."""
+    def _dispatch_hook(self, body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Dispatch a hook event and return a completed span when one was emitted."""
         session_id = body.get("session_id", "")
         hook_event_name = body.get("hook_event_name", "")
         if session_id:
@@ -1709,9 +1712,24 @@ class ClaudeHooksAPI:
 
         handler = handlers.get(hook_event_name)
         if handler:
-            handler(session_id, body)
-        else:
-            log.debug("Unhandled hook event: %s", hook_event_name)
+            result = handler(session_id, body)
+            return result if isinstance(result, dict) else None
+        log.debug("Unhandled hook event: %s", hook_event_name)
+        return None
+
+    def _normalize_spans_for_forwarding(self, spans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Return independent backend copies with locally-derived fields removed."""
+        normalized: List[Dict[str, Any]] = []
+        for source in spans:
+            span = copy.deepcopy(source)
+            metrics = span.get("metrics")
+            if metrics:
+                span["metrics"] = {key: value for key, value in metrics.items() if key not in COST_METRIC_KEYS}
+            tags = span.get("tags") or []
+            if "lapdog_forwarded:true" not in tags:
+                span["tags"] = list(tags) + ["lapdog_forwarded:true"]
+            normalized.append(span)
+        return normalized
 
     def _resolve_backend_target(
         self,
@@ -1808,8 +1826,9 @@ class ClaudeHooksAPI:
         if target is None:
             return
         url, headers = target
+        forwarded_spans = self._normalize_spans_for_forwarding(spans)
 
-        await self._post_spans_to_backend(url, headers, spans, f"forward {len(spans)} span updates")
+        await self._post_spans_to_backend(url, headers, forwarded_spans, f"forward {len(spans)} span updates")
 
     async def _forward_trace_to_backend(
         self, session_id: str, trace_id: Optional[str] = None, span_source: str = "Claude hooks"
@@ -1829,18 +1848,7 @@ class ClaudeHooksAPI:
             return
         url, headers = target
 
-        # Strip locally-computed cost estimates before forwarding — let real cost tracking happen on ingestion
-        forwarded_spans = []
-        for s in spans:
-            span = (
-                {**s, "metrics": {k: v for k, v in s["metrics"].items() if k not in COST_METRIC_KEYS}}
-                if s.get("metrics")
-                else dict(s)
-            )
-            tags: List[Any] = span.get("tags") or []
-            if "lapdog_forwarded:true" not in tags:
-                span["tags"] = tags + ["lapdog_forwarded:true"]
-            forwarded_spans.append(span)
+        forwarded_spans = self._normalize_spans_for_forwarding(spans)
 
         await self._post_spans_to_backend(
             url,
@@ -1933,9 +1941,18 @@ class ClaudeHooksAPI:
         if body.get("hook_event_name") == "Stop":
             await asyncio.sleep(1.0)
 
-        self._dispatch_hook(body)
+        completed_span = self._dispatch_hook(body)
 
         hook_event_name = body.get("hook_event_name", "")
+
+        if hook_event_name == "PostToolUse" and completed_span is not None:
+            try:
+                await asyncio.wait_for(
+                    self._forward_span_update([completed_span]),
+                    timeout=_INCREMENTAL_FORWARD_TIMEOUT_SECONDS,
+                )
+            except Exception as e:
+                log.warning("Error trying to forward completed tool span: %r", e)
 
         # Forward completed traces to the backend (includes the now-updated root span).
         # The eager root span is only used locally so the test agent UI has a root node

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,11 +1,16 @@
+import asyncio
 import gzip
 import json
 import os
 import subprocess
 import tempfile
+from typing import Any
+from typing import Dict
+from typing import List
 
 import msgpack
 
+from ddapm_test_agent import claude_hooks as claude_hooks_module
 from ddapm_test_agent.claude_hooks import ClaudeHooksAPI
 from ddapm_test_agent.claude_link_tracker import ClaudeLinkTracker
 from ddapm_test_agent.claude_proxy import ClaudeProxyAPI
@@ -1200,3 +1205,211 @@ def test_instrumented_live_task_subagent_parents_to_spawning_step():
     assert subagent["name"] == "Task - Explore"
     assert subagent["parent_id"] == step["span_id"]
     assert by_id[subagent["parent_id"]]["meta"]["span"]["kind"] == "step"
+
+
+class _HookRequest:
+    def __init__(self, body: Dict[str, Any]) -> None:
+        self._body = body
+
+    async def json(self) -> Dict[str, Any]:
+        return dict(self._body)
+
+
+async def test_post_tool_use_incrementally_forwards_completed_tool_before_stop(monkeypatch):
+    hooks = ClaudeHooksAPI()
+    hooks.set_app(
+        {
+            "disable_llmobs_data_forwarding": False,
+            "dd_site": "datadoghq.com",
+            "dd_api_key": "test-key",
+            "agent_url": "",
+        }
+    )
+    calls = []
+    backend = {}
+
+    async def fake_post_spans(url: str, headers: Dict[str, str], spans: List[Dict[str, Any]], description: str) -> None:
+        calls.append((description, spans))
+        for span in spans:
+            backend[(span["trace_id"], span["span_id"])] = span
+
+    monkeypatch.setattr(hooks, "_post_spans_to_backend", fake_post_spans)
+    session_id = "incremental-session"
+    await hooks.handle_hook(_HookRequest({"session_id": session_id, "hook_event_name": "SessionStart"}))
+    await hooks.handle_hook(
+        _HookRequest(
+            {
+                "session_id": session_id,
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "run a tool",
+            }
+        )
+    )
+    await hooks.handle_hook(
+        _HookRequest(
+            {
+                "session_id": session_id,
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_use_id": "tool-1",
+                "tool_input": {"command": "true"},
+            }
+        )
+    )
+    await hooks.handle_hook(
+        _HookRequest(
+            {
+                "session_id": session_id,
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Bash",
+                "tool_use_id": "tool-1",
+                "tool_response": "ok",
+            }
+        )
+    )
+
+    assert len(calls) == 1
+    description, tool_spans = calls[0]
+    assert description == "forward 1 span updates"
+    assert any(span["span_id"] == tool_spans[0]["span_id"] for span in hooks._assembled_spans)
+    assert tool_spans[0]["meta"]["span"]["kind"] == "tool"
+    assert tool_spans[0]["meta"]["metadata"]["tool_id"] == "tool-1"
+
+    await hooks.handle_hook(_HookRequest({"session_id": session_id, "hook_event_name": "Stop"}))
+    assert len(calls) == 2
+    assert len(backend) == len({(span["trace_id"], span["span_id"]) for span in hooks._assembled_spans})
+
+    hooks._set_session_tags(hooks._sessions[session_id], {"post_close": "yes"})
+    assert all("post_close:yes" in span["tags"] for span in hooks._assembled_spans)
+    assert all("post_close:yes" not in span["tags"] for _, spans in calls for span in spans)
+
+
+async def test_forwarders_share_non_mutating_normalization(monkeypatch):
+    hooks = ClaudeHooksAPI()
+    session = hooks._get_or_create_session("normalization-session")
+    source = {
+        "span_id": "span-1",
+        "trace_id": session.trace_id,
+        "tags": ["session_id:normalization-session"],
+        "metrics": {"input_tokens": 10, "estimated_total_cost": 3.5, "custom": 20},
+    }
+    hooks._assembled_spans = [source]
+    hooks.set_app(
+        {
+            "disable_llmobs_data_forwarding": False,
+            "dd_site": "datadoghq.com",
+            "dd_api_key": "test-key",
+            "agent_url": "",
+        }
+    )
+    sent = []
+
+    async def fake_post_spans(url: str, headers: Dict[str, str], spans: List[Dict[str, Any]], description: str) -> None:
+        sent.append(spans)
+
+    monkeypatch.setattr(hooks, "_post_spans_to_backend", fake_post_spans)
+    await hooks._forward_span_update([source])
+    await hooks._forward_trace_to_backend(session.session_id)
+
+    assert sent[0] == sent[1]
+    assert sent[0][0]["metrics"] == {"input_tokens": 10, "custom": 20}
+    assert sent[0][0]["tags"] == ["session_id:normalization-session", "lapdog_forwarded:true"]
+    assert source == {
+        "span_id": "span-1",
+        "trace_id": session.trace_id,
+        "tags": ["session_id:normalization-session"],
+        "metrics": {"input_tokens": 10, "estimated_total_cost": 3.5, "custom": 20},
+    }
+
+
+async def test_incremental_forwarding_guards_and_failure_isolation(monkeypatch):
+    hooks = ClaudeHooksAPI()
+    span = {"span_id": "span-1", "trace_id": "trace-1", "metrics": {}, "tags": []}
+    calls = []
+
+    async def fake_post_spans(*args: Any) -> None:
+        calls.append(args)
+
+    monkeypatch.setattr(hooks, "_post_spans_to_backend", fake_post_spans)
+    await hooks._forward_span_update([span])
+    assert calls == []
+
+    hooks.set_app(
+        {
+            "disable_llmobs_data_forwarding": True,
+            "dd_site": "datadoghq.com",
+            "dd_api_key": "test-key",
+            "agent_url": "",
+        }
+    )
+    await hooks._forward_span_update([span])
+    assert calls == []
+
+    hooks._app["disable_llmobs_data_forwarding"] = False
+    hooks._app["dd_api_key"] = None
+    await hooks._forward_span_update([span])
+    assert calls == []
+
+
+async def test_incremental_timeout_cancels_held_open_sender_and_preserves_hook_result(monkeypatch, caplog):
+    hooks = ClaudeHooksAPI()
+    hooks.set_app(
+        {
+            "disable_llmobs_data_forwarding": False,
+            "dd_site": "",
+            "dd_api_key": None,
+            "agent_url": "http://127.0.0.1:1",
+        }
+    )
+    assert claude_hooks_module._INCREMENTAL_FORWARD_TIMEOUT_SECONDS == 1.0
+    production_timeout = 0.05
+    monkeypatch.setattr(claude_hooks_module, "_INCREMENTAL_FORWARD_TIMEOUT_SECONDS", production_timeout)
+    sender_started = asyncio.Event()
+    sender_cancelled = asyncio.Event()
+
+    async def held_open_post(*args: Any) -> None:
+        sender_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            sender_cancelled.set()
+            raise
+
+    monkeypatch.setattr(hooks, "_post_to_backend", held_open_post)
+    session_id = "timeout-session"
+    await hooks.handle_hook(_HookRequest({"session_id": session_id, "hook_event_name": "SessionStart"}))
+    await hooks.handle_hook(
+        _HookRequest(
+            {
+                "session_id": session_id,
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_use_id": "timeout-tool",
+                "tool_input": {"command": "true"},
+            }
+        )
+    )
+    with caplog.at_level("WARNING", logger=claude_hooks_module.__name__):
+        response = await asyncio.wait_for(
+            hooks.handle_hook(
+                _HookRequest(
+                    {
+                        "session_id": session_id,
+                        "hook_event_name": "PostToolUse",
+                        "tool_name": "Bash",
+                        "tool_use_id": "timeout-tool",
+                        "tool_response": "ok",
+                    }
+                )
+            ),
+            timeout=production_timeout * 10,
+        )
+
+    assert sender_started.is_set()
+    assert any(
+        record.getMessage() == "Error trying to forward completed tool span: TimeoutError()"
+        for record in caplog.records
+    )
+    assert sender_cancelled.is_set()
+    assert response.status == 200
+    assert json.loads(response.body) == {"status": "ok"}

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1217,6 +1217,7 @@ class _HookRequest:
 
 async def test_post_tool_use_incrementally_forwards_completed_tool_before_stop(monkeypatch):
     hooks = ClaudeHooksAPI()
+    hooks._link_tracker = ClaudeLinkTracker()
     hooks.set_app(
         {
             "disable_llmobs_data_forwarding": False,
@@ -1235,7 +1236,11 @@ async def test_post_tool_use_incrementally_forwards_completed_tool_before_stop(m
 
     monkeypatch.setattr(hooks, "_post_spans_to_backend", fake_post_spans)
     session_id = "incremental-session"
-    await hooks.handle_hook(_HookRequest({"session_id": session_id, "hook_event_name": "SessionStart"}))
+    await hooks.handle_hook(
+        _HookRequest(
+            {"session_id": session_id, "hook_event_name": "SessionStart", "lapdog_instrumented": True}
+        )
+    )
     await hooks.handle_hook(
         _HookRequest(
             {
@@ -1245,6 +1250,15 @@ async def test_post_tool_use_incrementally_forwards_completed_tool_before_stop(m
             }
         )
     )
+    session = hooks._sessions[session_id]
+    hooks._start_step_for_llm(
+        session=session,
+        llm_span_id="llm-1",
+        agent_parent_id=session.root_span_id,
+        llm_start_ns=1,
+        tool_use_ids=["tool-1"],
+    )
+    hooks._link_tracker.on_llm_tool_choice("tool-1", "Bash", "{}", "llm-1", session.trace_id)
     await hooks.handle_hook(
         _HookRequest(
             {
@@ -1282,6 +1296,94 @@ async def test_post_tool_use_incrementally_forwards_completed_tool_before_stop(m
     hooks._set_session_tags(hooks._sessions[session_id], {"post_close": "yes"})
     assert all("post_close:yes" in span["tags"] for span in hooks._assembled_spans)
     assert all("post_close:yes" not in span["tags"] for _, spans in calls for span in spans)
+
+
+async def test_turn_root_parent_is_deferred_to_single_final_flush(monkeypatch):
+    hooks = ClaudeHooksAPI()
+    hooks.set_app(
+        {
+            "disable_llmobs_data_forwarding": False,
+            "dd_site": "datadoghq.com",
+            "dd_api_key": "test-key",
+            "agent_url": "",
+        }
+    )
+    rows = []
+
+    async def fake_post_spans(url: str, headers: Dict[str, str], spans: List[Dict[str, Any]], description: str) -> None:
+        rows.extend(spans)
+
+    monkeypatch.setattr(hooks, "_post_spans_to_backend", fake_post_spans)
+    session_id = "turn-root-parent-session"
+    await hooks.handle_hook(_HookRequest({"session_id": session_id, "hook_event_name": "SessionStart"}))
+    await hooks.handle_hook(
+        _HookRequest({"session_id": session_id, "hook_event_name": "UserPromptSubmit", "prompt": "run a tool"})
+    )
+    await hooks.handle_hook(
+        _HookRequest(
+            {"session_id": session_id, "hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_use_id": "root-tool", "tool_input": {"command": "true"}}
+        )
+    )
+    await hooks.handle_hook(
+        _HookRequest(
+            {"session_id": session_id, "hook_event_name": "PostToolUse", "tool_name": "Bash", "tool_use_id": "root-tool", "tool_response": "ok"}
+        )
+    )
+
+    assert not [row for row in rows if row.get("meta", {}).get("metadata", {}).get("tool_id") == "root-tool"]
+    await hooks.handle_hook(_HookRequest({"session_id": session_id, "hook_event_name": "Stop"}))
+
+    tool_rows = [row for row in rows if row.get("meta", {}).get("metadata", {}).get("tool_id") == "root-tool"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0]["parent_id"] == hooks._sessions[session_id].root_span_id
+
+
+async def test_late_reparent_still_produces_one_final_row_under_step(monkeypatch):
+    hooks = ClaudeHooksAPI()
+    hooks.set_app(
+        {
+            "disable_llmobs_data_forwarding": False,
+            "dd_site": "datadoghq.com",
+            "dd_api_key": "test-key",
+            "agent_url": "",
+        }
+    )
+    rows = []
+
+    async def fake_post_spans(url: str, headers: Dict[str, str], spans: List[Dict[str, Any]], description: str) -> None:
+        rows.extend(spans)
+
+    monkeypatch.setattr(hooks, "_post_spans_to_backend", fake_post_spans)
+    session_id = "late-reparent-session"
+    await hooks.handle_hook(
+        _HookRequest({"session_id": session_id, "hook_event_name": "SessionStart", "lapdog_instrumented": True})
+    )
+    await hooks.handle_hook(
+        _HookRequest({"session_id": session_id, "hook_event_name": "UserPromptSubmit", "prompt": "run a tool"})
+    )
+    await hooks.handle_hook(
+        _HookRequest({"session_id": session_id, "hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_use_id": "late-tool", "tool_input": {"command": "true"}})
+    )
+    await hooks.handle_hook(
+        _HookRequest({"session_id": session_id, "hook_event_name": "PostToolUse", "tool_name": "Bash", "tool_use_id": "late-tool", "tool_response": "ok"})
+    )
+    assert rows == []
+
+    session = hooks._sessions[session_id]
+    active_step = hooks._start_step_for_llm(
+        session=session,
+        llm_span_id="late-llm",
+        agent_parent_id=session.root_span_id,
+        llm_start_ns=1,
+        tool_use_ids=["late-tool"],
+    )
+    tool = next(span for span in hooks._assembled_spans if span.get("meta", {}).get("metadata", {}).get("tool_id") == "late-tool")
+    assert tool["parent_id"] == active_step.span_id
+
+    await hooks.handle_hook(_HookRequest({"session_id": session_id, "hook_event_name": "Stop"}))
+    tool_rows = [row for row in rows if row.get("meta", {}).get("metadata", {}).get("tool_id") == "late-tool"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0]["parent_id"] == active_step.span_id
 
 
 async def test_forwarders_share_non_mutating_normalization(monkeypatch):
@@ -1353,6 +1455,7 @@ async def test_incremental_forwarding_guards_and_failure_isolation(monkeypatch):
 
 async def test_incremental_timeout_cancels_held_open_sender_and_preserves_hook_result(monkeypatch, caplog):
     hooks = ClaudeHooksAPI()
+    hooks._link_tracker = ClaudeLinkTracker()
     hooks.set_app(
         {
             "disable_llmobs_data_forwarding": False,
@@ -1377,7 +1480,16 @@ async def test_incremental_timeout_cancels_held_open_sender_and_preserves_hook_r
 
     monkeypatch.setattr(hooks, "_post_to_backend", held_open_post)
     session_id = "timeout-session"
-    await hooks.handle_hook(_HookRequest({"session_id": session_id, "hook_event_name": "SessionStart"}))
+    await hooks.handle_hook(
+        _HookRequest(
+            {"session_id": session_id, "hook_event_name": "SessionStart", "lapdog_instrumented": True}
+        )
+    )
+    session = hooks._sessions[session_id]
+    hooks._start_step_for_llm(
+        session=session, llm_span_id="timeout-llm", agent_parent_id=session.root_span_id, llm_start_ns=1, tool_use_ids=["timeout-tool"]
+    )
+    hooks._link_tracker.on_llm_tool_choice("timeout-tool", "Bash", "{}", "timeout-llm", session.trace_id)
     await hooks.handle_hook(
         _HookRequest(
             {


### PR DESCRIPTION
### Problem
The test agent's Claude-hook path forwards spans only at the closing flush (`Stop`/`SessionEnd`), so a completed tool span is invisible in LLM Observability until its whole turn closes. During a long-running agent turn, tool activity is not observable until the end.

### Cause
A tool span's parent is provisional until its inference step exists. `_reparent_stale_children_to_step` moves a tool from the turn root to its inference step in one direction only, after the fact. When a tool completes at `PostToolUse`, its parent may still be the turn root, which the closing flush later re-parents under a step. In our runs, re-sending one span ID under a changed `parent_id` produced two rows rather than one.

### Fix
Call the existing incremental forwarder `_forward_span_update()` from the successful `PostToolUse` branch, after the completed tool span is appended, gated on parent finality: forward only a completed tool span whose `parent_id` is already a registered step span for the session. A turn-root-parented tool is not forwarded early; the closing flush publishes it. The incremental send inherits the final flush's normalization, forwarding-disable, target-resolution, authentication, tagging, cost-metric stripping, and failure-isolation policy, and is bounded to a 1-second await below the packaged Claude hook's 2-second local-call budget. No stored span is mutated.

### Evidence
- Focused Claude-hook gate on `a6b847bb`: **31 passed** (exit 0).
- Full pytest gate on `a6b847bb`: **685 passed / 3 skipped** (exit 0).
- Readings below are from a private Datadog org (link viewable to that org only); the hermetic gates above are reproducible from this repo.
- Real ParkBench dogfood run on the gated revision produced a valid scored report; its still-open turn exposed **9 completed tool spans with zero duplicate span IDs**. Observed early coverage: **9/13** tool spans.
- Independent workspace-org read: 48 unique rows in one trace and session — agent 1 / step 17 / llm 17 / tool 13, every tool under a step, zero duplicate or missing-parent IDs.
- Real ParkBench trace: https://app.datadoghq.com/llm/traces?query=trace_id%3A6a965012000000000c4effadf141f509

### Limitation
Early coverage is partial by design: only tool spans whose parent is already final (a registered step) are forwarded early. A tool span whose parent is still the turn root at `PostToolUse` is not forwarded until the closing flush. This is a deliberate trade for parent stability, not a claim of completeness. This change does not claim liveness, merge, or release; it only makes already-completed tool spans observable earlier when their tree position is final.
