### PR TITLE
refactor(lapdog): pull out lapdog into its own directory by extending the testagent server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ADD vcr-cassettes /vcr-cassettes
 # Add only necessary files to speed up development builds
 ADD README.md setup.py test_deps.txt ./
 ADD ddapm_test_agent ./ddapm_test_agent
+ADD lapdog ./lapdog
 ADD .git ./.git
 RUN pip install /src && \
     rm -rf /root/.cache/pip

--- a/ddapm_test_agent/agent.py
+++ b/ddapm_test_agent/agent.py
@@ -6,14 +6,12 @@ from collections import OrderedDict
 from collections import defaultdict
 from dataclasses import dataclass
 from dataclasses import field
-import gzip
 import json
 import logging
 import os
 import platform
 import pprint
 import re
-import requests
 import socket
 import sys
 import threading
@@ -40,7 +38,6 @@ from aiohttp.web import HTTPException
 from aiohttp.web import Request
 from aiohttp.web import middleware
 from grpc import aio as grpc_aio
-import msgpack
 from msgpack.exceptions import ExtraData as MsgPackExtraDataException
 from multidict import CIMultiDict
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceResponse
@@ -49,6 +46,7 @@ from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportM
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2_grpc import add_MetricsServiceServicer_to_server
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceResponse
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import add_TraceServiceServicer_to_server
+import requests
 from yarl import URL
 
 from . import _get_version
@@ -59,15 +57,9 @@ from .apmtelemetry import v2_decode_request as v2_apmtelemetry_decode_request
 from .checks import CheckTrace
 from .checks import Checks
 from .checks import start_trace
-from .claude_hooks import ClaudeHooksAPI
-from .claude_link_tracker import ClaudeLinkTracker
-from .claude_proxy import ClaudeProxyAPI
-from .pi_hooks import PiHooksAPI
-from .codex_hooks import CodexHooksAPI
-from .codex_proxy import CodexProxyAPI
+from .cors import ALLOWED_ORIGIN_PATTERN
 from .integration import Integration
-from .llmobs_event_platform import LLMObsEventPlatformAPI
-from .llmobs_event_platform import decode_llmobs_payload
+from .llmobs_trace import decode_llmobs_payload
 from .llmobs_trace import extract_llmobs_envelopes_from_v04_traces
 from .logs import LOGS_ENDPOINT
 from .logs import OTLPLogsGRPCServicer
@@ -102,30 +94,8 @@ from .tracestats import v06StatsPayload
 from .vcr_proxy import proxy_request
 
 
-def _inject_lapdog_forwarded(data: bytes, content_encoding: str) -> bytes:
-    """Decode a forwarded LLM obs msgpack payload, add lapdog_forwarded:true to each span's tags, and re-encode.
-
-    Falls back to the original bytes if decoding fails (e.g. unexpected format).
-    """
-    try:
-        is_gzipped = "gzip" in content_encoding.lower()
-        if is_gzipped:
-            data = gzip.decompress(data)
-        payload = msgpack.unpackb(data, raw=False)
-        if isinstance(payload, dict):
-            ml_obs = payload.get("ml_obs")
-            spans = (ml_obs.get("spans") if isinstance(ml_obs, dict) else None) or payload.get("spans") or []
-            for span in spans:
-                if not isinstance(span, dict):
-                    continue
-                tags = span.get("tags") or []
-                if "lapdog_forwarded:true" not in tags:
-                    span["tags"] = tags + ["lapdog_forwarded:true"]
-        data = msgpack.packb(payload, use_bin_type=True)
-        if is_gzipped:
-            data = gzip.compress(data)
-    except Exception:
-        pass
+def _identity_llmobs_payload(data: bytes, content_encoding: str) -> bytes:
+    """Return the payload unchanged for standalone test-agent forwarding."""
     return data
 
 
@@ -447,6 +417,8 @@ class Agent:
         )
 
         self.vcr_cassette_prefix: Optional[str] = None
