### PR TITLE
chore(lapdog): add `--help` and `--version` commands, better `status` view, and actual version from `/info` lapdog runs

### DIFF
--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -25,10 +25,13 @@ from lapdog import backfill_pi
 from lapdog import codex_args
 from lapdog import tracer_inject
 from lapdog.lapdog_ascii_art import build_running_banner
+from lapdog.lapdog_ascii_art import build_status_banner
 from lapdog.paths import CODEX_APP_CURSOR_FILE
 from lapdog.paths import LAPDOG_DIR
 from lapdog.paths import LOG_FILE
 from lapdog.paths import PID_FILE
+
+from ddapm_test_agent import _get_version
 
 LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "tags", "uninstall"]
 # Managed launchers that also exist as external binaries a user might invoke by
@@ -256,6 +259,9 @@ def _start_lapdog(
     os.makedirs(os.path.dirname(log_path), exist_ok=True)
     args = [sys.executable, "-m", "ddapm_test_agent.agent", "--lapdog-mode"]
 
+    env = os.environ.copy()
+    env["TEST_AGENT_VERSION"] = _get_version()
+
     if not forward_data:
         args.append("--disable-llmobs-data-forwarding")
 
@@ -272,7 +278,7 @@ def _start_lapdog(
     else:
         popen_kwargs["start_new_session"] = True
     with open(log_path, "w") as log_file:
-        proc = subprocess.Popen(args, stdout=log_file, **popen_kwargs)
+        proc = subprocess.Popen(args, stdout=log_file, env=env, **popen_kwargs)
     _write_pid_file(proc.pid, port)
     _wait_for_lapdog(proc, log_path)
 
@@ -388,7 +394,7 @@ def cmd_status() -> None:
         status = _http_get_status(url, timeout=2)
         if status >= 400:
             raise OSError(f"HTTP {status}")
-        print(f"[lapdog] Lapdog running at {url} (pid={pid}, logs: {_log_file_path()})", file=sys.stderr)
+        print(build_status_banner(port=port, pid=pid, logs_path=_log_file_path()))
     except Exception as e:
         print(f"[lapdog] Lapdog not reachable at {url}: {e}", file=sys.stderr)
         sys.exit(1)
@@ -1076,7 +1082,7 @@ def cmd_uninstall() -> None:
     )
 
 
-def _parse_command(cmd_args: List[str]) -> Tuple[List[str], List[str]]:
+def _parse_command(cmd_args: List[str]) -> Tuple[List[str], Optional[List[str]]]:
     lapdog_args: List[str] = []
 
     for arg_idx, arg in enumerate(cmd_args):
@@ -1085,9 +1091,7 @@ def _parse_command(cmd_args: List[str]) -> Tuple[List[str], List[str]]:
 
         lapdog_args.append(arg)
 
-    # no sub command found
-    print(LAPDOG_USAGE, file=sys.stderr)
-    sys.exit(1)
+    return lapdog_args, None
 
 
 def _parse_lapdog_args(lapdog_args: List[str]) -> argparse.Namespace:
@@ -1095,6 +1099,7 @@ def _parse_lapdog_args(lapdog_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Lapdog CLI",
         prog="lapdog",
+        add_help=False
     )
 
     parser.add_argument(
@@ -1127,6 +1132,22 @@ def _parse_lapdog_args(lapdog_args: List[str]) -> argparse.Namespace:
             "CLI. Sources: ~/.codex/sessions (codex), ~/.claude/projects (claude), "
             "~/.pi/agent/sessions + ~/.omp/agent/sessions (pi)."
         ),
+    )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        dest="version",
+        help="Print version info and exit."
+    )
+
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        dest="help",
+        help="Print usage info and exit."
     )
 
     return parser.parse_args(args=lapdog_args)
@@ -1201,6 +1222,18 @@ def main() -> None:
 
     lapdog_args, remaining = _parse_command(args[1:])
     lapdog_parsed_args = _parse_lapdog_args(lapdog_args)
+
+    if lapdog_parsed_args.version:
+        print(_get_version())
+        sys.exit(0)
+
+    if lapdog_parsed_args.help:
+        print(LAPDOG_USAGE)
+        sys.exit(0)
+
+    if not remaining:
+        print(LAPDOG_USAGE)
+        sys.exit(1)
 
     sub_cmd = _canonical_launcher(remaining[0]) or remaining[0].lower()
     sub_cmd_args = remaining[1:]

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -387,7 +387,7 @@ def cmd_status() -> None:
     """Print lapdog status (from /info). Only works when lapdog was started by this CLI (pid file exists)."""
     pid, port = _read_pid_file()
     if port is None:
