### PR TITLE
chore(lapdog): remove `-h` and `-v` flags for `lapdog`

### DIFF
--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -1135,7 +1135,6 @@ def _parse_lapdog_args(lapdog_args: List[str]) -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "-v",
         "--version",
         action="store_true",
         dest="version",
@@ -1143,7 +1142,6 @@ def _parse_lapdog_args(lapdog_args: List[str]) -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "-h",
         "--help",
         action="store_true",
         dest="help",


### PR DESCRIPTION
Introduced in #414, these are problematic as they conflict with the parsing of the rest of the lapdog subcommands. As this is a sensitive parsing path and I don't want to open a can of worms by supporting `-h` and `-v`, or hardcoding something, I'm opting for just supporting `--help` and `--version` only.