+        self.llmobs_payload_transform: Callable[[bytes, str], bytes] = _identity_llmobs_payload
+        self.llmobs_span_update_listener: Optional[Callable[[bytes, str], None]] = None
 
     async def traces(self) -> TraceMap:
         """Return the traces stored by the agent in the order in which they
@@ -1029,8 +1001,9 @@ class Agent:
             headers["DD-API-KEY"] = dd_api_key
 
         raw = await request.read()
-        if request.app["lapdog_mode"]:
-            raw = _inject_lapdog_forwarded(raw, request.headers.get("Content-Encoding", ""))
+        transformed_raw = self.llmobs_payload_transform(raw, request.headers.get("Content-Encoding", ""))
+        if transformed_raw is not raw:
+            raw = transformed_raw
             headers = {k: v for k, v in headers.items() if k.lower() != "content-length"}
         async with ClientSession() as session:
             async with session.post(url, headers=headers, data=raw) as resp:
@@ -1066,8 +1039,9 @@ class Agent:
                 try:
                     fwd_data = data
                     fwd_headers = headers
-                    if request.app["lapdog_mode"]:
-                        fwd_data = _inject_lapdog_forwarded(data, headers.get("Content-Encoding", ""))
+                    transformed_data = self.llmobs_payload_transform(data, headers.get("Content-Encoding", ""))
+                    if transformed_data is not data:
+                        fwd_data = transformed_data
                         fwd_headers = {k: v for k, v in headers.items() if k.lower() != "content-length"}
                     async with ClientSession() as session:
                         async with session.post(url, headers=fwd_headers, data=fwd_data) as resp:
@@ -1079,9 +1053,8 @@ class Agent:
                     log.warning("Error forwarding LLMObs span update: %s", e)
 
         # Update local stored spans
-        llmobs_api = request.app.get("llmobs_event_platform_api")
-        if llmobs_api:
-            llmobs_api.update_spans(data, content_type)
+        if self.llmobs_span_update_listener is not None:
+            self.llmobs_span_update_listener(data, content_type)
 
         return web.HTTPOk()
 
@@ -1115,8 +1088,9 @@ class Agent:
             headers["DD-API-KEY"] = dd_api_key
 
         raw = await request.read()
-        if request.app["lapdog_mode"]:
-            raw = _inject_lapdog_forwarded(raw, request.headers.get("Content-Encoding", ""))
+        transformed_raw = self.llmobs_payload_transform(raw, request.headers.get("Content-Encoding", ""))
+        if transformed_raw is not raw:
+            raw = transformed_raw
             headers = {k: v for k, v in headers.items() if k.lower() != "content-length"}
         async with ClientSession() as session:
             async with session.post(url, headers=headers, data=raw) as resp:
@@ -1151,8 +1125,9 @@ class Agent:
                 try:
                     fwd_data = data
                     fwd_headers = headers
-                    if request.app["lapdog_mode"]:
-                        fwd_data = _inject_lapdog_forwarded(data, headers.get("Content-Encoding", ""))
+                    transformed_data = self.llmobs_payload_transform(data, headers.get("Content-Encoding", ""))
+                    if transformed_data is not data:
+                        fwd_data = transformed_data
                         fwd_headers = {k: v for k, v in headers.items() if k.lower() != "content-length"}
                     async with ClientSession() as session:
                         async with session.post(url, headers=fwd_headers, data=fwd_data) as resp:
@@ -1163,9 +1138,8 @@ class Agent:
                 except Exception as e:
                     log.warning("Error forwarding LLMObs span update: %s", e)
 
-        llmobs_api = request.app.get("llmobs_event_platform_api")
-        if llmobs_api:
-            llmobs_api.update_spans(data, content_type)
+        if self.llmobs_span_update_listener is not None:
+            self.llmobs_span_update_listener(data, content_type)
 
         return web.HTTPOk()
 
@@ -1219,15 +1193,13 @@ class Agent:
 
     async def handle_settings(self, request: Request) -> web.Response:
         """Allow to change test agent settings on the fly"""
-        from .llmobs_event_platform import _ALLOWED_ORIGIN_PATTERN
-
         headers: Dict[str, str] = {
             "Access-Control-Allow-Methods": "POST, OPTIONS",
             "Access-Control-Allow-Headers": "Content-Type",
             "Vary": "Origin",
         }
         origin = request.headers.get("Origin", "")
-        if _ALLOWED_ORIGIN_PATTERN.match(origin):
+        if ALLOWED_ORIGIN_PATTERN.match(origin):
             headers["Access-Control-Allow-Origin"] = origin
 
         # Handle OPTIONS preflight
@@ -1270,15 +1242,13 @@ class Agent:
         return web.HTTPAccepted(headers=headers)
 
     async def handle_info(self, request: Request) -> web.Response:
-        from .llmobs_event_platform import _ALLOWED_ORIGIN_PATTERN
-
         headers: Dict[str, str] = {
             "Access-Control-Allow-Methods": "GET, OPTIONS",
             "Access-Control-Allow-Headers": "Content-Type",
             "Vary": "Origin",
         }
         origin = request.headers.get("Origin", "")
-        if _ALLOWED_ORIGIN_PATTERN.match(origin):
+        if ALLOWED_ORIGIN_PATTERN.match(origin):
             headers["Access-Control-Allow-Origin"] = origin
 
         # Handle OPTIONS preflight
@@ -1550,15 +1520,13 @@ class Agent:
         return web.json_response(traces)
 
     async def handle_session_requests(self, request: Request) -> web.Response:
-        from .llmobs_event_platform import _ALLOWED_ORIGIN_PATTERN
-
         headers: Dict[str, str] = {
             "Access-Control-Allow-Methods": "GET, OPTIONS",
             "Access-Control-Allow-Headers": "Content-Type",
             "Vary": "Origin",
         }
         origin = request.headers.get("Origin", "")
-        if _ALLOWED_ORIGIN_PATTERN.match(origin):
+        if ALLOWED_ORIGIN_PATTERN.match(origin):
             headers["Access-Control-Allow-Origin"] = origin
 
         # Handle OPTIONS preflight
@@ -2065,7 +2033,6 @@ def make_app(
     dd_site: str,
     dd_api_key: Optional[str],
     disable_llmobs_data_forwarding: bool,
-    lapdog_mode: bool = False,
     org_prop_marker: str = "",
     enable_web_ui: bool = False,
 ) -> web.Application:
@@ -2149,41 +2116,6 @@ def make_app(
         ]
     )
 
-    # Add LLM Observability Event Platform API routes
-    # These provide Datadog Event Platform compatible endpoints for local development
-    llmobs_event_platform_api = LLMObsEventPlatformAPI(agent)
-    app["llmobs_event_platform_api"] = llmobs_event_platform_api
-    app.add_routes(llmobs_event_platform_api.get_routes())
-
-    # Add Claude Code hooks and proxy routes with shared link tracker
-    claude_link_tracker = ClaudeLinkTracker()
-    claude_hooks_api = ClaudeHooksAPI(link_tracker=claude_link_tracker)
-    claude_hooks_api.set_app(app)
-    app.add_routes(claude_hooks_api.get_routes())
-    llmobs_event_platform_api.set_claude_hooks_api(claude_hooks_api)
-
-    claude_proxy_api = ClaudeProxyAPI(hooks_api=claude_hooks_api, link_tracker=claude_link_tracker)
-    app.add_routes(claude_proxy_api.get_routes())
-
-    pi_hooks_api = PiHooksAPI(hooks_api=claude_hooks_api)
-    app.add_routes(pi_hooks_api.get_routes())
-
-    codex_hooks_api = CodexHooksAPI(hooks_api=claude_hooks_api)
-    app.add_routes(codex_hooks_api.get_routes())
-
-    codex_proxy_api = CodexProxyAPI(hooks_api=codex_hooks_api)
-    app.add_routes(codex_proxy_api.get_routes())
-
-    async def _cleanup_claude_proxy(app: web.Application) -> None:
-        await claude_proxy_api.close()
-
-    app.on_cleanup.append(_cleanup_claude_proxy)
-
-    async def _cleanup_codex_proxy(app: web.Application) -> None:
-        await codex_proxy_api.close()
-
-    app.on_cleanup.append(_cleanup_codex_proxy)
-
     checks = Checks(
         checks=[
             CheckMetaTracerVersionHeader,
@@ -2226,7 +2158,6 @@ def make_app(
         disable_llmobs_data_forwarding = True
 
     app["disable_llmobs_data_forwarding"] = disable_llmobs_data_forwarding
-    app["lapdog_mode"] = lapdog_mode
 
     return app
 
@@ -2362,7 +2293,10 @@ def _handle_windows_named_pipe_client(
             pass
 
 
-def main(args: Optional[List[str]] = None) -> None:
+def main(
+    args: Optional[List[str]] = None,
+    app_factory: Optional[Callable[..., web.Application]] = None,
+) -> None:
     if args is None:
         args = sys.argv[1:]
     parser = argparse.ArgumentParser(
@@ -2577,11 +2511,6 @@ def main(args: Optional[List[str]] = None) -> None:
         default=os.environ.get("DISABLE_LLMOBS_DATA_FORWARDING", "").lower() in ("true", "1", "yes"),
         help="Disable data forwarding to Datadog.",
     )
-    parser.add_argument(
-        "--lapdog-mode",
-        action="store_true",
-        default=False,
-    )
     parsed_args = parser.parse_args(args=args)
     logging.basicConfig(level=parsed_args.log_level)
 
@@ -2618,7 +2547,10 @@ def main(args: Optional[List[str]] = None) -> None:
             "default snapshot directory %r does not exist or is not readable. Snapshotting will not work.",
             os.path.abspath(parsed_args.snapshot_dir),
         )
-    app = make_app(
+    if app_factory is None:
+        app_factory = make_app
+
+    app = app_factory(
         enabled_checks=parsed_args.enabled_checks,
         log_span_fmt=parsed_args.log_span_fmt,
         snapshot_dir=parsed_args.snapshot_dir,
@@ -2640,7 +2572,6 @@ def main(args: Optional[List[str]] = None) -> None:
         dd_site=parsed_args.dd_site,
         dd_api_key=parsed_args.dd_api_key,
         disable_llmobs_data_forwarding=parsed_args.disable_llmobs_data_forwarding,
-        lapdog_mode=parsed_args.lapdog_mode,
         org_prop_marker=parsed_args.org_prop_marker,
         enable_web_ui=parsed_args.web_ui_port > 0,
     )

--- a/ddapm_test_agent/cors.py
+++ b/ddapm_test_agent/cors.py
@@ -1,0 +1,51 @@
+"""Shared CORS helpers for test-agent HTTP endpoints."""
+
+import re
+from typing import Awaitable
+from typing import Callable
+from typing import Dict
+
+from aiohttp import web
+from aiohttp.web import Request
+
+
+# Allowed CORS origins: Datadog UI domains and localhost for local development.
+ALLOWED_ORIGIN_PATTERN = re.compile(
+    r"^https?://(localhost(:\d+)?|127\.0\.0\.1(:\d+)?|[\w.-]+\.datadoghq\.(com|eu)|[\w.-]+\.ddog-gov\.com|[\w.-]+\.datad0g\.com|[\w.-]+\.static-app\.us1\.staging\.dog)$"
+)
+
+_CORS_ALLOW_METHODS = "GET, POST, OPTIONS"
+_CORS_ALLOW_HEADERS = (
+    "Content-Type, Authorization, X-DD-Api-Key, X-DD-Application-Key, "
+    "X-CSRF-Token, x-csrf-token, x-web-ui-version, X-Datadog-Trace-ID, "
+    "X-Datadog-Parent-ID, X-Datadog-Origin, X-Datadog-Sampling-Priority, Accept, Origin, Referer"
+)
+
+
+def cors_headers(request: Request) -> Dict[str, str]:
+    """Build CORS headers, only allowing known origins."""
+    headers: Dict[str, str] = {
+        "Access-Control-Allow-Methods": _CORS_ALLOW_METHODS,
+        "Access-Control-Allow-Headers": _CORS_ALLOW_HEADERS,
+        "Vary": "Origin",
+    }
+    origin = request.headers.get("Origin", "")
+    if ALLOWED_ORIGIN_PATTERN.match(origin):
+        headers["Access-Control-Allow-Origin"] = origin
+    return headers
+
+
+def with_cors(
+    handler: Callable[[Request], Awaitable[web.StreamResponse]],
+) -> Callable[[Request], Awaitable[web.StreamResponse]]:
+    """Wrap a handler with CORS headers and OPTIONS preflight support."""
+
+    async def wrapper(request: Request) -> web.StreamResponse:
+        headers = cors_headers(request)
+        if request.method == "OPTIONS":
+            return web.Response(status=200, headers=headers)
+        response = await handler(request)
+        response.headers.update(headers)
+        return response
+
+    return wrapper

--- a/ddapm_test_agent/llmobs_trace.py
+++ b/ddapm_test_agent/llmobs_trace.py
@@ -5,11 +5,15 @@ POSTing to ``/evp_proxy/.../llmobs``, these helpers rebuild SDK span events and 
 envelopes so the agent can synthesize an equivalent EVP request at ingestion time.
 """
 