-        print("[lapdog] No lapdog running (start with 'lapdog start' or 'lapdog claude').", file=sys.stderr)
+        print(build_status_banner(is_running=False))
         sys.exit(1)
     url = _url_for_port(port)
     try:

--- a/lapdog/lapdog_ascii_art.py
+++ b/lapdog/lapdog_ascii_art.py
@@ -136,7 +136,7 @@ def _render_lapdog_art(face: str, shadow: str, reset: str) -> List[str]:
     return lines
 
 
-def _build(text_lines: list[str]) -> str:
+def _build(text_lines: List[str]) -> str:
     art_lines = _render_lapdog_art(FACE, SHADOW, RESET)
 
     # Vertically center the text block against the art.

--- a/lapdog/lapdog_ascii_art.py
+++ b/lapdog/lapdog_ascii_art.py
@@ -152,16 +152,21 @@ def _build(text_lines: list[str]) -> str:
     return "\n".join(ascii_lines)
 
 
-def build_status_banner(port: int | None, pid: int | None, logs_path: str) -> str:
+def build_status_banner(port: int | None = None, pid: int | None = None, logs_path: str | None = None, is_running: bool = True) -> str:
     lines = [
         f"{BOLD}lapdog{RESET} {DIM}v{_get_version()}{RESET}",
         "",
         "",
     ]
 
-    lines.append(f"{DIM}Lapdog is running on port {RESET}{BOLD}{port}{RESET}{DIM}.{RESET}" if port else "")
-    lines.append(f"{DIM}Process ID (pid): {RESET}{BOLD}{pid}{RESET}{DIM}.{RESET}" if pid else "")
-    lines.append(f"{DIM}Logs: {RESET}{BOLD}{logs_path}{RESET}{DIM}.{RESET}")
+    if is_running:
+        lines.append(f"{DIM}Lapdog is running on port {RESET}{BOLD}{port}{RESET}{DIM}.{RESET}" if port else "")
+        lines.append(f"{DIM}Process ID (pid): {RESET}{BOLD}{pid}{RESET}{DIM}.{RESET}" if pid else "")
+        lines.append(f"{DIM}Logs: {RESET}{BOLD}{logs_path}{RESET}{DIM}.{RESET}" if logs_path else "")
+    else:
+        lines.append(f"{DIM}Lapdog is not running.{RESET}")
+        lines.append(f"{DIM}Start lapdog with {RESET}{BOLD}lapdog start{RESET}{DIM} or {RESET}{BOLD}lapdog claude{RESET}")
+        lines.append(f"{DIM}to start and observe local agent data with Lapdog.")
 
     return _build(text_lines=lines)
 

--- a/lapdog/lapdog_ascii_art.py
+++ b/lapdog/lapdog_ascii_art.py
@@ -152,7 +152,12 @@ def _build(text_lines: list[str]) -> str:
     return "\n".join(ascii_lines)
 
 
