### PR TITLE
feat(lapdog): add cost tracking for fable-5.1 and astra-6

### DIFF
--- a/ddapm_test_agent/claude_cost_tracker.py
+++ b/ddapm_test_agent/claude_cost_tracker.py
@@ -11,7 +11,7 @@ and the metric keys expected by the web-ui LLM observability span detail view:
     estimated_cache_write_input_cost
     estimated_cache_read_input_cost
 
-Pricing data last updated 2026-08 based on:
+Pricing data last updated 2026-09 based on:
   * Anthropic public pricing: https://www.anthropic.com/pricing#api
   * pi-ai models.generated.js (the data Claude Code itself uses to compute
     the self-reported per-turn cost shown in its UI):
@@ -24,7 +24,9 @@ whereas Opus 4 / 4.1 / 3 still cost $15 / $75 / $1.50 / $18.75 per Mtok.
 Using the old Opus rates for 4.5+ overcharges by exactly 3x.
 
 The Claude 5 family adds Sonnet 5 ($3 / $15 per Mtok, same tier as Sonnet 4.6)
-and Fable 5 / Mythos 5 ($10 / $50 per Mtok — the most capable tier).  Sonnet 5
+and Fable 5 / Mythos 5 ($10 / $50 per Mtok — the most capable tier). Fable 5.1
+keeps those input and output rates while reducing cache reads to $0.25 per Mtok.
+Sonnet 5
 carries an introductory rate of $2 / $10 per Mtok through 2026-08-31; because
 these values are only estimates, the table uses the higher ongoing list price
 ($3 / $15) as a conservative upper bound rather than the temporary intro rate.