+import gzip
+import json
 import logging
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+
+import msgpack
 
 
 log = logging.getLogger(__name__)
@@ -20,6 +24,30 @@ LLMOBS_ROOT_PARENT_ID = "undefined"
 
 ERROR_TYPE_TAG = "error.type"
 TRACE_ID_HIGH_TAG = "_dd.p.tid"
+
+
+def decode_llmobs_payload(data: bytes, content_type: str) -> List[Dict[str, Any]]:
+    """Decode an LLMObs payload encoded as JSON or msgpack, optionally with gzip."""
+    events: List[Dict[str, Any]] = []
+    try:
+        if content_type and "gzip" in content_type.lower():
+            data = gzip.decompress(data)
+
+        if content_type and "msgpack" in content_type.lower():
+            payload = msgpack.unpackb(data, raw=False, strict_map_key=False)
+        else:
+            try:
+                payload = json.loads(data)
+            except json.JSONDecodeError:
+                payload = msgpack.unpackb(data, raw=False, strict_map_key=False)
+
+        if isinstance(payload, list):
+            events.extend(payload)
+        else:
+            events.append(payload)
+    except Exception as e:
+        log.warning("Failed to decode LLMObs payload: %s", e)
+    return events
 
 
 def _format_apm_trace_id(apm_trace_id: int, meta: Any) -> str:

--- a/ddapm_test_agent/web.py
+++ b/ddapm_test_agent/web.py
@@ -18,6 +18,8 @@ from aiohttp.web import StreamResponse
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 
+from .cors import ALLOWED_ORIGIN_PATTERN
+
 
 log = logging.getLogger(__name__)
 
@@ -1116,8 +1118,6 @@ class WebUI:
 
     async def handle_requests_sse(self, request: web.Request) -> StreamResponse:
         """Handle Server-Sent Events for real-time request updates"""
-        from .llmobs_event_platform import _ALLOWED_ORIGIN_PATTERN
-
         sse_headers: Dict[str, str] = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -1125,7 +1125,7 @@ class WebUI:
             "Vary": "Origin",
         }
         origin = request.headers.get("Origin", "")