-def build_status_banner(port: int | None = None, pid: int | None = None, logs_path: str | None = None, is_running: bool = True) -> str:
+def build_status_banner(
+    port: Optional[int] = None,
+    pid: Optional[int] = None,
+    logs_path: Optional[str] = None,
+    is_running: bool = True
+) -> str:
     lines = [
         f"{BOLD}lapdog{RESET} {DIM}v{_get_version()}{RESET}",
         "",

--- a/lapdog/lapdog_ascii_art.py
+++ b/lapdog/lapdog_ascii_art.py
@@ -52,6 +52,13 @@ _LAPDOG_LETTERS = (
 )
 
 
+FACE = "\033[38;5;177m"  # light purple
+SHADOW = "\033[38;5;54m"  # deep purple
+DIM = "\033[2m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
 def _render_lapdog_art(face: str, shadow: str, reset: str) -> List[str]:
     """Render LAPDOG word art as colored lines with a 1-cell drop shadow.
 
@@ -129,39 +136,52 @@ def _render_lapdog_art(face: str, shadow: str, reset: str) -> List[str]:
     return lines
 
 
+def _build(text_lines: list[str]) -> str:
+    art_lines = _render_lapdog_art(FACE, SHADOW, RESET)
+
+    # Vertically center the text block against the art.
+    pad_top = max((len(art_lines) - len(text_lines)) // 2, 0)
+    padded_right = [""] * pad_top + text_lines
+    while len(padded_right) < len(art_lines):
+        padded_right.append("")
+
+    ascii_lines = [""]
+    for art, text in zip(art_lines, padded_right):
+        ascii_lines.append(f"  {art}  {text}")
+    ascii_lines.append("")
+    return "\n".join(ascii_lines)
+
+
+def build_status_banner(port: int | None, pid: int | None, logs_path: str) -> str:
+    lines = [
+        f"{BOLD}lapdog{RESET} {DIM}v{_get_version()}{RESET}",
+        "",
+        "",
+    ]
+
+    lines.append(f"{DIM}Lapdog is running on port {RESET}{BOLD}{port}{RESET}{DIM}.{RESET}" if port else "")
+    lines.append(f"{DIM}Process ID (pid): {RESET}{BOLD}{pid}{RESET}{DIM}.{RESET}" if pid else "")
+    lines.append(f"{DIM}Logs: {RESET}{BOLD}{logs_path}{RESET}{DIM}.{RESET}")
+
+    return _build(text_lines=lines)
+
+
 def build_running_banner(data_type: str, warning_lines: Optional[List[str]] = None) -> str:
     """
     Arguments:
         data_type: The type of data (coding session, application)
         warning_lines: Optional extra lines to show instead of the default stop hint.
     """
-    face = "\033[38;5;177m"  # light purple
-    shadow = "\033[38;5;54m"  # deep purple
-    dim = "\033[2m"
-    bold = "\033[1m"
-    reset = "\033[0m"
-
-    art_lines = _render_lapdog_art(face, shadow, reset)
-
-    right_lines = [
-        f"{bold}lapdog{reset} {dim}v{_get_version()}{reset}",
+    lines = [
+        f"{BOLD}lapdog{RESET} {DIM}v{_get_version()}{RESET}",
         "",
-        f"{dim}Lapdog has started and is listening for data.{reset}",
-        f"{dim}Open {reset}{face}https://lapdog.datadoghq.com{reset}{dim} to view insights,{reset}",
-        f"{dim}costs, optimizations and more related to this {data_type}.{reset}",
+        f"{DIM}Lapdog has started and is listening for data.{RESET}",
+        f"{DIM}Open {RESET}{FACE}https://lapdog.datadoghq.com{RESET}{DIM} to view insights,{RESET}",
+        f"{DIM}costs, optimizations and more related to this {data_type}.{RESET}",
     ]
     if warning_lines:
-        right_lines.extend(f"{dim}{line}{reset}" for line in warning_lines)
+        lines.extend(f"{DIM}{line}{RESET}" for line in warning_lines)
     else:
-        right_lines.append(f"{dim}Run {bold}lapdog stop{reset} {dim}to stop Lapdog from running.{reset}")
-    # Vertically center the text block against the art.
-    pad_top = max((len(art_lines) - len(right_lines)) // 2, 0)
-    padded_right = [""] * pad_top + right_lines
-    while len(padded_right) < len(art_lines):
-        padded_right.append("")
+        lines.append(f"{DIM}Run {BOLD}lapdog stop{RESET} {DIM}to stop Lapdog from running.{RESET}")
 
-    lines = [""]
-    for art, text in zip(art_lines, padded_right):
-        lines.append(f"  {art}  {text}")
-    lines.append("")
-    return "\n".join(lines)
+    return _build(text_lines=lines)

--- a/releasenotes/notes/lapdog-help-and-version-e9ee2ec3360e9952.yaml
+++ b/releasenotes/notes/lapdog-help-and-version-e9ee2ec3360e9952.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Lapdog: Adds ``--version`` and ``--help`` flags for the ``lapdog`` CLI (e.g. ``lapdog --version``).


### PR DESCRIPTION
Adds a few things as noted in the title:
- `--help` and `--version` commands
- a better view for the `status` command (see attachment below)
- the actual test agent version as part of the `/info` check, useful for applications consuming from `lapdog` (e.g the actual [lapdog](https://lapdog.datadoghq.com/) application)

Version in `/info` from running `lapdog start`:
```
(.venv) ➜  dd-apm-test-agent git:(sabrenner/lapdog-touchups) curl http://localhost:8126/info
{"version": "1.65.1.dev1+g7609015d8.d20260905", "endpoints": ["/v0.4/traces", "/v0.5/traces", "/v0.7/traces", "/v1.0/traces", "/v0.6/stats", "/telemetry/proxy/", "/v0.7/config", "/tracer_flare/v1", "/evp_proxy/v2/", "/evp_proxy/v4/"], "feature_flags": [], "config": {}, "client_drop_p0s": true, "peer_tags": ["db.name", "mongodb.db", "messaging.system"], "span_events": true, "llmobs_data_forwarding": false, "authenticated": false}%
```

<img width="697" height="129" alt="Screenshot 2026-09-08 at 1 45 21 PM" src="https://github.com/user-attachments/assets/54a6d3c7-dbb2-4ab4-b7f5-23eda4fbca6a" />

And when not running:
<img width="738" height="125" alt="Screenshot 2026-09-08 at 1 53 53 PM" src="https://github.com/user-attachments/assets/a1ce694a-a32c-4b9b-91e8-61e539ab5e3b" />
