### PR TITLE
fix(lapdog): bound in-memory retention

### DIFF
--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -408,7 +408,7 @@ class _AgentSession:
 
 
 class Agent:
-    def __init__(self) -> None:
+    def __init__(self, max_requests: Optional[int] = None) -> None:
         """
         Try to only store the requests sent to the agent. There are many representations
         of data but typically information is lost while transforming the data so it is best
@@ -416,6 +416,7 @@ class Agent:
         """
         # Token to be used if running test cases synchronously
         self._requests: List[Request] = []
+        self._max_requests = max(0, max_requests) if max_requests is not None else None
         self._rc_server = RemoteConfigServer()
         self._trace_failures: Dict[str, List[Tuple[CheckTrace, str]]] = defaultdict(default_value_trace_failures)
         self._trace_check_results_by_check: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(
@@ -555,7 +556,12 @@ class Agent:
         # result in: RuntimeError: readany() called while another coroutine is already waiting for incoming data
         # See: https://github.com/DataDog/dd-apm-test-agent/pull/101 for more info
         request["_testagent_data"] = await request.read()
+        self._append_request(request)
+
+    def _append_request(self, request: Request) -> None:
         self._requests.append(request)
+        if self._max_requests is not None and len(self._requests) > self._max_requests:
+            del self._requests[: len(self._requests) - self._max_requests]
 
     def _request_data(self, request: Request) -> bytes:
         """Return the data from the request.
@@ -832,7 +838,7 @@ class Agent:
             handler=self.handle_evp_proxy_v4_api_v2_llmobs,
             session_token=token,
         )
-        self._requests.append(cast(Request, synthetic))
+        self._append_request(cast(Request, synthetic))
 
     def _decode_v05_traces(self, request: Request) -> v04TracePayload:
         raw_data = self._request_data(request)
@@ -1386,7 +1392,7 @@ class Agent:
 
     async def handle_session_start(self, request: Request) -> web.Response:
         rates = json.loads(request.url.query.get("agent_sample_rate_by_service", "{}"))
-        self._requests.append(request)
+        self._append_request(request)
         session = self._sessions[_session_token(request)]
         session.sample_rate_by_service_env = rates
         log.info("Starting new session with token %r: %r", _session_token(request), session)
@@ -1636,7 +1642,7 @@ class Agent:
 
     async def handle_v1_profiling(self, request: Request) -> web.Response:
         await request.read()
-        self._requests.append(request)
+        self._append_request(request)
         # TODO: valid response?
         return web.HTTPOk()
 
@@ -2068,8 +2074,10 @@ def make_app(
     lapdog_mode: bool = False,
     org_prop_marker: str = "",
     enable_web_ui: bool = False,
+    max_requests: int = 200,
 ) -> web.Application:
-    agent = Agent()
+    retention_limit = max_requests if lapdog_mode else None
+    agent = Agent(max_requests=retention_limit)
 
     # Build middleware list conditionally
     middlewares = []
@@ -2157,7 +2165,10 @@ def make_app(
 
     # Add Claude Code hooks and proxy routes with shared link tracker
     claude_link_tracker = ClaudeLinkTracker()
-    claude_hooks_api = ClaudeHooksAPI(link_tracker=claude_link_tracker)
+    claude_hooks_api = ClaudeHooksAPI(
+        link_tracker=claude_link_tracker,
+        retention_limit=retention_limit,
+    )
     claude_hooks_api.set_app(app)
     app.add_routes(claude_hooks_api.get_routes())
     llmobs_event_platform_api.set_claude_hooks_api(claude_hooks_api)
@@ -2165,10 +2176,10 @@ def make_app(
     claude_proxy_api = ClaudeProxyAPI(hooks_api=claude_hooks_api, link_tracker=claude_link_tracker)
     app.add_routes(claude_proxy_api.get_routes())
 
-    pi_hooks_api = PiHooksAPI(hooks_api=claude_hooks_api)
+    pi_hooks_api = PiHooksAPI(hooks_api=claude_hooks_api, retention_limit=retention_limit)
     app.add_routes(pi_hooks_api.get_routes())
 
-    codex_hooks_api = CodexHooksAPI(hooks_api=claude_hooks_api)
+    codex_hooks_api = CodexHooksAPI(hooks_api=claude_hooks_api, retention_limit=retention_limit)
     app.add_routes(codex_hooks_api.get_routes())
 
     codex_proxy_api = CodexProxyAPI(hooks_api=codex_hooks_api)
@@ -2551,7 +2562,7 @@ def main(args: Optional[List[str]] = None) -> None:
         "--max-requests",
         type=int,
         default=int(os.environ.get("MAX_REQUESTS", 200)),
-        help="Maximum number of requests to keep in memory for the UI (default: 200). Older requests are discarded when limit is reached.",
+        help="Maximum number of requests and events to keep in memory for the UI and Lapdog mode (default: 200). Older entries are discarded when the limit is reached.",
     )
     parser.add_argument(
         "--dd-site",
@@ -2643,6 +2654,7 @@ def main(args: Optional[List[str]] = None) -> None:
         lapdog_mode=parsed_args.lapdog_mode,
         org_prop_marker=parsed_args.org_prop_marker,
         enable_web_ui=parsed_args.web_ui_port > 0,
+        max_requests=parsed_args.max_requests,
     )
 
     # Validate port configuration

--- a/ddapm_test_agent/claude_hooks.py
+++ b/ddapm_test_agent/claude_hooks.py
@@ -329,7 +329,11 @@ def _extract_intent(tool_name: str, tool_input: Any) -> str:
 class ClaudeHooksAPI:
     """Handler for Claude Code hook events."""
 
-    def __init__(self, link_tracker: Optional[ClaudeLinkTracker] = None) -> None:
+    def __init__(
+        self,
+        link_tracker: Optional[ClaudeLinkTracker] = None,
+        retention_limit: Optional[int] = None,
+    ) -> None:
         self._sessions: Dict[str, SessionState] = {}
         self._session_ids_by_token: Dict[str, Set[str]] = {}
         self._session_tokens_by_id: Dict[str, Set[str]] = {}
@@ -337,6 +341,8 @@ class ClaudeHooksAPI:
         self._tag_update_sequence = 0
         self._assembled_spans: List[Dict[str, Any]] = []
         self._raw_events: List[Dict[str, Any]] = []
+        self._retention_limit = max(0, retention_limit) if retention_limit is not None else None
+        self._completed_trace_ids: List[str] = []
         self._link_tracker = link_tracker
         self._app: Optional[web.Application] = None
 
@@ -427,6 +433,19 @@ class ClaudeHooksAPI:
             self._assembled_spans.append(span)
         else:
             self._assembled_spans.insert(index, span)
+
+    def _append_raw_event(self, event: Dict[str, Any]) -> None:
+        self._raw_events.append(event)
+        if self._retention_limit is not None and len(self._raw_events) > self._retention_limit:
+            del self._raw_events[: len(self._raw_events) - self._retention_limit]
+
+    def _mark_trace_completed(self, trace_id: str) -> None:
+        if self._retention_limit is None or trace_id in self._completed_trace_ids:
+            return
+        self._completed_trace_ids.append(trace_id)
+        while len(self._completed_trace_ids) > self._retention_limit:
+            expired_trace_id = self._completed_trace_ids.pop(0)
+            self._assembled_spans = [span for span in self._assembled_spans if span.get("trace_id") != expired_trace_id]
 
     def _get_or_create_session(self, session_id: str) -> SessionState:
         """Get existing session or create a new one."""
@@ -1927,7 +1946,7 @@ class ClaudeHooksAPI:
         session_token = body.pop("lapdog_session_token", "")
         if isinstance(session_token, str) and session_token:
             self._register_session_token(session_token, session_id)
-        self._raw_events.append(body)
+        self._append_raw_event(body)
 
         # wait for the transcript to be fully flushed before dispatching the hook
         if body.get("hook_event_name") == "Stop":
@@ -1944,6 +1963,9 @@ class ClaudeHooksAPI:
         if hook_event_name in ("Stop", "SessionEnd"):
             await self._forward_trace_to_backend(session_id)
             await self._forward_eval_metrics_to_backend(session_id)
+            session = self._sessions.get(session_id)
+            if session is not None:
+                self._mark_trace_completed(session.trace_id)
 
         return web.json_response({"status": "ok"})
 
@@ -2090,7 +2112,10 @@ class ClaudeHooksAPI:
             log.warning("claude backfill_session failed for %s: %r", session_id, exc)
             return web.json_response({"status": "error", "error": repr(exc)}, status=400)
         self._assembled_spans.extend(spans)
-        traces = len({s.get("trace_id") for s in spans})
+        trace_ids = {str(s.get("trace_id")) for s in spans if s.get("trace_id")}
+        for trace_id in trace_ids:
+            self._mark_trace_completed(trace_id)
+        traces = len(trace_ids)
         return web.json_response({"status": "ok", "spans_created": len(spans), "traces_created": traces})
 
     def get_routes(self) -> List[web.RouteDef]:

--- a/ddapm_test_agent/codex_hooks.py
+++ b/ddapm_test_agent/codex_hooks.py
@@ -1,6 +1,7 @@
 """Codex session JSONL -> LLM Observability spans."""
 
 import datetime
+import hashlib
 import json
 import logging
 import os
@@ -300,7 +301,7 @@ class CodexTurn:
 
 
 class CodexSession:
-    def __init__(self, session_id: str, start_ns: int) -> None:
+    def __init__(self, session_id: str, start_ns: int, retention_limit: Optional[int] = None) -> None:
         self.raw_session_id = session_id
         self.session_id = session_id
         self.start_ns = start_ns
@@ -319,7 +320,9 @@ class CodexSession:
         self.pending_tool_reasoning: Dict[str, List[Dict[str, Any]]] = {}
         self.active_turn: Optional[CodexTurn] = None
         self.completed_turns: List[str] = []
-        self.seen_records: Set[str] = set()
+        self.seen_records: Set[bytes] = set()
+        self.seen_record_order: List[bytes] = []
+        self.retention_limit = max(0, retention_limit) if retention_limit is not None else None
         # Codex reuses tool call_ids like "web_search_2" across turns. Track
         # how many times each id has been seen and the unique id currently in
         # flight so PendingToolSpan keys stay unique and outputs pair correctly.
@@ -331,6 +334,18 @@ class CodexSession:
         self.pending_subagents: Dict[str, Dict[str, Any]] = {}
         self.task_id = ""
         self.proxy_session_keys: Set[str] = set()
+
+    def remember_record(self, record_fingerprint: str) -> bool:
+        digest = hashlib.sha256(record_fingerprint.encode()).digest()
+        if digest in self.seen_records:
+            return False
+        self.seen_records.add(digest)
+        if self.retention_limit is not None:
+            self.seen_record_order.append(digest)
+            if len(self.seen_record_order) > self.retention_limit:
+                expired_digest = self.seen_record_order.pop(0)
+                self.seen_records.remove(expired_digest)
+        return True
 
 
 class CodexConfig:
@@ -350,11 +365,13 @@ class CodexHooksAPI:
     and posts each record here, wrapped with the Codex session id.
     """
 
-    def __init__(self, hooks_api: ClaudeHooksAPI) -> None:
+    def __init__(self, hooks_api: ClaudeHooksAPI, retention_limit: Optional[int] = None) -> None:
         self._hooks_api = hooks_api
         self._config = CodexConfig()
         self._sessions: Dict[str, CodexSession] = {}
         self._raw_events: List[Dict[str, Any]] = []
+        self._retention_limit = max(0, retention_limit) if retention_limit is not None else None
+        self._completed_trace_ids: List[str] = []
         self._last_session_id = ""
         self._proxy_session_ids: Dict[str, str] = {}
         self._orphan_proxy_llm_spans: List[OrphanProxySpan] = []
@@ -394,7 +411,11 @@ class CodexHooksAPI:
     def _get_or_create_session(self, session_id: str, start_ns: int) -> CodexSession:
         if session_id not in self._sessions:
             group_session_id = self._child_session_ids.get(session_id, session_id)
-            self._sessions[session_id] = CodexSession(session_id=group_session_id, start_ns=start_ns)
+            self._sessions[session_id] = CodexSession(
+                session_id=group_session_id,
+                start_ns=start_ns,
+                retention_limit=self._retention_limit,
+            )
             if session_id not in self._hooks_api._sessions:
                 self._hooks_api._sessions[session_id] = SessionState(
                     session_id=group_session_id,
@@ -1897,10 +1918,8 @@ class CodexHooksAPI:
             record_fingerprint = json.dumps(record, sort_keys=True, separators=(",", ":"))
         except (TypeError, ValueError):
             record_fingerprint = ""
-        if record_fingerprint:
-            if record_fingerprint in session.seen_records:
-                return []
-            session.seen_records.add(record_fingerprint)
+        if record_fingerprint and not session.remember_record(record_fingerprint):
+            return []
 
         record_type = record.get("type", "")
 
@@ -1950,6 +1969,8 @@ class CodexHooksAPI:
         raw_body = dict(body)
         raw_body.pop("proxy_session_key", None)
         self._raw_events.append(raw_body)
+        if self._retention_limit is not None and len(self._raw_events) > self._retention_limit:
+            del self._raw_events[: len(self._raw_events) - self._retention_limit]
         self._last_session_id = session_id
         is_backfill = body.get("backfill") is True
         completed = self._dispatch(session_id, record, proxy_session_key=proxy_session_key)
@@ -1961,7 +1982,23 @@ class CodexHooksAPI:
                 await self._hooks_api._forward_eval_metrics_to_backend(
                     completed_session_id, trace_id=completed_trace_id
                 )
+        for _, completed_trace_id in completed:
+            self._mark_trace_completed(completed_trace_id)
         return web.json_response({"status": "ok"})
+
+    def _mark_trace_completed(self, trace_id: str) -> None:
+        if self._retention_limit is None or trace_id in self._completed_trace_ids:
+            return
+        self._completed_trace_ids.append(trace_id)
+        while len(self._completed_trace_ids) > self._retention_limit:
+            expired_trace_id = self._completed_trace_ids.pop(0)
+            self._hooks_api._assembled_spans = [
+                span for span in self._hooks_api._assembled_spans if span.get("trace_id") != expired_trace_id
+            ]
+            for session in self._sessions.values():
+                turn = session.active_turn
+                if turn is not None and turn.closed and turn.trace_id == expired_trace_id:
+                    session.active_turn = None
 
     async def handle_raw_events(self, request: Request) -> web.Response:
         return web.json_response({"events": self._raw_events})

--- a/ddapm_test_agent/pi_hooks.py
+++ b/ddapm_test_agent/pi_hooks.py
@@ -288,9 +288,10 @@ class PiHooksAPI:
     forwarding so pi traces are queryable through the same Event Platform APIs.
     """
 
-    def __init__(self, hooks_api: ClaudeHooksAPI) -> None:
+    def __init__(self, hooks_api: ClaudeHooksAPI, retention_limit: Optional[int] = None) -> None:
         self._hooks_api = hooks_api
         self._raw_events: List[Dict[str, Any]] = []
+        self._retention_limit = max(0, retention_limit) if retention_limit is not None else None
         # Pending LLM span per session (pi sends one LLM call at a time)
         self._pending_llm: Dict[str, PendingLLMSpan] = {}
         # Active step span per session (one inference cycle)
@@ -1080,6 +1081,8 @@ class PiHooksAPI:
         if isinstance(session_token, str) and session_token:
             self._hooks_api._register_session_token(session_token, session_id)
         self._raw_events.append(body)
+        if self._retention_limit is not None and len(self._raw_events) > self._retention_limit:
+            del self._raw_events[: len(self._raw_events) - self._retention_limit]
         self._dispatch(body)
 
         hook_event_name = body.get("hook_event_name", "")
@@ -1088,6 +1091,9 @@ class PiHooksAPI:
         if hook_event_name in ("agent_end", "session_shutdown"):
             await self._hooks_api._forward_trace_to_backend(session_id)
             await self._hooks_api._forward_eval_metrics_to_backend(session_id)
+            session = self._hooks_api._sessions.get(session_id)
+            if session is not None:
+                self._hooks_api._mark_trace_completed(session.trace_id)
 
         return web.json_response({"status": "ok"})
 
@@ -1134,7 +1140,10 @@ class PiHooksAPI:
             log.warning("pi backfill_session failed for %s: %r", session_id, exc)
             return web.json_response({"status": "error", "error": repr(exc)}, status=400)
         self._hooks_api._assembled_spans.extend(spans)
-        traces = len({s.get("trace_id") for s in spans})
+        trace_ids = {str(s.get("trace_id")) for s in spans if s.get("trace_id")}
+        for trace_id in trace_ids:
+            self._hooks_api._mark_trace_completed(trace_id)
+        traces = len(trace_ids)
         return web.json_response({"status": "ok", "spans_created": len(spans), "traces_created": traces})
 
     def get_routes(self) -> List[web.RouteDef]:

--- a/releasenotes/notes/bound-lapdog-memory-c08ce57b1bcaaff7.yaml
+++ b/releasenotes/notes/bound-lapdog-memory-c08ce57b1bcaaff7.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Bound in-memory request, coding-agent event, and completed trace retention
+    when the test agent runs in Lapdog mode.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,16 @@ def disable_llmobs_data_forwarding() -> Generator[bool, None, None]:
 
 
 @pytest.fixture
+def lapdog_mode() -> Generator[bool, None, None]:
+    yield False
+
+
+@pytest.fixture
+def max_requests() -> Generator[int, None, None]:
+    yield 200
+
+
+@pytest.fixture
 async def agent_app(
     aiohttp_server,
     agent_enabled_checks,
@@ -187,6 +197,8 @@ async def agent_app(
     dd_site,
     dd_api_key,
     disable_llmobs_data_forwarding,
+    lapdog_mode,
+    max_requests,
 ):
     app = await aiohttp_server(
         make_app(
@@ -211,6 +223,8 @@ async def agent_app(
             dd_site=dd_site,
             dd_api_key=dd_api_key,
             disable_llmobs_data_forwarding=disable_llmobs_data_forwarding,
+            lapdog_mode=lapdog_mode,
+            max_requests=max_requests,
         )
     )
     yield app

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -8,6 +8,7 @@ import msgpack
 import pytest
 
 from ddapm_test_agent.claude_hooks import ClaudeHooksAPI
+from ddapm_test_agent.codex_hooks import CodexSession
 
 
 @pytest.fixture
@@ -242,6 +243,42 @@ async def test_codex_raw_events_redact_launch_token(agent):
     assert raw_events
     assert all("proxy_session_key" not in event for event in raw_events)
     assert "codex-secret-launch-token" not in json.dumps(raw_events)
+
+
+@pytest.mark.parametrize(("lapdog_mode", "max_requests"), [(True, 2)])
+async def test_codex_lapdog_mode_bounds_in_memory_history(agent, agent_app, lapdog_mode, max_requests):
+    for index in range(3):
+        session_id = f"bounded-codex-{index}"
+        await _post(agent, session_id, _session_meta(session_id))
+        await _post(agent, session_id, _turn_context(f"turn-{index}"))
+        await _post(agent, session_id, _event("user_message", message=f"input-{index}"))
+        await _post(agent, session_id, _event("agent_message", message=f"output-{index}"))
+        await _post(agent, session_id, _event("task_complete", last_agent_message=f"output-{index}"))
+
+    raw_response = await agent.get("/codex/hooks/raw")
+    raw_events = (await raw_response.json())["events"]
+    assert len(raw_events) == max_requests
+    assert {event["session_id"] for event in raw_events} == {"bounded-codex-2"}
+
+    spans_response = await agent.get("/claude/hooks/spans")
+    retained_session_ids = {span.get("session_id") for span in (await spans_response.json())["spans"]}
+    assert "bounded-codex-0" not in retained_session_ids
+    assert {"bounded-codex-1", "bounded-codex-2"}.issubset(retained_session_ids)
+
+    for _ in range(3):
+        assert (await agent.get("/info")).status == 200
+    assert len(agent_app.app["agent"]._requests) == max_requests
+
+
+def test_codex_lapdog_mode_bounds_record_deduplication():
+    session = CodexSession("bounded-dedup", start_ns=0, retention_limit=2)
+
+    assert session.remember_record("first")
+    assert not session.remember_record("first")
+    assert session.remember_record("second")
+    assert session.remember_record("third")
+    assert len(session.seen_records) == 2
+    assert session.remember_record("first")
 
 
 async def test_codex_session_tags_target_only_requested_thread(agent):


### PR DESCRIPTION
## Summary

Lapdog's long-running test agent retained every proxied request, raw coding-agent event, completed span, and full Codex JSONL replay fingerprint. With the Codex App watcher scanning many sessions, those collections grew without bound.

This change applies the existing `--max-requests` limit in Lapdog mode to:

- captured test-agent requests and coding-agent raw events
- completed coding-agent traces, while preserving active traces
- Codex replay fingerprints, stored as bounded SHA-256 digests instead of full serialized records

Normal test-agent mode remains unbounded to preserve existing test behavior.