-        if _ALLOWED_ORIGIN_PATTERN.match(origin):
+        if ALLOWED_ORIGIN_PATTERN.match(origin):
             sse_headers["Access-Control-Allow-Origin"] = origin
 
         response = StreamResponse(

--- a/lapdog/README.md
+++ b/lapdog/README.md
@@ -92,7 +92,7 @@ docker run --rm \
     -p 4318:4318 \
     -p 4317:4317 \
     ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest \
-    ddapm-test-agent --lapdog-mode
+    python -m lapdog.server
 ```
 
 Then point your application at the host: `DD_TRACE_AGENT_URL=http://localhost:8126`.
@@ -106,7 +106,7 @@ docker run --rm \
     -p 8126:8126 \
     -v "$PWD/.lapdog-data:/snapshots" \
     ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest \
-    ddapm-test-agent --lapdog-mode
+    python -m lapdog.server
 ```
 
 If you want the `lapdog claude` or `lapdog codex` workflow, the CLI must run

--- a/lapdog/_clock.py
+++ b/lapdog/_clock.py
@@ -1,4 +1,4 @@
-"""Monotonic wall-clock helper used by span emitters.
+"""Monotonic wall-clock helper used by Lapdog span emitters.
 
 Windows' ``time.time_ns()`` is backed by ``GetSystemTimePreciseAsFileTime``,
 which advertises 100 ns resolution but can return identical values on
@@ -15,6 +15,7 @@ track ``perf_counter_ns`` alongside every timestamp.
 
 import threading
 import time
+
 
 _lock = threading.Lock()
 _last_ns = 0

--- a/lapdog/app_names.py
+++ b/lapdog/app_names.py
@@ -1,6 +1,7 @@
-"""Shared ml_app names for lapdog coding-agent integrations."""
+"""Shared ml_app names for Lapdog coding-agent integrations."""
 
 import os
+
 
 CLAUDE_CODE_ML_APP = os.environ.get("DD_CLAUDE_CODE_ML_APP", "claude-code")
 PI_CODING_AGENT_ML_APP = os.environ.get("DD_PI_CODING_AGENT_ML_APP", "pi-coding-agent")

--- a/lapdog/backfill_utils.py
+++ b/lapdog/backfill_utils.py
@@ -1,4 +1,4 @@
-"""Shared helpers for server-side historical session backfills."""
+"""Shared helpers for Lapdog's server-side historical session backfills."""
 
 import json
 import secrets

--- a/lapdog/claude_cost_tracker.py
+++ b/lapdog/claude_cost_tracker.py
@@ -1,4 +1,4 @@
-"""Cost tracking for Anthropic models used with Claude Code.
+"""Cost tracking for Anthropic models used with Claude Code in Lapdog.
 
 Pricing is in nanodollars per token (1 nanodollar = 1e-9 USD), matching the
 convention used in dd-go/domains/ml-observability/libs/costtracker/model_prices.go

--- a/lapdog/claude_hooks.py
+++ b/lapdog/claude_hooks.py
@@ -27,9 +27,11 @@ from aiohttp import web
 from aiohttp.web import Request
 import msgpack
 
-from ddapm_test_agent import claude_backfill
+from ddapm_test_agent.cors import with_cors
 
+from . import claude_session_backfill
 from ._clock import monotonic_wall_ns
+from .app_names import CLAUDE_CODE_ML_APP
 from .backfill_utils import has_backfilled_session
 from .claude_cost_tracker import COST_METRIC_KEYS
 from .claude_link_tracker import ClaudeLinkTracker
@@ -40,8 +42,7 @@ from .coding_agent_metadata import extract_git_repository_url
 from .coding_agent_metadata import git_commit_sha_tags
 from .coding_agent_metadata import project_metadata_tags
 from .coding_agent_metadata import resolve_project_metadata
-from .lapdog_app_names import CLAUDE_CODE_ML_APP
-from .llmobs_event_platform import with_cors
+
 
 log = logging.getLogger(__name__)
 
@@ -2082,7 +2083,7 @@ class ClaudeHooksAPI:
             )
 
         try:
-            spans = claude_backfill.session_to_spans(session_id, cwd, entries, subagents=subagents)
+            spans = claude_session_backfill.session_to_spans(session_id, cwd, entries, subagents=subagents)
         except Exception as exc:
             # A single malformed transcript shouldn't propagate as a 500 that
             # closes the connection — return a structured failure so the

--- a/lapdog/claude_link_tracker.py
+++ b/lapdog/claude_link_tracker.py
@@ -1,4 +1,4 @@
-"""Span link tracking for connecting LLM and tool spans in Claude Code traces.
+"""Span link tracking for connecting LLM and tool spans in Lapdog's Claude Code traces.
 
 Follows the same linking pattern as dd-trace-py's LinkTracker:
 - LLM.output -> Tool.input (when LLM generates tool_use, link to the tool span)
@@ -11,6 +11,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+
 
 log = logging.getLogger(__name__)
 

--- a/lapdog/claude_proxy.py
+++ b/lapdog/claude_proxy.py
@@ -24,6 +24,8 @@ import aiohttp
 from aiohttp import web
 from aiohttp.web import Request
 
+from ddapm_test_agent.cors import with_cors
+
 from ._clock import monotonic_wall_ns
 from .claude_cost_tracker import compute_cost_metrics
 from .claude_hooks import ClaudeHooksAPI
@@ -35,7 +37,7 @@ from .claude_hooks import _get_context_limit
 from .claude_link_tracker import ClaudeLinkTracker
 from .claude_link_tracker import SpanLink
 from .coding_agent_metadata import apply_project_metadata_to_span
-from .llmobs_event_platform import with_cors
+
 
 log = logging.getLogger(__name__)
 

--- a/lapdog/claude_session_backfill.py
+++ b/lapdog/claude_session_backfill.py
@@ -40,12 +40,13 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from ddapm_test_agent.backfill_utils import backfill_metadata
-from ddapm_test_agent.backfill_utils import format_span_id
-from ddapm_test_agent.backfill_utils import format_trace_id
-from ddapm_test_agent.backfill_utils import to_text
-from ddapm_test_agent.claude_cost_tracker import compute_cost_metrics
-from ddapm_test_agent.lapdog_app_names import CLAUDE_CODE_ML_APP as _ML_APP
+from .app_names import CLAUDE_CODE_ML_APP as _ML_APP
+from .backfill_utils import backfill_metadata
+from .backfill_utils import format_span_id
+from .backfill_utils import format_trace_id
+from .backfill_utils import to_text
+from .claude_cost_tracker import compute_cost_metrics
+
 
 _HOSTNAME = socket.gethostname()
 _USERNAME = os.environ.get("HOST_USER") or getpass.getuser()

--- a/lapdog/cli.py
+++ b/lapdog/cli.py
@@ -4,8 +4,8 @@ import argparse
 import json
 import os
 from pathlib import Path
-import shutil
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -19,6 +19,7 @@ import urllib.error
 import urllib.request
 import uuid
 
+from ddapm_test_agent import _get_version
 from lapdog import backfill_claude
 from lapdog import backfill_codex
 from lapdog import backfill_pi
@@ -31,7 +32,6 @@ from lapdog.paths import LAPDOG_DIR
 from lapdog.paths import LOG_FILE
 from lapdog.paths import PID_FILE
 
-from ddapm_test_agent import _get_version
 
 LAPDOG_COMMANDS = ["start", "stop", "status", "claude", "pi", "codex", "tags", "uninstall"]
 # Managed launchers that also exist as external binaries a user might invoke by
@@ -257,7 +257,7 @@ def _start_lapdog(
     """Start lapdog in background with logs to the log file; wait until ready or exit on timeout. Return (process, log_path)."""
     log_path = _log_file_path()
     os.makedirs(os.path.dirname(log_path), exist_ok=True)
-    args = [sys.executable, "-m", "ddapm_test_agent.agent", "--lapdog-mode"]
+    args = [sys.executable, "-m", "lapdog.server"]
 
     env = os.environ.copy()
     env["TEST_AGENT_VERSION"] = _get_version()

--- a/lapdog/codex_cost_tracker.py
+++ b/lapdog/codex_cost_tracker.py
@@ -1,4 +1,4 @@
-"""Cost tracking for OpenAI models used by Codex.
+"""Cost tracking for OpenAI models used by Codex in Lapdog.
 
 Pricing is in nanodollars per token (1 nanodollar = 1e-9 USD), matching the
 metric keys expected by the web-ui LLM observability span detail view.

--- a/lapdog/codex_hooks.py
+++ b/lapdog/codex_hooks.py
@@ -15,6 +15,8 @@ from typing import Tuple
 from aiohttp import web
 from aiohttp.web import Request
 
+from ddapm_test_agent.cors import with_cors
+
 from .claude_hooks import ClaudeHooksAPI
 from .claude_hooks import PendingToolSpan
 from .claude_hooks import SessionState
@@ -26,7 +28,7 @@ from .coding_agent_metadata import apply_project_metadata_to_span
 from .coding_agent_metadata import extract_agent_project_name
 from .coding_agent_metadata import extract_git_repository_url
 from .coding_agent_metadata import resolve_project_metadata
-from .llmobs_event_platform import with_cors
+
 
 log = logging.getLogger(__name__)
 

--- a/lapdog/codex_proxy.py
+++ b/lapdog/codex_proxy.py
@@ -13,16 +13,18 @@ import aiohttp
 from aiohttp import web
 from aiohttp.web import Request
 
+from ddapm_test_agent.cors import with_cors
+
 from ._clock import monotonic_wall_ns
 from .claude_hooks import _format_span_id
 from .claude_hooks import _format_trace_id
 from .codex_cost_tracker import compute_openai_cost_metrics
 from .codex_hooks import CodexHooksAPI
+from .codex_hooks import _canonical_tool_status
 from .codex_hooks import _copy_messages
 from .codex_hooks import _copy_reasoning_items
-from .codex_hooks import _canonical_tool_status
 from .codex_hooks import _extract_reasoning_metadata
-from .llmobs_event_platform import with_cors
+
 
 log = logging.getLogger(__name__)
 

--- a/lapdog/coding_agent_metadata.py
+++ b/lapdog/coding_agent_metadata.py
@@ -1,4 +1,4 @@
-"""Project metadata helpers for coding-agent LLMObs traces."""
+"""Project metadata helpers for Lapdog coding-agent LLMObs traces."""
 
 import dataclasses
 from functools import lru_cache
@@ -11,6 +11,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from urllib.parse import urlparse
+
 
 log = logging.getLogger(__name__)
 

--- a/lapdog/llmobs_event_platform.py
+++ b/lapdog/llmobs_event_platform.py
@@ -2,14 +2,11 @@
 
 from collections import defaultdict
 from datetime import datetime
-import gzip
 import json
 import logging
 import re
 import statistics
 from typing import Any
-from typing import Awaitable
-from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -18,57 +15,20 @@ import uuid
 
 from aiohttp import web
 from aiohttp.web import Request
-import msgpack
+
+from ddapm_test_agent.cors import with_cors
+from ddapm_test_agent.llmobs_trace import decode_llmobs_payload
 
 from . import llmobs_query_parser
 from ._clock import monotonic_wall_ns
 
+
 if TYPE_CHECKING:
-    from .agent import Agent
+    from ddapm_test_agent.agent import Agent
+
     from .claude_hooks import ClaudeHooksAPI
 
 log = logging.getLogger(__name__)
-
-# Allowed CORS origins: Datadog UI domains and localhost for local development
-_ALLOWED_ORIGIN_PATTERN = re.compile(
-    r"^https?://(localhost(:\d+)?|127\.0\.0\.1(:\d+)?|[\w.-]+\.datadoghq\.(com|eu)|[\w.-]+\.ddog-gov\.com|[\w.-]+\.datad0g\.com|[\w.-]+\.static-app\.us1\.staging\.dog)$"
-)
-
-_CORS_ALLOW_METHODS = "GET, POST, OPTIONS"
-_CORS_ALLOW_HEADERS = (
-    "Content-Type, Authorization, X-DD-Api-Key, X-DD-Application-Key, "
-    "X-CSRF-Token, x-csrf-token, x-web-ui-version, X-Datadog-Trace-ID, "
-    "X-Datadog-Parent-ID, X-Datadog-Origin, X-Datadog-Sampling-Priority, Accept, Origin, Referer"
-)
-
-
-def _cors_headers(request: Request) -> Dict[str, str]:
-    """Build CORS headers, only allowing known origins."""
-    headers: Dict[str, str] = {
-        "Access-Control-Allow-Methods": _CORS_ALLOW_METHODS,
-        "Access-Control-Allow-Headers": _CORS_ALLOW_HEADERS,
-        "Vary": "Origin",
-    }
-    origin = request.headers.get("Origin", "")
-    if _ALLOWED_ORIGIN_PATTERN.match(origin):
-        headers["Access-Control-Allow-Origin"] = origin
-    return headers
-
-
-def with_cors(
-    handler: Callable[[Request], Awaitable[web.StreamResponse]],
-) -> Callable[[Request], Awaitable[web.StreamResponse]]:
-    """Wrap handler to add CORS headers and handle OPTIONS preflight."""
-
-    async def wrapper(request: Request) -> web.StreamResponse:
-        headers = _cors_headers(request)
-        if request.method == "OPTIONS":
-            return web.Response(status=200, headers=headers)
-        response = await handler(request)
-        response.headers.update(headers)
-        return response
-
-    return wrapper
 
 
 def _deep_merge(source: Dict[str, Any], target: Dict[str, Any]) -> None:
@@ -78,30 +38,6 @@ def _deep_merge(source: Dict[str, Any], target: Dict[str, Any]) -> None:
             _deep_merge(value, target[key])
         else:
             target[key] = value
-
-
-def decode_llmobs_payload(data: bytes, content_type: str) -> List[Dict[str, Any]]:
-    """Decode LLMObs payload (gzip+msgpack or JSON)."""
-    events = []
-    try:
-        if content_type and "gzip" in content_type.lower():
-            data = gzip.decompress(data)
-
-        if content_type and "msgpack" in content_type.lower():
-            payload = msgpack.unpackb(data, raw=False, strict_map_key=False)
-        else:
-            try:
-                payload = json.loads(data)
-            except json.JSONDecodeError:
-                payload = msgpack.unpackb(data, raw=False, strict_map_key=False)
-
-        if isinstance(payload, list):
-            events.extend(payload)
-        else:
-            events.append(payload)
-    except Exception as e:
-        log.warning(f"Failed to decode LLMObs payload: {e}")
-    return events
 
 
 def extract_spans_from_events(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -515,11 +451,7 @@ def _build_trace_aggregates(
 
     result: Dict[str, Dict[str, Any]] = {}
     for tid, trace_spans in by_trace.items():
-        llm_spans = [
-            span
-            for span in trace_spans
-            if span.get("meta", {}).get("span", {}).get("kind") == "llm"
-        ]
+        llm_spans = [span for span in trace_spans if span.get("meta", {}).get("span", {}).get("kind") == "llm"]
         num_evaluations_failed = sum(
             sum(
                 1

--- a/lapdog/llmobs_query_parser.py
+++ b/lapdog/llmobs_query_parser.py
@@ -1,4 +1,4 @@
-"""LLM Observability Query Parser with Boolean Logic Support.
+"""Lapdog's LLM Observability Query Parser with Boolean Logic Support.
 
 This module implements a query parser that supports:
 - Boolean operators: AND, OR, NOT
@@ -22,6 +22,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+
 
 # ============================================================================
 # AST Node Classes

--- a/lapdog/pi_hooks.py
+++ b/lapdog/pi_hooks.py
@@ -37,9 +37,11 @@ from typing import cast
 from aiohttp import web
 from aiohttp.web import Request
 
-from ddapm_test_agent import pi_backfill
+from ddapm_test_agent.cors import with_cors
 
+from . import pi_session_backfill
 from ._clock import monotonic_wall_ns
+from .app_names import PI_CODING_AGENT_ML_APP
 from .backfill_utils import has_backfilled_session
 from .claude_cost_tracker import compute_cost_metrics
 from .claude_cost_tracker import cost_from_provider_usage
@@ -51,8 +53,7 @@ from .claude_hooks import _format_trace_id
 from .claude_hooks import _to_json_str
 from .codex_cost_tracker import compute_openai_cost_metrics
 from .coding_agent_metadata import apply_project_metadata_to_span
-from .lapdog_app_names import PI_CODING_AGENT_ML_APP
-from .llmobs_event_platform import with_cors
+
 
 log = logging.getLogger(__name__)
 
@@ -1129,7 +1130,7 @@ class PiHooksAPI:
             )
 
         try:
-            spans = pi_backfill.session_to_spans(session_id, cwd, entries)
+            spans = pi_session_backfill.session_to_spans(session_id, cwd, entries)
         except Exception as exc:
             log.warning("pi backfill_session failed for %s: %r", session_id, exc)
             return web.json_response({"status": "error", "error": repr(exc)}, status=400)

--- a/lapdog/pi_session_backfill.py
+++ b/lapdog/pi_session_backfill.py
@@ -19,14 +19,15 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from ddapm_test_agent.backfill_utils import backfill_metadata
-from ddapm_test_agent.backfill_utils import format_span_id
-from ddapm_test_agent.backfill_utils import format_trace_id
-from ddapm_test_agent.backfill_utils import to_text
-from ddapm_test_agent.claude_hooks import ClaudeHooksAPI
-from ddapm_test_agent.coding_agent_metadata import CodingAgentProjectMetadata
-from ddapm_test_agent.coding_agent_metadata import resolve_project_metadata
-from ddapm_test_agent.lapdog_app_names import PI_CODING_AGENT_ML_APP as _ML_APP
+from .app_names import PI_CODING_AGENT_ML_APP as _ML_APP
+from .backfill_utils import backfill_metadata
+from .backfill_utils import format_span_id
+from .backfill_utils import format_trace_id
+from .backfill_utils import to_text
+from .claude_hooks import ClaudeHooksAPI
+from .coding_agent_metadata import CodingAgentProjectMetadata
+from .coding_agent_metadata import resolve_project_metadata
+
 
 _TAGS_API = ClaudeHooksAPI()
 

--- a/lapdog/server.py
+++ b/lapdog/server.py
@@ -1,0 +1,91 @@
+"""Lapdog server composed on top of the Datadog APM test-agent application."""
+
+import gzip
+from typing import Any
+from typing import List
+from typing import Optional
+
+from aiohttp import web
+import msgpack
+
+from ddapm_test_agent import agent as test_agent
+
+from .claude_hooks import ClaudeHooksAPI
+from .claude_link_tracker import ClaudeLinkTracker
+from .claude_proxy import ClaudeProxyAPI
+from .codex_hooks import CodexHooksAPI
+from .codex_proxy import CodexProxyAPI
+from .llmobs_event_platform import LLMObsEventPlatformAPI
+from .pi_hooks import PiHooksAPI
+
+
+def _inject_lapdog_forwarded(data: bytes, content_encoding: str) -> bytes:
+    """Add ``lapdog_forwarded:true`` to each forwarded LLMObs span."""
+    try:
+        is_gzipped = "gzip" in content_encoding.lower()
+        if is_gzipped:
+            data = gzip.decompress(data)
+        payload = msgpack.unpackb(data, raw=False)
+        if isinstance(payload, dict):
+            ml_obs = payload.get("ml_obs")
+            spans = (ml_obs.get("spans") if isinstance(ml_obs, dict) else None) or payload.get("spans") or []
+            for span in spans:
+                if not isinstance(span, dict):
+                    continue
+                tags = span.get("tags") or []
+                if "lapdog_forwarded:true" not in tags:
+                    span["tags"] = tags + ["lapdog_forwarded:true"]
+        data = msgpack.packb(payload, use_bin_type=True)
+        if is_gzipped:
+            data = gzip.compress(data)
+    except Exception:
+        pass
+    return data
+
+
+def extend_app(app: web.Application) -> web.Application:
+    """Add Lapdog routes, shared state, forwarding behavior, and cleanup hooks."""
+    agent = app["agent"]
+
+    llmobs_event_platform_api = LLMObsEventPlatformAPI(agent)
+    claude_link_tracker = ClaudeLinkTracker()
+    claude_hooks_api = ClaudeHooksAPI(link_tracker=claude_link_tracker)
+    claude_hooks_api.set_app(app)
+    llmobs_event_platform_api.set_claude_hooks_api(claude_hooks_api)
+
+    claude_proxy_api = ClaudeProxyAPI(hooks_api=claude_hooks_api, link_tracker=claude_link_tracker)
+    pi_hooks_api = PiHooksAPI(hooks_api=claude_hooks_api)
+    codex_hooks_api = CodexHooksAPI(hooks_api=claude_hooks_api)
+    codex_proxy_api = CodexProxyAPI(hooks_api=codex_hooks_api)
+
+    app.add_routes(llmobs_event_platform_api.get_routes())
+    app.add_routes(claude_hooks_api.get_routes())
+    app.add_routes(claude_proxy_api.get_routes())
+    app.add_routes(pi_hooks_api.get_routes())
+    app.add_routes(codex_hooks_api.get_routes())
+    app.add_routes(codex_proxy_api.get_routes())
+
+    app["llmobs_event_platform_api"] = llmobs_event_platform_api
+    agent.llmobs_payload_transform = _inject_lapdog_forwarded
+    agent.llmobs_span_update_listener = llmobs_event_platform_api.update_spans
+
+    async def cleanup_proxies(cleanup_app: web.Application) -> None:
+        await claude_proxy_api.close()
+        await codex_proxy_api.close()
+
+    app.on_cleanup.append(cleanup_proxies)
+    return app
+
+
+def make_app(*args: Any, **kwargs: Any) -> web.Application:
+    """Create the standard test-agent app and extend it with Lapdog behavior."""
+    return extend_app(test_agent.make_app(*args, **kwargs))
+
+
+def main(args: Optional[List[str]] = None) -> None:
+    """Run the Lapdog server using the shared test-agent server lifecycle."""
+    test_agent.main(args=args, app_factory=make_app)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,10 +39,11 @@ from ddapm_test_agent.apmtelemetry import TelemetryEvent
 from ddapm_test_agent.client import TestOTLPClient
 from ddapm_test_agent.logs import LOGS_ENDPOINT
 from ddapm_test_agent.metrics import METRICS_ENDPOINT
-from ddapm_test_agent.traces_otlp import TRACES_ENDPOINT
 from ddapm_test_agent.trace import Span
 from ddapm_test_agent.trace import Trace
 from ddapm_test_agent.trace_snapshot import DEFAULT_SNAPSHOT_IGNORES
+from ddapm_test_agent.traces_otlp import TRACES_ENDPOINT
+from lapdog.server import make_app as make_lapdog_app
 
 
 # Fix the service name to make tests consistently pass local and in CI.
@@ -219,6 +220,65 @@ async def agent_app(
 @pytest.fixture
 async def agent(agent_app, aiohttp_client, loop):
     client = await aiohttp_client(agent_app)
+    yield client
+
+
+@pytest.fixture
+async def lapdog_agent_app(
+    aiohttp_server,
+    agent_enabled_checks,
+    log_span_fmt,
+    snapshot_dir,
+    snapshot_ci_mode,
+    snapshot_ignored_attrs,
+    agent_url,
+    trace_request_delay,
+    suppress_trace_parse_errors,
+    pool_trace_check_failures,
+    disable_error_responses,
+    snapshot_removed_attrs,
+    snapshot_regex_placeholders,
+    vcr_cassettes_directory,
+    vcr_ci_mode,
+    vcr_provider_map,
+    vcr_ignore_headers,
+    vcr_json_body_normalizers,
+    vcr_body_regex_normalizers,
+    dd_site,
+    dd_api_key,
+    disable_llmobs_data_forwarding,
+):
+    app = await aiohttp_server(
+        make_lapdog_app(
+            enabled_checks=agent_enabled_checks,
+            log_span_fmt=log_span_fmt,
+            snapshot_dir=str(snapshot_dir),
+            snapshot_ci_mode=snapshot_ci_mode,
+            snapshot_ignored_attrs=snapshot_ignored_attrs,
+            agent_url=agent_url,
+            trace_request_delay=trace_request_delay,
+            suppress_trace_parse_errors=suppress_trace_parse_errors,
+            pool_trace_check_failures=pool_trace_check_failures,
+            disable_error_responses=disable_error_responses,
+            snapshot_removed_attrs=snapshot_removed_attrs,
+            snapshot_regex_placeholders=snapshot_regex_placeholders,
+            vcr_cassettes_directory=vcr_cassettes_directory,
+            vcr_ci_mode=vcr_ci_mode,
+            vcr_provider_map=vcr_provider_map,
+            vcr_ignore_headers=vcr_ignore_headers,
+            vcr_json_body_normalizers=vcr_json_body_normalizers,
+            vcr_body_regex_normalizers=vcr_body_regex_normalizers,
+            dd_site=dd_site,
+            dd_api_key=dd_api_key,
+            disable_llmobs_data_forwarding=disable_llmobs_data_forwarding,
+        )
+    )
+    yield app
+
+
+@pytest.fixture
+async def lapdog_agent(lapdog_agent_app, aiohttp_client, loop):
+    client = await aiohttp_client(lapdog_agent_app)
     yield client
 
 

--- a/tests/test_backfill_claude.py
+++ b/tests/test_backfill_claude.py
@@ -5,8 +5,8 @@ from typing import Dict
 from typing import List
 from unittest import mock
 
-from ddapm_test_agent import claude_backfill
 from lapdog import backfill_claude
+from lapdog import claude_session_backfill as claude_backfill
 
 
 def _write_transcript(path: Path, entries: List[Dict[str, Any]]) -> None:

--- a/tests/test_backfill_pi.py
+++ b/tests/test_backfill_pi.py
@@ -5,9 +5,9 @@ from typing import Dict
 from typing import List
 from unittest import mock
 
-from ddapm_test_agent import pi_backfill
 from lapdog import _backfill_common
 from lapdog import backfill_pi
+from lapdog import pi_session_backfill as pi_backfill
 
 
 def _write_session(path: Path, entries: List[Dict[str, Any]]) -> None:

--- a/tests/test_claude_cost_tracker.py
+++ b/tests/test_claude_cost_tracker.py
@@ -1,4 +1,4 @@
-from ddapm_test_agent.claude_cost_tracker import compute_cost_metrics
+from lapdog.claude_cost_tracker import compute_cost_metrics
 
 
 class TestModelLookup:

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -5,10 +5,16 @@ import subprocess
 import tempfile
 
 import msgpack
+import pytest
 
-from ddapm_test_agent.claude_hooks import ClaudeHooksAPI
-from ddapm_test_agent.claude_link_tracker import ClaudeLinkTracker
-from ddapm_test_agent.claude_proxy import ClaudeProxyAPI
+from lapdog.claude_hooks import ClaudeHooksAPI
+from lapdog.claude_link_tracker import ClaudeLinkTracker
+from lapdog.claude_proxy import ClaudeProxyAPI
+
+
+@pytest.fixture
+def agent(lapdog_agent):
+    return lapdog_agent
 
 
 async def _post_hook(agent, event):
@@ -460,7 +466,7 @@ async def test_hook_tool_use_creates_tool_span(agent):
 
 
 async def test_claude_project_metadata_from_hook_cwd(agent, tmp_path, monkeypatch):
-    from ddapm_test_agent.coding_agent_metadata import _local_git_metadata
+    from lapdog.coding_agent_metadata import _local_git_metadata
 
     monkeypatch.delenv("DD_GIT_REPOSITORY_URL", raising=False)
     _local_git_metadata.cache_clear()
@@ -514,7 +520,7 @@ async def test_claude_project_metadata_from_hook_cwd(agent, tmp_path, monkeypatc
 
 async def test_claude_spans_tagged_with_git_commit_sha(agent, tmp_path, monkeypatch):
     """Spans carry git.commit.sha for the same repo as the git.repository_url tag."""
-    from ddapm_test_agent.coding_agent_metadata import _local_git_metadata
+    from lapdog.coding_agent_metadata import _local_git_metadata
 
     monkeypatch.delenv("DD_GIT_REPOSITORY_URL", raising=False)
     _local_git_metadata.cache_clear()
@@ -573,7 +579,7 @@ async def test_claude_spans_tagged_with_git_commit_sha(agent, tmp_path, monkeypa
 
 async def test_claude_project_metadata_updates_when_cwd_changes(agent, tmp_path, monkeypatch):
     """A hook posted with a new cwd mid-session should re-resolve project metadata."""
-    from ddapm_test_agent.coding_agent_metadata import _local_git_metadata
+    from lapdog.coding_agent_metadata import _local_git_metadata
 
     monkeypatch.delenv("DD_GIT_REPOSITORY_URL", raising=False)
     _local_git_metadata.cache_clear()

--- a/tests/test_claude_steps.py
+++ b/tests/test_claude_steps.py
@@ -6,10 +6,11 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from ddapm_test_agent._clock import monotonic_wall_ns
-from ddapm_test_agent.claude_hooks import ClaudeHooksAPI
-from ddapm_test_agent.claude_link_tracker import ClaudeLinkTracker
-from ddapm_test_agent.claude_proxy import ClaudeProxyAPI
+from lapdog._clock import monotonic_wall_ns
+from lapdog.claude_hooks import ClaudeHooksAPI
+from lapdog.claude_link_tracker import ClaudeLinkTracker
+from lapdog.claude_proxy import ClaudeProxyAPI
+
 
 # ------------------------------------------------------------------
 # Helpers
@@ -484,7 +485,7 @@ def test_step_has_semantic_type_tag():
 
 
 def test_proxy_llm_span_uses_session_base_tags_with_git_commit_sha(tmp_path, monkeypatch):
-    from ddapm_test_agent.coding_agent_metadata import _local_git_metadata
+    from lapdog.coding_agent_metadata import _local_git_metadata
 
     monkeypatch.delenv("DD_GIT_REPOSITORY_URL", raising=False)
     _local_git_metadata.cache_clear()

--- a/tests/test_codex_cost_tracker.py
+++ b/tests/test_codex_cost_tracker.py
@@ -1,4 +1,4 @@
-from ddapm_test_agent.codex_cost_tracker import compute_openai_cost_metrics
+from lapdog.codex_cost_tracker import compute_openai_cost_metrics
 
 
 class TestModelLookup:

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -7,7 +7,12 @@ import subprocess
 import msgpack
 import pytest
 
-from ddapm_test_agent.claude_hooks import ClaudeHooksAPI
+from lapdog.claude_hooks import ClaudeHooksAPI
+
+
+@pytest.fixture
+def agent(lapdog_agent):
+    return lapdog_agent
 
 
 @pytest.fixture
@@ -332,7 +337,7 @@ async def test_codex_project_metadata_from_session_git(agent):
 
 
 async def test_codex_project_metadata_uses_local_git_fallback(agent, tmp_path, monkeypatch):
-    from ddapm_test_agent.coding_agent_metadata import _local_git_metadata
+    from lapdog.coding_agent_metadata import _local_git_metadata
 
     monkeypatch.delenv("DD_GIT_REPOSITORY_URL", raising=False)
     _local_git_metadata.cache_clear()
@@ -374,7 +379,7 @@ async def test_codex_project_metadata_uses_local_git_fallback(agent, tmp_path, m
 
 
 async def test_codex_project_metadata_uses_cwd_basename_without_git(agent, tmp_path, monkeypatch):
-    from ddapm_test_agent.coding_agent_metadata import _local_git_metadata
+    from lapdog.coding_agent_metadata import _local_git_metadata
 
     monkeypatch.delenv("DD_GIT_REPOSITORY_URL", raising=False)
     _local_git_metadata.cache_clear()

--- a/tests/test_codex_proxy.py
+++ b/tests/test_codex_proxy.py
@@ -4,8 +4,13 @@ import json
 from aiohttp import web
 import pytest
 
-from ddapm_test_agent import codex_proxy as codex_proxy_module
-from ddapm_test_agent.codex_proxy import _is_client_disconnect_error
+from lapdog import codex_proxy as codex_proxy_module
+from lapdog.codex_proxy import _is_client_disconnect_error
+
+
+@pytest.fixture
+def agent(lapdog_agent):
+    return lapdog_agent
 
 
 @pytest.fixture

--- a/tests/test_coding_agent_metadata.py
+++ b/tests/test_coding_agent_metadata.py
@@ -1,13 +1,13 @@
 import dataclasses
 import subprocess
 
-from ddapm_test_agent.coding_agent_metadata import _local_git_metadata
-from ddapm_test_agent.coding_agent_metadata import git_commit_sha_for_cwd
-from ddapm_test_agent.coding_agent_metadata import git_commit_sha_tags
-from ddapm_test_agent.coding_agent_metadata import normalize_git_repository_url
-from ddapm_test_agent.coding_agent_metadata import project_metadata_tags
-from ddapm_test_agent.coding_agent_metadata import project_name_from_git_repository_url
-from ddapm_test_agent.coding_agent_metadata import resolve_project_metadata
+from lapdog.coding_agent_metadata import _local_git_metadata
+from lapdog.coding_agent_metadata import git_commit_sha_for_cwd
+from lapdog.coding_agent_metadata import git_commit_sha_tags
+from lapdog.coding_agent_metadata import normalize_git_repository_url
+from lapdog.coding_agent_metadata import project_metadata_tags
+from lapdog.coding_agent_metadata import project_name_from_git_repository_url
+from lapdog.coding_agent_metadata import resolve_project_metadata
 
 
 def _git(repo, *args):

--- a/tests/test_lapdog_cli.py
+++ b/tests/test_lapdog_cli.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 import pytest
 
-from lapdog import codex_args
 from lapdog import cli
+from lapdog import codex_args
 
 
 def test_codex_command_is_registered():
@@ -1012,3 +1012,21 @@ def test_main_routes_unknown_command_to_cmd_exec(monkeypatch):
 
     cmd_exec.assert_called_once()
     cmd_claude.assert_not_called()
+
+
+def test_start_lapdog_uses_dedicated_server_module(tmp_path, monkeypatch):
+    process = mock.Mock(pid=1234)
+    popen = mock.Mock(return_value=process)
+    monkeypatch.setattr(cli, "_log_file_path", lambda: str(tmp_path / "lapdog.log"))
+    monkeypatch.setattr(cli, "_write_pid_file", mock.Mock())
+    monkeypatch.setattr(cli, "_wait_for_lapdog", mock.Mock())
+    monkeypatch.setattr(cli.subprocess, "Popen", popen)
+
+    cli._start_lapdog(8126)
+
+    assert popen.call_args.args[0] == [
+        cli.sys.executable,
+        "-m",
+        "lapdog.server",
+        "--disable-llmobs-data-forwarding",
+    ]

--- a/tests/test_lapdog_server.py
+++ b/tests/test_lapdog_server.py
@@ -1,0 +1,52 @@
+"""Tests for the boundary between the base test agent and the Lapdog server."""
+
+LAPDOG_ROUTE_PATHS = {
+    "/claude/hooks",
+    "/lapdog/session/tags",
+    "/claude/hooks/session/tags",
+    "/claude/hooks/backfill_session",
+    "/claude/hooks/sessions",
+    "/claude/hooks/spans",
+    "/claude/hooks/raw",
+    "/claude/proxy/{path}",
+    "/pi/hooks",
+    "/pi/hooks/backfill_session",
+    "/pi/hooks/raw",
+    "/codex/hooks",
+    "/codex/hooks/raw",
+    "/codex/proxy/{proxy_session_key}/v1/{path}",
+    "/codex/proxy/v1/{path}",
+    "/api/unstable/llm-obs-query-rewriter/list",
+    "/api/unstable/llm-obs-query-rewriter/list/{request_id}",
+    "/api/unstable/llm-obs-query-rewriter/aggregate",
+    "/api/unstable/llm-obs-query-rewriter/fetch_one",
+    "/api/unstable/llm-obs-query-rewriter/facet_info",
+    "/api/unstable/llm-obs-query-rewriter/facet_range_info",
+    "/api/ui/event-platform/llmobs/facets",
+    "/api/v1/logs-analytics/list",
+    "/api/v1/logs-analytics/list/{request_id}",
+    "/api/v1/logs-analytics/aggregate",
+    "/api/v1/logs-analytics/fetch_one",
+    "/api/ui/llm-obs/v1/trace/{trace_id}",
+    "/api/ui/query/scalar",
+}
+
+
+def _route_paths(client):
+    return {route.resource.canonical for route in client.app.router.routes()}
+
+
+async def test_base_agent_does_not_expose_lapdog_routes(agent):
+    assert LAPDOG_ROUTE_PATHS.isdisjoint(_route_paths(agent))
+
+
+async def test_lapdog_server_adds_all_lapdog_routes(lapdog_agent):
+    assert LAPDOG_ROUTE_PATHS <= _route_paths(lapdog_agent)
+
+
+async def test_lapdog_and_base_apps_use_different_forwarding_extensions(agent, lapdog_agent):
+    base_agent = agent.app["agent"]
+    extended_agent = lapdog_agent.app["agent"]
+    assert base_agent.llmobs_payload_transform is not extended_agent.llmobs_payload_transform
+    assert base_agent.llmobs_span_update_listener is None
+    assert extended_agent.llmobs_span_update_listener is not None

--- a/tests/test_llmobs_event_platform.py
+++ b/tests/test_llmobs_event_platform.py
@@ -6,6 +6,11 @@ import pytest
 
 
 @pytest.fixture
+def agent(lapdog_agent):
+    return lapdog_agent
+
+
+@pytest.fixture
 def llmobs_payload():
     return {
         "ml_app": "test-app",

--- a/tests/test_llmobs_query_parser.py
+++ b/tests/test_llmobs_query_parser.py
@@ -2,8 +2,9 @@
 
 import pytest
 
-from ddapm_test_agent.llmobs_event_platform import apply_filters
-from ddapm_test_agent.llmobs_event_platform import parse_filter_query
+from lapdog.llmobs_event_platform import apply_filters
+from lapdog.llmobs_event_platform import parse_filter_query
+
 
 # ============================================================================
 # Test Fixtures

--- a/tests/test_pi_hooks.py
+++ b/tests/test_pi_hooks.py
@@ -3,6 +3,13 @@
 import json
 import subprocess
 
+import pytest
+
+
+@pytest.fixture
+def agent(lapdog_agent):
+    return lapdog_agent
+
 
 async def _post(agent, event):
     return await agent.post(
@@ -321,7 +328,7 @@ async def test_single_step_with_llm_no_tools(agent):
 
 
 async def test_pi_project_metadata_from_extension_cwd(agent, tmp_path, monkeypatch):
-    from ddapm_test_agent.coding_agent_metadata import _local_git_metadata
+    from lapdog.coding_agent_metadata import _local_git_metadata
 
     monkeypatch.delenv("DD_GIT_REPOSITORY_URL", raising=False)
     _local_git_metadata.cache_clear()


### PR DESCRIPTION
Refactors the `lapdog` &harr; `ddapm-test-agent` relationship so `ddapm-test-agent` does not have to know about lapdog or its implementation. This makes it a bit easier to add on routes for lapdog-specific things without polluting the test agent more.