@@ -87,6 +89,14 @@ COST_METRIC_KEYS: FrozenSet[str] = frozenset(
 _ONE_TIER = 0  # sentinel: no upper bound on a single tier
 
 _PRICING: List[Tuple[str, List[_PriceTier]]] = [
+    # ---- Fable 5.1 ---------------------------------------------------------
+    # $10 / $50 / $0.25 cache-read / $12.50 cache-write per Mtok.
+    # This must precede Fable 5 so prefix matching does not use the older
+    # model's $1.00 cache-read rate.
+    (
+        "claude-fable-5-1",
+        [_PriceTier(0, _ONE_TIER, 10_000, 12_500, 250, 50_000)],
+    ),
     # ---- Fable 5 / Mythos 5 (most capable tier, Claude 5 family) -------------
     # $10 / $50 / $1.00 cache-read / $12.50 cache-write per Mtok.
     # Mythos 5 is Project-Glasswing-only but shares Fable 5's pricing.

--- a/ddapm_test_agent/claude_cost_tracker.py
+++ b/ddapm_test_agent/claude_cost_tracker.py
@@ -25,11 +25,11 @@ Using the old Opus rates for 4.5+ overcharges by exactly 3x.
 
 The Claude 5 family adds Sonnet 5 ($3 / $15 per Mtok, same tier as Sonnet 4.6)
 and Fable 5 / Mythos 5 ($10 / $50 per Mtok — the most capable tier). Fable 5.1
-keeps those input and output rates while reducing cache reads to $0.25 per Mtok.
-Sonnet 5
-carries an introductory rate of $2 / $10 per Mtok through 2026-08-31; because
-these values are only estimates, the table uses the higher ongoing list price
-($3 / $15) as a conservative upper bound rather than the temporary intro rate.
+and Mythos 5.1 keep those input and output rates while reducing cache reads to
+$0.25 per Mtok. Sonnet 5 carries an introductory rate of $2 / $10 per Mtok
+through 2026-08-31; because these values are only estimates, the table uses the
+higher ongoing list price ($3 / $15) as a conservative upper bound rather than
+the temporary intro rate.
 
 Only the popular models used with Claude Code are included.
 """
@@ -89,12 +89,16 @@ COST_METRIC_KEYS: FrozenSet[str] = frozenset(
 _ONE_TIER = 0  # sentinel: no upper bound on a single tier
 
 _PRICING: List[Tuple[str, List[_PriceTier]]] = [
-    # ---- Fable 5.1 ---------------------------------------------------------
+    # ---- Fable 5.1 / Mythos 5.1 --------------------------------------------
     # $10 / $50 / $0.25 cache-read / $12.50 cache-write per Mtok.
-    # This must precede Fable 5 so prefix matching does not use the older
-    # model's $1.00 cache-read rate.
+    # These must precede their 5.0 prefixes so prefix matching does not use
+    # the older models' $1.00 cache-read rate.
     (
         "claude-fable-5-1",
+        [_PriceTier(0, _ONE_TIER, 10_000, 12_500, 250, 50_000)],
+    ),
+    (
+        "claude-mythos-5-1",
         [_PriceTier(0, _ONE_TIER, 10_000, 12_500, 250, 50_000)],
     ),
     # ---- Fable 5 / Mythos 5 (most capable tier, Claude 5 family) -------------

--- a/ddapm_test_agent/codex_cost_tracker.py
+++ b/ddapm_test_agent/codex_cost_tracker.py
@@ -9,7 +9,8 @@ Latest models:
   * gpt-6-astra ($10 / $50 per Mtok, 90% cached-input discount). Prompts over
     272K input tokens cost 2x for input/cache and 1.5x for output.
   * gpt-5.6 family (Sol $5 / $30, Terra $2 / $12 per Mtok, 90% cached-input
-    discount). The nano-tier "Luna" variant is deliberately left out so it
+    discount). Prompts over 272K input tokens cost 2x for input/cache and 1.5x
+    for output. The nano-tier "Luna" variant is deliberately left out so it
     resolves to the higher "gpt-5.6" (Sol) rate via prefix match — a
     conservative upper bound, since its own rate was inconsistent across
     sources.
@@ -42,8 +43,20 @@ _PRICING: List[_OpenAIPrice] = [
         long_context_threshold=272_000,
     ),
     # gpt-5.6 family (Terra listed before the Sol catch-all so it isn't shadowed).
-    _OpenAIPrice("gpt-5.6-terra", input_price=2_000, cached_input=200, output=12_000),
-    _OpenAIPrice("gpt-5.6", input_price=5_000, cached_input=500, output=30_000),
+    _OpenAIPrice(
+        "gpt-5.6-terra",
+        input_price=2_000,
+        cached_input=200,
+        output=12_000,
+        long_context_threshold=272_000,
+    ),
+    _OpenAIPrice(
+        "gpt-5.6",
+        input_price=5_000,
+        cached_input=500,
+        output=30_000,
+        long_context_threshold=272_000,
+    ),
     _OpenAIPrice("gpt-5.5", input_price=5_000, cached_input=500, output=30_000),
     _OpenAIPrice("gpt-5.4-mini", input_price=750, cached_input=75, output=4_500),
     _OpenAIPrice("gpt-5.4", input_price=2_500, cached_input=250, output=15_000),

--- a/ddapm_test_agent/codex_cost_tracker.py
+++ b/ddapm_test_agent/codex_cost_tracker.py
@@ -8,8 +8,9 @@ Pricing data last updated 2026-09 from OpenAI API pricing pages.
 Latest models:
   * gpt-6-astra ($10 / $50 per Mtok, 90% cached-input discount). Prompts over
     272K input tokens cost 2x for input/cache and 1.5x for output.
-  * gpt-5.6 family (Sol $5 / $30, Terra $2 / $12 per Mtok, 90% cached-input
-    discount). Prompts over 272K input tokens cost 2x for input/cache and 1.5x
+  * gpt-5.6 family (Sol $4 / $20, Terra $2 / $12 per Mtok, 90% cached-input
+    discount). Sol's promotional rates are documented through at least
+    2026-11-21. Prompts over 272K input tokens cost 2x for input/cache and 1.5x
     for output. The nano-tier "Luna" variant is deliberately left out so it
     resolves to the higher "gpt-5.6" (Sol) rate via prefix match — a
     conservative upper bound, since its own rate was inconsistent across
@@ -52,9 +53,9 @@ _PRICING: List[_OpenAIPrice] = [
     ),
     _OpenAIPrice(
         "gpt-5.6",
-        input_price=5_000,
-        cached_input=500,
-        output=30_000,
+        input_price=4_000,
+        cached_input=400,
+        output=20_000,
         long_context_threshold=272_000,
     ),
     _OpenAIPrice("gpt-5.5", input_price=5_000, cached_input=500, output=30_000),

--- a/ddapm_test_agent/codex_cost_tracker.py
+++ b/ddapm_test_agent/codex_cost_tracker.py
@@ -3,10 +3,11 @@
 Pricing is in nanodollars per token (1 nanodollar = 1e-9 USD), matching the
 metric keys expected by the web-ui LLM observability span detail view.
 
-Pricing data last updated 2026-08 from OpenAI API pricing pages. Standard
-rates are documented for context lengths under 270K tokens.
+Pricing data last updated 2026-09 from OpenAI API pricing pages.
 
-Latest models added 2026-08:
+Latest models:
+  * gpt-6-astra ($10 / $50 per Mtok, 90% cached-input discount). Prompts over
+    272K input tokens cost 2x for input/cache and 1.5x for output.
   * gpt-5.6 family (Sol $5 / $30, Terra $2 / $12 per Mtok, 90% cached-input
     discount). The nano-tier "Luna" variant is deliberately left out so it
     resolves to the higher "gpt-5.6" (Sol) rate via prefix match — a
@@ -29,9 +30,17 @@ class _OpenAIPrice:
     input_price: int
     cached_input: int
     output: int
+    long_context_threshold: int = 0
 
 
 _PRICING: List[_OpenAIPrice] = [
+    _OpenAIPrice(
+        "gpt-6-astra",
+        input_price=10_000,
+        cached_input=1_000,
+        output=50_000,
+        long_context_threshold=272_000,
+    ),
     # gpt-5.6 family (Terra listed before the Sol catch-all so it isn't shadowed).
     _OpenAIPrice("gpt-5.6-terra", input_price=2_000, cached_input=200, output=12_000),
     _OpenAIPrice("gpt-5.6", input_price=5_000, cached_input=500, output=30_000),
@@ -74,9 +83,13 @@ def compute_openai_cost_metrics(
     if price is None:
         return {}
 
-    non_cached_input_cost = non_cached_input_tokens * price.input_price
-    cache_read_cost = cached_input_tokens * price.cached_input
-    output_cost = output_tokens * price.output
+    total_input_tokens = non_cached_input_tokens + cached_input_tokens
+    long_context = price.long_context_threshold and total_input_tokens > price.long_context_threshold
+    input_multiplier = 2 if long_context else 1
+    output_numerator = 3 if long_context else 2
+    non_cached_input_cost = non_cached_input_tokens * price.input_price * input_multiplier
+    cache_read_cost = cached_input_tokens * price.cached_input * input_multiplier
+    output_cost = output_tokens * price.output * output_numerator // 2
     input_cost = non_cached_input_cost + cache_read_cost
 
     return {

--- a/releasenotes/notes/fable-5-1-astra-costs-0581fef3bd6eef45.yaml
+++ b/releasenotes/notes/fable-5-1-astra-costs-0581fef3bd6eef45.yaml
@@ -2,4 +2,5 @@
 features:
   - |
     Add Lapdog cost tracking for Claude Fable 5.1 and GPT-6 Astra, including
-    Fable 5.1's reduced cache-read rate and Astra's long-context pricing.
+    Fable 5.1's reduced cache-read rate and long-context pricing for GPT-5.6
+    and Astra.

--- a/releasenotes/notes/fable-5-1-astra-costs-0581fef3bd6eef45.yaml
+++ b/releasenotes/notes/fable-5-1-astra-costs-0581fef3bd6eef45.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add Lapdog cost tracking for Claude Fable 5.1 and GPT-6 Astra, including
+    Fable 5.1's reduced cache-read rate and Astra's long-context pricing.

--- a/releasenotes/notes/fable-5-1-astra-costs-0581fef3bd6eef45.yaml
+++ b/releasenotes/notes/fable-5-1-astra-costs-0581fef3bd6eef45.yaml
@@ -1,6 +1,7 @@
 ---
 features:
   - |
-    Add Lapdog cost tracking for Claude Fable 5.1 and GPT-6 Astra, including
-    Fable 5.1's reduced cache-read rate and long-context pricing for GPT-5.6
-    and Astra.
+    Add Lapdog cost tracking for Claude Fable 5.1, Claude Mythos 5.1, and
+    GPT-6 Astra. Includes Claude models' reduced cache-read rate and
+    long-context pricing for GPT-5.6 and Astra. For GPT-5.6 Sol models, costs are
+    tracked at promotional pricing rates documented through November 21, 2026.

--- a/tests/test_claude_cost_tracker.py
+++ b/tests/test_claude_cost_tracker.py
@@ -31,6 +31,9 @@ class TestModelLookup:
         assert compute_cost_metrics("claude-fable-5", 1000, 0, 0, 0) is not None
         assert compute_cost_metrics("claude-mythos-5", 1000, 0, 0, 0) is not None
 
+    def test_fable_5_1(self) -> None:
+        assert compute_cost_metrics("claude-fable-5-1", 1000, 0, 0, 0) is not None
+
     def test_unknown_model_returns_none(self) -> None:
         assert compute_cost_metrics("gpt-4o", 1000, 0, 0, 0) is None
 
@@ -133,6 +136,15 @@ class TestCostCalculation:
             assert result["estimated_cache_write_input_cost"] == 200 * 12_500, model
             assert result["estimated_cache_read_input_cost"] == 500 * 1_000, model
             assert result["estimated_output_cost"] == 50 * 50_000, model
+
+    def test_fable_5_1_pricing(self) -> None:
+        # Fable 5.1 keeps Fable 5's rates but reduces cache reads to $0.25/Mtok.
+        result = compute_cost_metrics("claude-fable-5-1", 100, 200, 500, 50)
+        assert result is not None
+        assert result["estimated_non_cached_input_cost"] == 100 * 10_000
+        assert result["estimated_cache_write_input_cost"] == 200 * 12_500
+        assert result["estimated_cache_read_input_cost"] == 500 * 250
+        assert result["estimated_output_cost"] == 50 * 50_000
 
     def test_zero_tokens_returns_all_zeros(self) -> None:
         result = compute_cost_metrics("claude-sonnet-4-6", 0, 0, 0, 0)

--- a/tests/test_claude_cost_tracker.py
+++ b/tests/test_claude_cost_tracker.py
@@ -31,8 +31,9 @@ class TestModelLookup:
         assert compute_cost_metrics("claude-fable-5", 1000, 0, 0, 0) is not None
         assert compute_cost_metrics("claude-mythos-5", 1000, 0, 0, 0) is not None
 
-    def test_fable_5_1(self) -> None:
+    def test_fable_and_mythos_5_1(self) -> None:
         assert compute_cost_metrics("claude-fable-5-1", 1000, 0, 0, 0) is not None
+        assert compute_cost_metrics("claude-mythos-5-1", 1000, 0, 0, 0) is not None
 
     def test_unknown_model_returns_none(self) -> None:
         assert compute_cost_metrics("gpt-4o", 1000, 0, 0, 0) is None
@@ -137,14 +138,15 @@ class TestCostCalculation:
             assert result["estimated_cache_read_input_cost"] == 500 * 1_000, model
             assert result["estimated_output_cost"] == 50 * 50_000, model
 
-    def test_fable_5_1_pricing(self) -> None:
-        # Fable 5.1 keeps Fable 5's rates but reduces cache reads to $0.25/Mtok.
-        result = compute_cost_metrics("claude-fable-5-1", 100, 200, 500, 50)
-        assert result is not None
-        assert result["estimated_non_cached_input_cost"] == 100 * 10_000
-        assert result["estimated_cache_write_input_cost"] == 200 * 12_500
-        assert result["estimated_cache_read_input_cost"] == 500 * 250
-        assert result["estimated_output_cost"] == 50 * 50_000
+    def test_fable_and_mythos_5_1_pricing(self) -> None:
+        # Fable/Mythos 5.1 keep the 5.0 rates but reduce cache reads to $0.25/Mtok.
+        for model in ("claude-fable-5-1", "claude-mythos-5-1"):
+            result = compute_cost_metrics(model, 100, 200, 500, 50)
+            assert result is not None, model
+            assert result["estimated_non_cached_input_cost"] == 100 * 10_000, model
+            assert result["estimated_cache_write_input_cost"] == 200 * 12_500, model
+            assert result["estimated_cache_read_input_cost"] == 500 * 250, model
+            assert result["estimated_output_cost"] == 50 * 50_000, model
 
     def test_zero_tokens_returns_all_zeros(self) -> None:
         result = compute_cost_metrics("claude-sonnet-4-6", 0, 0, 0, 0)

--- a/tests/test_codex_cost_tracker.py
+++ b/tests/test_codex_cost_tracker.py
@@ -42,13 +42,13 @@ class TestCostCalculation:
         assert result["estimated_output_cost"] == 50_000
 
     def test_gpt_5_6_sol_pricing(self) -> None:
-        # gpt-5.6 (Sol): $5 input / $0.50 cached / $30 output per Mtok.
+        # gpt-5.6 (Sol): $4 input / $0.40 cached / $20 output per Mtok.
         result = compute_openai_cost_metrics("gpt-5.6", 100, 20, 50)
-        assert result["estimated_non_cached_input_cost"] == 100 * 5_000
-        assert result["estimated_cache_read_input_cost"] == 20 * 500
-        assert result["estimated_output_cost"] == 50 * 30_000
-        assert result["estimated_input_cost"] == 100 * 5_000 + 20 * 500
-        assert result["estimated_total_cost"] == 100 * 5_000 + 20 * 500 + 50 * 30_000
+        assert result["estimated_non_cached_input_cost"] == 100 * 4_000
+        assert result["estimated_cache_read_input_cost"] == 20 * 400
+        assert result["estimated_output_cost"] == 50 * 20_000
+        assert result["estimated_input_cost"] == 100 * 4_000 + 20 * 400
+        assert result["estimated_total_cost"] == 100 * 4_000 + 20 * 400 + 50 * 20_000
 
     def test_gpt_5_6_terra_not_shadowed_by_sol(self) -> None:
         # "gpt-5.6-terra" must match the Terra tier, not the "gpt-5.6" catch-all.
@@ -58,7 +58,7 @@ class TestCostCalculation:
     def test_gpt_5_6_long_context_pricing(self) -> None:
         # Above 272K input tokens: input/cache cost 2x and output costs 1.5x.
         for model, input_price, cached_input, output_price in (
-            ("gpt-5.6", 5_000, 500, 30_000),
+            ("gpt-5.6", 4_000, 400, 20_000),
             ("gpt-5.6-terra", 2_000, 200, 12_000),
         ):
             result = compute_openai_cost_metrics(model, 272_000, 1, 50)
@@ -68,7 +68,7 @@ class TestCostCalculation:
 
     def test_gpt_5_6_long_context_boundary(self) -> None:
         for model, input_price, output_price in (
-            ("gpt-5.6", 5_000, 30_000),
+            ("gpt-5.6", 4_000, 20_000),
             ("gpt-5.6-terra", 2_000, 12_000),
         ):
             result = compute_openai_cost_metrics(model, 272_000, 0, 1)

--- a/tests/test_codex_cost_tracker.py
+++ b/tests/test_codex_cost_tracker.py
@@ -2,6 +2,10 @@ from ddapm_test_agent.codex_cost_tracker import compute_openai_cost_metrics
 
 
 class TestModelLookup:
+    def test_gpt_6_astra(self) -> None:
+        assert compute_openai_cost_metrics("gpt-6-astra", 1000, 0, 0) != {}
+        assert compute_openai_cost_metrics("gpt-6-astra-2026-09-03", 1000, 0, 0) != {}
+
     def test_gpt_5_6(self) -> None:
         assert compute_openai_cost_metrics("gpt-5.6", 1000, 0, 0) != {}
 
@@ -16,6 +20,27 @@ class TestModelLookup:
 
 
 class TestCostCalculation:
+    def test_gpt_6_astra_pricing(self) -> None:
+        # gpt-6-astra: $10 input / $1 cached / $50 output per Mtok.
+        result = compute_openai_cost_metrics("gpt-6-astra", 100, 20, 50)
+        assert result["estimated_non_cached_input_cost"] == 100 * 10_000
+        assert result["estimated_cache_read_input_cost"] == 20 * 1_000
+        assert result["estimated_output_cost"] == 50 * 50_000
+        assert result["estimated_input_cost"] == 100 * 10_000 + 20 * 1_000
+        assert result["estimated_total_cost"] == 100 * 10_000 + 20 * 1_000 + 50 * 50_000
+
+    def test_gpt_6_astra_long_context_pricing(self) -> None:
+        # Above 272K input tokens: input/cache cost 2x and output costs 1.5x.
+        result = compute_openai_cost_metrics("gpt-6-astra", 272_000, 1, 50)
+        assert result["estimated_non_cached_input_cost"] == 272_000 * 10_000 * 2
+        assert result["estimated_cache_read_input_cost"] == 1 * 1_000 * 2
+        assert result["estimated_output_cost"] == 50 * 50_000 * 3 // 2
+
+    def test_gpt_6_astra_long_context_boundary(self) -> None:
+        result = compute_openai_cost_metrics("gpt-6-astra", 272_000, 0, 1)
+        assert result["estimated_non_cached_input_cost"] == 272_000 * 10_000
+        assert result["estimated_output_cost"] == 50_000
+
     def test_gpt_5_6_sol_pricing(self) -> None:
         # gpt-5.6 (Sol): $5 input / $0.50 cached / $30 output per Mtok.
         result = compute_openai_cost_metrics("gpt-5.6", 100, 20, 50)

--- a/tests/test_codex_cost_tracker.py
+++ b/tests/test_codex_cost_tracker.py
@@ -55,6 +55,26 @@ class TestCostCalculation:
         result = compute_openai_cost_metrics("gpt-5.6-terra", 100, 0, 0)
         assert result["estimated_non_cached_input_cost"] == 100 * 2_000
 
+    def test_gpt_5_6_long_context_pricing(self) -> None:
+        # Above 272K input tokens: input/cache cost 2x and output costs 1.5x.
+        for model, input_price, cached_input, output_price in (
+            ("gpt-5.6", 5_000, 500, 30_000),
+            ("gpt-5.6-terra", 2_000, 200, 12_000),
+        ):
+            result = compute_openai_cost_metrics(model, 272_000, 1, 50)
+            assert result["estimated_non_cached_input_cost"] == 272_000 * input_price * 2
+            assert result["estimated_cache_read_input_cost"] == cached_input * 2
+            assert result["estimated_output_cost"] == 50 * output_price * 3 // 2
+
+    def test_gpt_5_6_long_context_boundary(self) -> None:
+        for model, input_price, output_price in (
+            ("gpt-5.6", 5_000, 30_000),
+            ("gpt-5.6-terra", 2_000, 12_000),
+        ):
+            result = compute_openai_cost_metrics(model, 272_000, 0, 1)
+            assert result["estimated_non_cached_input_cost"] == 272_000 * input_price
+            assert result["estimated_output_cost"] == output_price
+
     def test_gpt_5_3_codex_pricing(self) -> None:
         # gpt-5.3-codex: $1.75 input / $0.175 cached / $14 output per Mtok.
         result = compute_openai_cost_metrics("gpt-5.3-codex", 100, 20, 50)


### PR DESCRIPTION
Adds cost tracking for the `astra-6` and `fable-5.1` models from OpenAI and Anthropic respectively for `lapdog`.

https://developers.openai.com/api/docs/pricing
https://claude.com/pricing#api